### PR TITLE
Improve slack histogram clarity

### DIFF
--- a/common/timing.cc
+++ b/common/timing.cc
@@ -256,9 +256,11 @@ void timing_analysis(Context *ctx, bool print_histogram, bool print_path)
         log_break();
         log_info("Slack histogram:\n");
         log_info(" legend: * represents %d endpoint(s)\n", max_freq / bar_width);
+        log_info("         + represents [1,%d) endpoint(s)\n", max_freq / bar_width);
         for (unsigned i = 0; i < bins.size(); ++i)
-            log_info("%6d < ps < %6d |%s\n", min_slack + bin_size * i, min_slack + bin_size * (i + 1),
-                     std::string(bins[i] * bar_width / max_freq, '*').c_str());
+            log_info("[%6d, %6d) |%s%c\n", min_slack + bin_size * i, min_slack + bin_size * (i + 1),
+                     std::string(bins[i] * bar_width / max_freq, '*').c_str(),
+                     (bins[i] * bar_width) % max_freq > 0 ? '+' : ' ');
     }
 }
 


### PR DESCRIPTION
```
Info: Slack histogram:
Info:  legend: * represents 54 endpoint(s)
Info:          + represents [1,54) endpoint(s)
Info: [ -2748,  -1953) |+
Info: [ -1953,  -1158) |+
Info: [ -1158,   -363) |*+
Info: [  -363,    432) |**+
Info: [   432,   1227) |***+
Info: [  1227,   2022) |*****+
Info: [  2022,   2817) |********+
Info: [  2817,   3612) |**************+
Info: [  3612,   4407) |**************************+
Info: [  4407,   5202) |**********************************+
Info: [  5202,   5997) |**************************************************+
Info: [  5997,   6792) |************************************************************ 
Info: [  6792,   7587) |**********************************************************+
Info: [  7587,   8382) |************************************************+
Info: [  8382,   9177) |*****************************************************+
Info: [  9177,   9972) |*******************************************+
Info: [  9972,  10767) |************************+
Info: [ 10767,  11562) |****************+
Info: [ 11562,  12357) |*********+
Info: [ 12357,  13152) |*+
Info: [ 13152,  13947) |+
```