### PR TITLE
Speedup assign_budget by walking design in topographical order

### DIFF
--- a/common/timing.cc
+++ b/common/timing.cc
@@ -215,10 +215,11 @@ struct Timing
                 if (ctx->getPortClock(usr.cell, usr.port) != IdString()) {
                     const auto net_arrival = nd.max_arrival;
                     auto path_budget = clk_period - (net_arrival + net_delay);
-                    auto budget_share = budget_override ? 0 : path_budget / net_length_plus_one;
-                    if (update)
+                    if (update) {
+                        auto budget_share = budget_override ? 0 : path_budget / net_length_plus_one;
                         usr.budget = std::min(usr.budget, net_delay + budget_share);
-                    net_min_remaining_budget = std::min(net_min_remaining_budget, path_budget - budget_share);
+                        net_min_remaining_budget = std::min(net_min_remaining_budget, path_budget - budget_share);
+                    }
 
                     if (path_budget < min_slack) {
                         min_slack = path_budget;
@@ -232,7 +233,7 @@ struct Timing
                         int slack_ps = ctx->getDelayNS(path_budget) * 1000;
                         (*slack_histogram)[slack_ps]++;
                     }
-                } else {
+                } else if (update) {
                     // Iterate over all output ports on the same cell as the sink
                     for (const auto &port : usr.cell->ports) {
                         if (port.second.type == PORT_OUT && port.second.net) {
@@ -241,8 +242,7 @@ struct Timing
                             if (is_path) {
                                 auto path_budget = net_data.at(port.second.net).min_remaining_budget;
                                 auto budget_share = budget_override ? 0 : path_budget / net_length_plus_one;
-                                if (update)
-                                    usr.budget = std::min(usr.budget, net_delay + budget_share);
+                                usr.budget = std::min(usr.budget, net_delay + budget_share);
                                 net_min_remaining_budget =
                                         std::min(net_min_remaining_budget, path_budget - budget_share);
                             }

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -155,7 +155,7 @@ struct Timing
         for (auto &cell : ctx->cells) {
             input_ports.clear();
             output_ports.clear();
-            bool is_io = cell.second->type == ctx->id_sb_io; // HACK HACK HACK
+            bool is_io = ctx->isIOCell(cell.second.get());
             for (auto& port : cell.second->ports) {
                 if (!port.second.net) continue;
                 if (port.second.type == PORT_OUT)

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -500,6 +500,12 @@ IdString Arch::getPortClock(const CellInfo *cell, IdString port) const { return 
 
 bool Arch::isClockPort(const CellInfo *cell, IdString port) const { return false; }
 
+bool Arch::isIOCell(const CellInfo *cell) const
+{
+    return cell->type == id("TRELLIS_IO");
+}
+
+
 std::vector<std::pair<std::string, std::string>> Arch::getTilesAtLocation(int row, int col)
 {
     std::vector<std::pair<std::string, std::string>> ret;

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -375,7 +375,6 @@ BelId Arch::getPioByFunctionName(const std::string &name) const
 }
 
 std::vector<PortPin> Arch::getBelPins(BelId bel) const
-
 {
     std::vector<PortPin> ret;
     NPNR_ASSERT(bel != BelId());
@@ -500,11 +499,7 @@ IdString Arch::getPortClock(const CellInfo *cell, IdString port) const { return 
 
 bool Arch::isClockPort(const CellInfo *cell, IdString port) const { return false; }
 
-bool Arch::isIOCell(const CellInfo *cell) const
-{
-    return cell->type == id("TRELLIS_IO");
-}
-
+bool Arch::isIOCell(const CellInfo *cell) const { return cell->type == id("TRELLIS_IO"); }
 
 std::vector<std::pair<std::string, std::string>> Arch::getTilesAtLocation(int row, int col)
 {

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -422,7 +422,7 @@ delay_t Arch::predictDelay(const NetInfo *net_info, const PortRef &sink) const
     return 200 * (abs(driver_loc.x - sink_loc.x) + abs(driver_loc.y - sink_loc.y));
 }
 
-delay_t Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t budget) const { return budget; }
+bool Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const { return false; }
 
 // -----------------------------------------------------------------------
 

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -805,7 +805,7 @@ struct Arch : BaseCtx
     delay_t getRipupDelayPenalty() const { return 200; }
     float getDelayNS(delay_t v) const { return v * 0.001; }
     uint32_t getDelayChecksum(delay_t v) const { return v; }
-    delay_t getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t budget) const;
+    bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const;
 
     // -------------------------------------------------
 

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -833,6 +833,8 @@ struct Arch : BaseCtx
     bool isClockPort(const CellInfo *cell, IdString port) const;
     // Return true if a port is a net
     bool isGlobalNet(const NetInfo *net) const;
+    // Return true if a cell is an IO
+    bool isIOCell(const CellInfo *cell) const;
 
     // -------------------------------------------------
     // Placement validity checks

--- a/generic/arch.cc
+++ b/generic/arch.cc
@@ -408,7 +408,7 @@ delay_t Arch::predictDelay(const NetInfo *net_info, const PortRef &sink) const
     return (dx + dy) * grid_distance_to_delay;
 }
 
-delay_t Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t budget) const { return budget; }
+bool Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const { return false; }
 
 // ---------------------------------------------------------------
 

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -200,7 +200,7 @@ struct Arch : BaseCtx
     delay_t getRipupDelayPenalty() const { return 1.0; }
     float getDelayNS(delay_t v) const { return v; }
     uint32_t getDelayChecksum(delay_t v) const { return 0; }
-    delay_t getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t budget) const;
+    bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const;
 
     bool pack() { return true; }
     bool place();

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -215,6 +215,8 @@ struct Arch : BaseCtx
     bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const;
     IdString getPortClock(const CellInfo *cell, IdString port) const;
     bool isClockPort(const CellInfo *cell, IdString port) const;
+    // Return true if a cell is an IO
+    bool isIOCell(const CellInfo *cell) const;
 
     bool isValidBelForCell(CellInfo *cell, BelId bel) const;
     bool isBelLocationValid(BelId bel) const;

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -637,17 +637,19 @@ std::vector<GroupId> Arch::getGroupGroups(GroupId group) const
 
 // -----------------------------------------------------------------------
 
-delay_t Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t budget) const
+bool Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const
 {
     const auto &driver = net_info->driver;
     if (driver.port == id_cout) {
         auto driver_loc = getBelLocation(driver.cell->bel);
         auto sink_loc = getBelLocation(sink.cell->bel);
         if (driver_loc.y == sink_loc.y)
-            return 0;
-        return 250;
+            budget = 0;
+        else
+            budget = 190;
+        return true;
     }
-    return budget;
+    return false;
 }
 
 // -----------------------------------------------------------------------

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -898,6 +898,11 @@ bool Arch::isGlobalNet(const NetInfo *net) const
     return net->driver.cell != nullptr && net->driver.port == id_glb_buf_out;
 }
 
+bool Arch::isIOCell(const CellInfo *cell) const
+{
+    return cell->type == id_sb_io;
+}
+
 // Assign arch arg info
 void Arch::assignArchInfo()
 {

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -291,7 +291,8 @@ BelId Arch::getBelByLocation(Loc loc) const
 
 BelRange Arch::getBelsByTile(int x, int y) const
 {
-    // In iCE40 chipdb bels at the same tile are consecutive and dense z ordinates are used
+    // In iCE40 chipdb bels at the same tile are consecutive and dense z ordinates
+    // are used
     BelRange br;
 
     br.b.cursor = Arch::getBelByLocation(Loc(x, y, 0)).index;
@@ -645,23 +646,27 @@ bool Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay
         auto sink_loc = getBelLocation(sink.cell->bel);
         if (driver_loc.y == sink_loc.y)
             budget = 0;
-        else switch (args.type) {
+        else
+            switch (args.type) {
 #ifndef ICE40_HX1K_ONLY
             case ArchArgs::HX8K:
 #endif
             case ArchArgs::HX1K:
-                budget = 190; break;
+                budget = 190;
+                break;
 #ifndef ICE40_HX1K_ONLY
             case ArchArgs::LP384:
             case ArchArgs::LP1K:
             case ArchArgs::LP8K:
-                budget = 290; break;
+                budget = 290;
+                break;
             case ArchArgs::UP5K:
-                budget = 560; break;
+                budget = 560;
+                break;
 #endif
             default:
                 log_error("Unsupported iCE40 chip type.\n");
-        }
+            }
         return true;
     }
     return false;
@@ -913,10 +918,7 @@ bool Arch::isGlobalNet(const NetInfo *net) const
     return net->driver.cell != nullptr && net->driver.port == id_glb_buf_out;
 }
 
-bool Arch::isIOCell(const CellInfo *cell) const
-{
-    return cell->type == id_sb_io;
-}
+bool Arch::isIOCell(const CellInfo *cell) const { return cell->type == id_sb_io; }
 
 // Assign arch arg info
 void Arch::assignArchInfo()

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -794,6 +794,8 @@ struct Arch : BaseCtx
     bool isClockPort(const CellInfo *cell, IdString port) const;
     // Return true if a port is a net
     bool isGlobalNet(const NetInfo *net) const;
+    // Return true if a cell is an IO
+    bool isIOCell(const CellInfo *cell) const;
 
     // -------------------------------------------------
 

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -766,7 +766,7 @@ struct Arch : BaseCtx
     delay_t getRipupDelayPenalty() const { return 200; }
     float getDelayNS(delay_t v) const { return v * 0.001; }
     uint32_t getDelayChecksum(delay_t v) const { return v; }
-    delay_t getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t budget) const;
+    bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const;
 
     // -------------------------------------------------
 

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -400,10 +400,10 @@ struct Arch : BaseCtx
     mutable std::unordered_map<Loc, int> bel_by_loc;
 
     std::vector<bool> bel_carry;
