### PR TITLE
Fix budget overrides

### DIFF
--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -138,7 +138,8 @@ class SAPlacer
         if ((placed_cells - constr_placed_cells) % 500 != 0)
             log_info("  initial placement placed %d/%d cells\n", int(placed_cells - constr_placed_cells),
                      int(autoplaced.size()));
-        assign_budget(ctx);
+        if (ctx->slack_redist_iter > 0)
+            assign_budget(ctx);
         ctx->yield();
 
         log_info("Running simulated annealing placer.\n");

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -48,22 +48,26 @@ struct Timing
 
     delay_t follow_net(NetInfo *net, int path_length, delay_t slack)
     {
-        delay_t net_budget = slack / (path_length + 1);
+        const delay_t default_budget = slack / (path_length + 1);
+        delay_t net_budget = default_budget;
         for (auto &usr : net->users) {
+            auto delay = net_delays ? ctx->getNetinfoRouteDelay(net, usr) : delay_t();
             if (crit_path)
                 current_path.push_back(&usr);
-            // If budget override is less than existing budget, then do not increment
-            // path length
-            int pl = path_length + 1;
-            auto budget = ctx->getBudgetOverride(net, usr, net_budget);
-            if (budget < net_budget) {
-                net_budget = budget;
-                pl = std::max(1, path_length);
+            // If budget override exists, use that value and do not increment path_length
+            auto budget = default_budget;
+            if (ctx->getBudgetOverride(net, usr, budget)) {
+                if (update)
+                    usr.budget = std::min(usr.budget, budget);
+                budget = follow_user_port(usr, path_length, slack - budget);
+                net_budget = std::min(net_budget, budget);
             }
-            auto delay = net_delays ? ctx->getNetinfoRouteDelay(net, usr) : delay_t();
-            net_budget = std::min(net_budget, follow_user_port(usr, pl, slack - delay));
-            if (update)
-                usr.budget = std::min(usr.budget, delay + net_budget);
+            else {
+                budget = follow_user_port(usr, path_length + 1, slack - delay);
+                net_budget = std::min(net_budget, budget);
+                if (update)
+                    usr.budget = std::min(usr.budget, delay + budget);
+            }
             if (crit_path)
                 current_path.pop_back();
         }

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -58,7 +58,7 @@ struct Timing
                 net_budget = budget;
                 pl = std::max(1, path_length);
             }
-            auto delay = ctx->getNetinfoRouteDelay(net, usr);
+            auto delay = ctx->slack_redist_iter > 0 ? ctx->getNetinfoRouteDelay(net, usr) : delay_t();
             net_budget = std::min(net_budget, follow_user_port(usr, pl, slack - delay));
             if (update)
                 usr.budget = std::min(usr.budget, delay + net_budget);

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -39,9 +39,10 @@ struct Timing
     PortRefVector *crit_path;
     DelayFrequency *slack_histogram;
 
-    Timing(Context *ctx, bool net_delays, bool update, PortRefVector *crit_path = nullptr, DelayFrequency *slack_histogram = nullptr)
-            : ctx(ctx), net_delays(net_delays), update(update), min_slack(1.0e12 / ctx->target_freq), crit_path(crit_path),
-              slack_histogram(slack_histogram)
+    Timing(Context *ctx, bool net_delays, bool update, PortRefVector *crit_path = nullptr,
+           DelayFrequency *slack_histogram = nullptr)
+            : ctx(ctx), net_delays(net_delays), update(update), min_slack(1.0e12 / ctx->target_freq),
+              crit_path(crit_path), slack_histogram(slack_histogram)
     {
     }
 
@@ -150,7 +151,7 @@ void assign_budget(Context *ctx, bool quiet)
 {
     if (!quiet) {
         log_break();
-        log_info("Annotating ports with timing budgets for target frequency %.2f MHz\n", ctx->target_freq/1e6);
+        log_info("Annotating ports with timing budgets for target frequency %.2f MHz\n", ctx->target_freq / 1e6);
     }
 
     Timing timing(ctx, ctx->slack_redist_iter > 0 /* net_delays */, true /* update */);

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -2,6 +2,7 @@
  *  nextpnr -- Next Generation Place and Route
  *
  *  Copyright (C) 2018  David Shah <david@symbioticeda.com>
+ *  Copyright (C) 2018  Eddie Hung <eddieh@ece.ubc.ca>
  *
  *  Permission to use, copy, modify, and/or distribute this software for any
  *  purpose with or without fee is hereby granted, provided that the above

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -402,9 +402,9 @@ Convert an `delay_t` to an actual real-world delay in nanoseconds.
 
 Convert a `delay_t` to an integer for checksum calculations.
 
-### delay\_t getBudgetOverride(const NetInfo \*net\_info, const PortRef &sink, delay\_t budget) const
+### bool getBudgetOverride(const NetInfo \*net\_info, const PortRef &sink, delay\_t &budget) const
 
-Overwrite or modify the timing budget for a given arc. Returns the new budget.
+Overwrite or modify (in-place) the timing budget for a given arc. Returns a bool to indicate whether this was done.
 
 Flow Methods
 ------------

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -422,7 +422,7 @@ delay_t Arch::predictDelay(const NetInfo *net_info, const PortRef &sink) const
     return 200 * (abs(driver_loc.x - sink_loc.x) + abs(driver_loc.y - sink_loc.y));
 }
 
-delay_t Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t budget) const { return budget; }
+bool Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const { return false; }
 
 // -----------------------------------------------------------------------
 

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -805,7 +805,7 @@ struct Arch : BaseCtx
     delay_t getRipupDelayPenalty() const { return 200; }
     float getDelayNS(delay_t v) const { return v * 0.001; }
     uint32_t getDelayChecksum(delay_t v) const { return v; }
