### PR TITLE
Restore original assign_budget behaviour (to distribute slack evenly)

### DIFF
--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -138,7 +138,8 @@ class SAPlacer
         if ((placed_cells - constr_placed_cells) % 500 != 0)
             log_info("  initial placement placed %d/%d cells\n", int(placed_cells - constr_placed_cells),
                      int(autoplaced.size()));
-        assign_budget(ctx);
+        if (ctx->slack_redist_iter > 0)
+            assign_budget(ctx);
         ctx->yield();
 
         log_info("Running simulated annealing placer.\n");

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -58,7 +58,7 @@ struct Timing
                 net_budget = budget;
                 pl = std::max(1, path_length);
             }
-            auto delay = ctx->getNetinfoRouteDelay(net, usr);
+            auto delay = ctx->slack_redist_iter > 0 ? ctx->getNetinfoRouteDelay(net, usr) : delay_t();
             net_budget = std::min(net_budget, follow_user_port(usr, pl, slack - delay));
             if (update)
                 usr.budget = std::min(usr.budget, delay + net_budget);

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -39,9 +39,10 @@ struct Timing
     PortRefVector *crit_path;
     DelayFrequency *slack_histogram;
 
-    Timing(Context *ctx, bool net_delays, bool update, PortRefVector *crit_path = nullptr, DelayFrequency *slack_histogram = nullptr)
-            : ctx(ctx), net_delays(net_delays), update(update), min_slack(1.0e12 / ctx->target_freq), crit_path(crit_path),
-              slack_histogram(slack_histogram)
+    Timing(Context *ctx, bool net_delays, bool update, PortRefVector *crit_path = nullptr,
+           DelayFrequency *slack_histogram = nullptr)
+            : ctx(ctx), net_delays(net_delays), update(update), min_slack(1.0e12 / ctx->target_freq),
+              crit_path(crit_path), slack_histogram(slack_histogram)
     {
     }
 
@@ -150,7 +151,7 @@ void assign_budget(Context *ctx, bool quiet)
 {
     if (!quiet) {
         log_break();
-        log_info("Annotating ports with timing budgets for target frequency %.2f MHz\n", ctx->target_freq/1e6);
+        log_info("Annotating ports with timing budgets for target frequency %.2f MHz\n", ctx->target_freq / 1e6);
     }
 
     Timing timing(ctx, ctx->slack_redist_iter > 0 /* net_delays */, true /* update */);

--- a/ice40/main.cc
+++ b/ice40/main.cc
@@ -366,6 +366,7 @@ int main(int argc, char *argv[])
 
             if (!ctx->pack() && !ctx->force)
                 log_error("Packing design failed.\n");
+            assign_budget(ctx.get());
             ctx->check();
             print_utilisation(ctx.get());
             if (!vm.count("pack-only")) {


### PR DESCRIPTION
During my experimentation with slack redistribution, I inadvertently juggled around where the first `assign_budget` is called for ice40 from after packing (where there are no net delays) to after initial placement (where a net delay estimate exists). 

This effect would cause the port budget to be initialised according to estimate net delays based on the (poor) initial placement, even when slack redistribution is not enabled.

This PR reverts this behaviour.