-    std::vector<CellInfo*> bel_to_cell;
-    std::vector<NetInfo*> wire_to_net;
-    std::vector<NetInfo*> pip_to_net;
-    std::vector<NetInfo*> switches_locked;
+    std::vector<CellInfo *> bel_to_cell;
+    std::vector<NetInfo *> wire_to_net;
+    std::vector<NetInfo *> pip_to_net;
+    std::vector<NetInfo *> switches_locked;
 
     ArchArgs args;
     Arch(ArchArgs args);
@@ -799,7 +799,8 @@ struct Arch : BaseCtx
 
     // -------------------------------------------------
 
-    // Perform placement validity checks, returning false on failure (all implemented in arch_place.cc)
+    // Perform placement validity checks, returning false on failure (all
+    // implemented in arch_place.cc)
 
     // Whether or not a given cell can be placed at a given Bel
     // This is not intended for Bel type checks, but finer-grained constraints
@@ -813,7 +814,8 @@ struct Arch : BaseCtx
     bool logicCellsCompatible(const std::vector<const CellInfo *> &cells) const;
 
     // -------------------------------------------------
-    // Assign architecure-specific arguments to nets and cells, which must be called between packing or further
+    // Assign architecure-specific arguments to nets and cells, which must be
+    // called between packing or further
     // netlist modifications, and validity checks
     void assignArchInfo();
     void assignCellInfo(CellInfo *cell);


