### PR TITLE
ecp5: Write tiletype names in correct order

### DIFF
--- a/ecp5/trellis_import.py
+++ b/ecp5/trellis_import.py
@@ -275,7 +275,7 @@ def write_database(dev_name, chip, ddrg, endianness):
 
 
     bba.l("tiletype_names", "RelPtr<char>")
-    for tt in tiletype_names:
+    for tt, idx in sorted(tiletype_names.items(), key=lambda x: x[1]):
         bba.s(tt, "name")
 
     bba.l("chip_info")


### PR DESCRIPTION
Accidentally relied on Python dictionary ordering, which happened to work on some distros but not on others. This explicitly orders correctly instead and should fix all these issues.