### PR TITLE
gui: fix #57

### DIFF
--- a/gui/fpgaviewwidget.cc
+++ b/gui/fpgaviewwidget.cc
@@ -240,9 +240,10 @@ void FPGAViewWidget::populateQuadTree(RendererData *data, const DecalXY &decal, 
             continue;
         }
 
+        bool res = true;
         if (el.type == GraphicElement::TYPE_BOX) {
             // Boxes are bounded by themselves.
-            data->qt->insert(PickQuadTree::BoundingBox(x + el.x1, y + el.y1, x + el.x2, y + el.y2), element);
+            res = data->qt->insert(PickQuadTree::BoundingBox(x + el.x1, y + el.y1, x + el.x2, y + el.y2), element);
         }
 
         if (el.type == GraphicElement::TYPE_LINE || el.type == GraphicElement::TYPE_ARROW) {
@@ -261,7 +262,11 @@ void FPGAViewWidget::populateQuadTree(RendererData *data, const DecalXY &decal, 
             x1 += 0.01;
             y1 += 0.01;
 
-            data->qt->insert(PickQuadTree::BoundingBox(x0, y0, x1, y1), element);
+            res = data->qt->insert(PickQuadTree::BoundingBox(x0, y0, x1, y1), element);
+        }
+
+        if (!res) {
+            NPNR_ASSERT_FALSE("populateQuadTree: could not insert element");
         }
     }
 }
@@ -450,8 +455,17 @@ void FPGAViewWidget::renderLines(void)
         NPNR_ASSERT(data->bbGlobal.w() != 0);
         NPNR_ASSERT(data->bbGlobal.h() != 0);
 
+        // Enlarge the bounding box slightly for the picking - when we insert
+        // elements into it, we enlarge their bounding boxes slightly, so
+        // we need to give ourselves some sagery margin here.
+        auto bb = data->bbGlobal;
+        bb.setX0(bb.x0() - 1);
+        bb.setY0(bb.y0() - 1);
+        bb.setX1(bb.x1() + 1);
+        bb.setY1(bb.y1() + 1);
+
         // Populate picking quadtree.
-        data->qt = std::unique_ptr<PickQuadTree>(new PickQuadTree(data->bbGlobal));
+        data->qt = std::unique_ptr<PickQuadTree>(new PickQuadTree(bb));
         for (auto const &decal : belDecals) {
             populateQuadTree(data.get(), decal.first,
                              PickedElement::fromBel(decal.second, decal.first.x, decal.first.y));


### PR DESCRIPTION
Turns out the bounding box of the quadtree root wasn't large enough to accommodate elements that were on the edge of the bounding box. Any time we added lines, we would slightly enlarge their bounding boxes, and thus exceed the root bounding box size.

This would fail silently - we also add an assert against this to easier debug similar bugs in the future.