### PR TITLE
gui: treemodel: unregister from parent when we get destroyed

### DIFF
--- a/gui/treemodel.h
+++ b/gui/treemodel.h
@@ -62,6 +62,8 @@ class Item
 
     void addChild(Item *child) { children_.append(child); }
 
+    void deleteChild(Item *child) { children_.removeAll(child); }
+
   public:
     Item(QString name, Item *parent) : name_(name), parent_(parent)
     {
@@ -100,7 +102,12 @@ class Item
     virtual bool canFetchMore() const { return false; }
     virtual void fetchMore() {}
 
-    ~Item() {}
+    ~Item()
+    {
+        if (parent_ != nullptr) {
+            parent_->deleteChild(this);
+        }
+    }
 };
 
 // IdString is an Item that corresponds to a real element in Arch.


### PR DESCRIPTION
This fixes mysterious crashes when a new context was being loaded. The
'Bels', 'Wires', and 'Nets' roots would get replaced by new ones in
TreeModel::Model::loadContext, but they would not get unregistered from
their parent.