### PR DESCRIPTION
Previously, `assign_budget` would walk recursively from each clocked output, through all its fanout paths, in order to determine the minimum slack of each path, before returning to distribute this path slack evenly.

This PR changes this by first generating a topographical ordering to walk the design (making the assumption it is a DAG, and there exists no combinatorial loops). Then it walks forward through the design in order to find the minimum slack of each path, and then backwards through the design to distribute this slack.

This should make `assign_budget` linear efficiency. The litmus test is that design03-up5k now completes in 4 minutes on my 1.4GHz machine.

```
Info: estimated Fmax = 7.72 MHz

Info: Slack histogram:
Info:  legend: * represents 48 endpoint(s)
Info:          + represents [1,48) endpoint(s)
Info: [-46196, -39808) |+
Info: [-39808, -33420) |+
Info: [-33420, -27032) |*+
Info: [-27032, -20644) |***+
Info: [-20644, -14256) |**+
Info: [-14256,  -7868) |+
Info: [ -7868,  -1480) |+
Info: [ -1480,   4908) |*+
Info: [  4908,  11296) |+
Info: [ 11296,  17684) |*+
Info: [ 17684,  24072) |***+
Info: [ 24072,  30460) |**+
Info: [ 30460,  36848) |**+
Info: [ 36848,  43236) |**+
Info: [ 43236,  49624) |***+
Info: [ 49624,  56012) |*****+
Info: [ 56012,  62400) |**********+
Info: [ 62400,  68788) |****************+
Info: [ 68788,  75176) |************+
Info: [ 75176,  81564) |************************************************************
Info: [ 81564,  87952) |+

real    3m58.400s
user    3m58.154s
sys     0m0.442s
```