-    delay_t getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t budget) const;
+    bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const;
 
     // -------------------------------------------------
 

--- a/generic/arch.cc
+++ b/generic/arch.cc
@@ -408,7 +408,7 @@ delay_t Arch::predictDelay(const NetInfo *net_info, const PortRef &sink) const
     return (dx + dy) * grid_distance_to_delay;
 }
 
-delay_t Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t budget) const { return budget; }
+bool Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const { return false; }
 
 // ---------------------------------------------------------------
 

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -200,7 +200,7 @@ struct Arch : BaseCtx
     delay_t getRipupDelayPenalty() const { return 1.0; }
     float getDelayNS(delay_t v) const { return v; }
     uint32_t getDelayChecksum(delay_t v) const { return 0; }
-    delay_t getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t budget) const;
+    bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const;
 
     bool pack() { return true; }
     bool place();

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -645,8 +645,23 @@ bool Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay
         auto sink_loc = getBelLocation(sink.cell->bel);
         if (driver_loc.y == sink_loc.y)
             budget = 0;
-        else
-            budget = 190;
+        else switch (args.type) {
+#ifndef ICE40_HX1K_ONLY
+            case ArchArgs::HX8K:
+#endif
+            case ArchArgs::HX1K:
+                budget = 190; break;
+#ifndef ICE40_HX1K_ONLY
+            case ArchArgs::LP384:
+            case ArchArgs::LP1K:
+            case ArchArgs::LP8K:
+                budget = 290; break;
+            case ArchArgs::UP5K:
+                budget = 560; break;
+#endif
+            default:
+                log_error("Unsupported iCE40 chip type.\n");
+        }
         return true;
     }
     return false;

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -640,7 +640,7 @@ std::vector<GroupId> Arch::getGroupGroups(GroupId group) const
 bool Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const
 {
     const auto &driver = net_info->driver;
-    if (driver.port == id_cout) {
+    if (driver.port == id_cout && sink.port == id_cin) {
         auto driver_loc = getBelLocation(driver.cell->bel);
         auto sink_loc = getBelLocation(sink.cell->bel);
         if (driver_loc.y == sink_loc.y)

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -637,17 +637,19 @@ std::vector<GroupId> Arch::getGroupGroups(GroupId group) const
 
 // -----------------------------------------------------------------------
 
-delay_t Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t budget) const
+bool Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const
 {
     const auto &driver = net_info->driver;
     if (driver.port == id_cout) {
         auto driver_loc = getBelLocation(driver.cell->bel);
         auto sink_loc = getBelLocation(sink.cell->bel);
         if (driver_loc.y == sink_loc.y)
-            return 0;
-        return 250;
+            budget = 0;
+        else
+            budget = 190;
+        return true;
     }
-    return budget;
+    return false;
 }
 
 // -----------------------------------------------------------------------

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -766,7 +766,7 @@ struct Arch : BaseCtx
     delay_t getRipupDelayPenalty() const { return 200; }
     float getDelayNS(delay_t v) const { return v * 0.001; }
     uint32_t getDelayChecksum(delay_t v) const { return v; }
-    delay_t getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t budget) const;
+    bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const;
 
     // -------------------------------------------------
 

--- a/ice40/main.cc
+++ b/ice40/main.cc
@@ -366,6 +366,7 @@ int main(int argc, char *argv[])
 
             if (!ctx->pack() && !ctx->force)
                 log_error("Packing design failed.\n");
+            assign_budget(ctx.get());
             ctx->check();
             print_utilisation(ctx.get());
             if (!vm.count("pack-only")) {


### PR DESCRIPTION
It appears that `Arch::getBudgetOverride()` wasn't being used correctly during STA. Builds on #38.

Also changed signature of `Arch::getBudgetOverride()` to `bool Arch::getBudgetOverride(const Netinfo*, const PortRef&, delay_t&)` to modify budget in place and return bool if this was done.

This appears to return a small QoR improvement:
On #38:
```
  | min | avg | max | success (/32)
master 100MHz | 50.88 | 55.04 | 60.28 | 32
master 70MHz | 50.4 | 54.97 | 59.13 | 31
master 60MHz | 51.16 | 54.97 | 59.06 | 32
master (default=12MHz) | 51.54 | 54.42 | 59.73 | 32
```

This:
```
  | min | avg | max | success (/32)
master 100MHz | 49.87 | 55.45 | 61 | 32
master 70MHz | 51.14 | 55.94 | 63.33 | 32
master 60MHz | 51.71 | 57.32 | 62.53 | 32
master (default=12MHz) | 50.17 | 56.25 | 62.26 | 31
```