### PR TITLE
Adding ECP5 carry support

### DIFF
--- a/common/chain_utils.h
+++ b/common/chain_utils.h
@@ -1,0 +1,68 @@
+/*
+ *  nextpnr -- Next Generation Place and Route
+ *
+ *  Copyright (C) 2018  David Shah <david@symbioticeda.com>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#ifndef CHAIN_UTILS_H
+#define CHAIN_UTILS_H
+
+#include "nextpnr.h"
+#include "util.h"
+
+NEXTPNR_NAMESPACE_BEGIN
+
+struct CellChain
+{
+    std::vector<CellInfo *> cells;
+};
+
+// Generic chain finder
+template <typename F1, typename F2, typename F3>
+std::vector<CellChain> find_chains(const Context *ctx, F1 cell_type_predicate, F2 get_previous, F3 get_next,
+                                   size_t min_length = 2)
+{
+    std::set<IdString> chained;
+    std::vector<CellChain> chains;
+    for (auto cell : sorted(ctx->cells)) {
+        if (chained.find(cell.first) != chained.end())
+            continue;
+        CellInfo *ci = cell.second;
+        if (cell_type_predicate(ctx, ci)) {
+            CellInfo *start = ci;
+            CellInfo *prev_start = ci;
+            while (prev_start != nullptr) {
+                start = prev_start;
+                prev_start = get_previous(ctx, start);
+            }
+            CellChain chain;
+            CellInfo *end = start;
+            while (end != nullptr) {
+                chain.cells.push_back(end);
+                end = get_next(ctx, end);
+            }
+            if (chain.cells.size() >= min_length) {
+                chains.push_back(chain);
+                for (auto c : chain.cells)
+                    chained.insert(c->name);
+            }
+        }
+    }
+    return chains;
+}
+
+NEXTPNR_NAMESPACE_END
+#endif

--- a/common/design_utils.cc
+++ b/common/design_utils.cc
@@ -74,7 +74,8 @@ void print_utilisation(const Context *ctx)
 }
 
 // Connect a net to a port
-void connect_port(const Context *ctx, NetInfo *net, CellInfo *cell, IdString port_name) {
+void connect_port(const Context *ctx, NetInfo *net, CellInfo *cell, IdString port_name)
+{
     PortInfo &port = cell->ports.at(port_name);
     NPNR_ASSERT(port.net == nullptr);
     port.net = net;

--- a/common/design_utils.cc
+++ b/common/design_utils.cc
@@ -73,4 +73,23 @@ void print_utilisation(const Context *ctx)
     log_break();
 }
 
+// Connect a net to a port
+void connect_port(const Context *ctx, NetInfo *net, CellInfo *cell, IdString port_name) {
+    PortInfo &port = cell->ports.at(port_name);
+    NPNR_ASSERT(port.net == nullptr);
+    port.net = net;
+    if (port.type == PORT_OUT) {
+        NPNR_ASSERT(net->driver.cell == nullptr);
+        net->driver.cell = cell;
+        net->driver.port = port_name;
+    } else if (port.type == PORT_IN) {
+        PortRef user;
+        user.cell = cell;
+        user.port = port_name;
+        net->users.push_back(user);
+    } else {
+        NPNR_ASSERT_FALSE("invalid port type for connect_port");
+    }
+}
+
 NEXTPNR_NAMESPACE_END

--- a/common/design_utils.h
+++ b/common/design_utils.h
@@ -82,6 +82,9 @@ template <typename F1> CellInfo *net_driven_by(const Context *ctx, const NetInfo
     }
 }
 
+// Connect a net to a port
+void connect_port(const Context *ctx, NetInfo *net, CellInfo *cell, IdString port_name);
+
 void print_utilisation(const Context *ctx);
 
 NEXTPNR_NAMESPACE_END

--- a/ecp5/arch_place.cc
+++ b/ecp5/arch_place.cc
@@ -39,25 +39,27 @@ bool Arch::slicesCompatible(const std::vector<const CellInfo *> &cells) const
     IdString CLKMUX, LSRMUX, SRMODE;
     bool first = true;
     for (auto cell : cells) {
-        if (first) {
-            clk_sig = cell->sliceInfo.clk_sig;
-            lsr_sig = cell->sliceInfo.lsr_sig;
-            CLKMUX = cell->sliceInfo.clkmux;
-            LSRMUX = cell->sliceInfo.lsrmux;
-            SRMODE = cell->sliceInfo.srmode;
-        } else {
-            if (cell->sliceInfo.clk_sig != clk_sig)
-                return false;
-            if (cell->sliceInfo.lsr_sig != lsr_sig)
-                return false;
-            if (cell->sliceInfo.clkmux != CLKMUX)
-                return false;
-            if (cell->sliceInfo.lsrmux != LSRMUX)
-                return false;
-            if (cell->sliceInfo.srmode != SRMODE)
-                return false;
+        if (cell->sliceInfo.using_dff) {
+            if (first) {
+                clk_sig = cell->sliceInfo.clk_sig;
+                lsr_sig = cell->sliceInfo.lsr_sig;
+                CLKMUX = cell->sliceInfo.clkmux;
+                LSRMUX = cell->sliceInfo.lsrmux;
+                SRMODE = cell->sliceInfo.srmode;
+            } else {
+                if (cell->sliceInfo.clk_sig != clk_sig)
+                    return false;
+                if (cell->sliceInfo.lsr_sig != lsr_sig)
+                    return false;
+                if (cell->sliceInfo.clkmux != CLKMUX)
+                    return false;
+                if (cell->sliceInfo.lsrmux != LSRMUX)
+                    return false;
+                if (cell->sliceInfo.srmode != SRMODE)
+                    return false;
+            }
+            first = false;
         }
-        first = false;
     }
     return true;
 }

--- a/ecp5/archdefs.h
+++ b/ecp5/archdefs.h
@@ -143,6 +143,7 @@ struct ArchCellInfo
 {
     struct
     {
+        bool using_dff;
         IdString clk_sig, lsr_sig, clkmux, lsrmux, srmode;
     } sliceInfo;
 };

--- a/ecp5/bitstream.cc
+++ b/ecp5/bitstream.cc
@@ -256,7 +256,22 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
                 cc.tiles[tname].add_enum("LSR1.SRMODE", str_or_default(ci->params, ctx->id("SRMODE"), "LSR_OVER_CE"));
                 cc.tiles[tname].add_enum("LSR1.LSRMUX", str_or_default(ci->params, ctx->id("LSRMUX"), "LSR"));
             }
-            // TODO: CLKMUX, CEMUX, carry
+
+            if (str_or_default(ci->params, ctx->id("MODE"), "LOGIC") == "CCU2") {
+                cc.tiles[tname].add_enum(slice + ".CCU2.INJECT1_0",
+                                         str_or_default(ci->params, ctx->id("INJECT1_0"), "YES"));
+                cc.tiles[tname].add_enum(slice + ".CCU2.INJECT1_1",
+                                         str_or_default(ci->params, ctx->id("INJECT1_1"), "YES"));
+            }
+
+            // Tie unused inputs high
+            for (auto input : {id_A0, id_B0, id_C0, id_D0, id_A1, id_B1, id_C1, id_D1}) {
+                if (ci->ports.find(input) == ci->ports.end() || ci->ports.at(input).net == nullptr) {
+                    cc.tiles[tname].add_enum(slice + "." + input.str(ctx) + "MUX", "1");
+                }
+            }
+
+            // TODO: CLKMUX
         } else if (ci->type == ctx->id("TRELLIS_IO")) {
             std::string pio = ctx->locInfo(bel)->bel_data[bel.index].name.get();
             std::string iotype = str_or_default(ci->attrs, ctx->id("IO_TYPE"), "LVCMOS33");

--- a/ecp5/bitstream.cc
+++ b/ecp5/bitstream.cc
@@ -244,17 +244,22 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
             cc.tiles[tname].add_enum(slice + ".REG1.REGSET",
                                      str_or_default(ci->params, ctx->id("REG1_REGSET"), "RESET"));
             cc.tiles[tname].add_enum(slice + ".CEMUX", str_or_default(ci->params, ctx->id("CEMUX"), "1"));
-            NetInfo *lsrnet = nullptr;
-            if (ci->ports.find(ctx->id("LSR")) != ci->ports.end() && ci->ports.at(ctx->id("LSR")).net != nullptr)
-                lsrnet = ci->ports.at(ctx->id("LSR")).net;
-            if (ctx->getBoundWireNet(ctx->getWireByName(
-                        ctx->id(fmt_str("X" << bel.location.x << "/Y" << bel.location.y << "/LSR0")))) == lsrnet) {
-                cc.tiles[tname].add_enum("LSR0.SRMODE", str_or_default(ci->params, ctx->id("SRMODE"), "LSR_OVER_CE"));
-                cc.tiles[tname].add_enum("LSR0.LSRMUX", str_or_default(ci->params, ctx->id("LSRMUX"), "LSR"));
-            } else if (ctx->getBoundWireNet(ctx->getWireByName(ctx->id(
-                               fmt_str("X" << bel.location.x << "/Y" << bel.location.y << "/LSR1")))) == lsrnet) {
-                cc.tiles[tname].add_enum("LSR1.SRMODE", str_or_default(ci->params, ctx->id("SRMODE"), "LSR_OVER_CE"));
-                cc.tiles[tname].add_enum("LSR1.LSRMUX", str_or_default(ci->params, ctx->id("LSRMUX"), "LSR"));
+
+            if (ci->sliceInfo.using_dff) {
+                NetInfo *lsrnet = nullptr;
+                if (ci->ports.find(ctx->id("LSR")) != ci->ports.end() && ci->ports.at(ctx->id("LSR")).net != nullptr)
+                    lsrnet = ci->ports.at(ctx->id("LSR")).net;
+                if (ctx->getBoundWireNet(ctx->getWireByName(
+                            ctx->id(fmt_str("X" << bel.location.x << "/Y" << bel.location.y << "/LSR0")))) == lsrnet) {
+                    cc.tiles[tname].add_enum("LSR0.SRMODE",
+                                             str_or_default(ci->params, ctx->id("SRMODE"), "LSR_OVER_CE"));
+                    cc.tiles[tname].add_enum("LSR0.LSRMUX", str_or_default(ci->params, ctx->id("LSRMUX"), "LSR"));
+                } else if (ctx->getBoundWireNet(ctx->getWireByName(ctx->id(
+                                   fmt_str("X" << bel.location.x << "/Y" << bel.location.y << "/LSR1")))) == lsrnet) {
+                    cc.tiles[tname].add_enum("LSR1.SRMODE",
+                                             str_or_default(ci->params, ctx->id("SRMODE"), "LSR_OVER_CE"));
+                    cc.tiles[tname].add_enum("LSR1.LSRMUX", str_or_default(ci->params, ctx->id("LSRMUX"), "LSR"));
+                }
             }
 
             if (str_or_default(ci->params, ctx->id("MODE"), "LOGIC") == "CCU2") {

--- a/ecp5/cells.cc
+++ b/ecp5/cells.cc
@@ -213,7 +213,7 @@ void lut_to_slice(Context *ctx, CellInfo *lut, CellInfo *lc, int index)
 
 void ccu2c_to_slice(Context *ctx, CellInfo *ccu, CellInfo *lc)
 {
-    lc->params[ctx->id("MODE")] = "CCU2C";
+    lc->params[ctx->id("MODE")] = "CCU2";
     lc->params[ctx->id("LUT0_INITVAL")] = str_or_default(ccu->params, ctx->id("INIT0"), "0");
     lc->params[ctx->id("LUT1_INITVAL")] = str_or_default(ccu->params, ctx->id("INIT1"), "0");
 

--- a/ecp5/cells.cc
+++ b/ecp5/cells.cc
@@ -211,4 +211,31 @@ void lut_to_slice(Context *ctx, CellInfo *lut, CellInfo *lc, int index)
     replace_port(lut, ctx->id("Z"), lc, ctx->id("F" + std::to_string(index)));
 }
 
+void ccu2c_to_slice(Context *ctx, CellInfo *ccu, CellInfo *lc)
+{
+    lc->params[ctx->id("MODE")] = "CCU2C";
+    lc->params[ctx->id("LUT0_INITVAL")] = str_or_default(ccu->params, ctx->id("INIT0"), "0");
+    lc->params[ctx->id("LUT1_INITVAL")] = str_or_default(ccu->params, ctx->id("INIT1"), "0");
+
+    lc->params[ctx->id("INJECT1_0")] = str_or_default(ccu->params, ctx->id("INJECT1_0"), "YES");
+    lc->params[ctx->id("INJECT1_1")] = str_or_default(ccu->params, ctx->id("INJECT1_1"), "YES");
+
+    replace_port(ccu, ctx->id("CIN"), lc, ctx->id("FCI"));
+
+    replace_port(ccu, ctx->id("A0"), lc, ctx->id("A0"));
+    replace_port(ccu, ctx->id("B0"), lc, ctx->id("B0"));
+    replace_port(ccu, ctx->id("C0"), lc, ctx->id("C0"));
+    replace_port(ccu, ctx->id("D0"), lc, ctx->id("D0"));
+
+    replace_port(ccu, ctx->id("A1"), lc, ctx->id("A1"));
+    replace_port(ccu, ctx->id("B1"), lc, ctx->id("B1"));
+    replace_port(ccu, ctx->id("C1"), lc, ctx->id("C1"));
+    replace_port(ccu, ctx->id("D1"), lc, ctx->id("D1"));
+
+    replace_port(ccu, ctx->id("S0"), lc, ctx->id("F0"));
+    replace_port(ccu, ctx->id("S1"), lc, ctx->id("F1"));
+
+    replace_port(ccu, ctx->id("COUT"), lc, ctx->id("FCO"));
+}
+
 NEXTPNR_NAMESPACE_END

--- a/ecp5/cells.cc
+++ b/ecp5/cells.cc
@@ -124,6 +124,28 @@ std::unique_ptr<CellInfo> create_ecp5_cell(Context *ctx, IdString type, std::str
         add_port(ctx, new_cell.get(), "C", PORT_IN);
         add_port(ctx, new_cell.get(), "D", PORT_IN);
         add_port(ctx, new_cell.get(), "Z", PORT_OUT);
+    } else if (type == ctx->id("CCU2C")) {
+        new_cell->params[ctx->id("INIT0")] = "0";
+        new_cell->params[ctx->id("INIT1")] = "0";
+        new_cell->params[ctx->id("INJECT1_0")] = "YES";
+        new_cell->params[ctx->id("INJECT1_1")] = "YES";
+
+        add_port(ctx, new_cell.get(), "CIN", PORT_IN);
+
+        add_port(ctx, new_cell.get(), "A0", PORT_IN);
+        add_port(ctx, new_cell.get(), "B0", PORT_IN);
+        add_port(ctx, new_cell.get(), "C0", PORT_IN);
+        add_port(ctx, new_cell.get(), "D0", PORT_IN);
+
+        add_port(ctx, new_cell.get(), "A1", PORT_IN);
+        add_port(ctx, new_cell.get(), "B1", PORT_IN);
+        add_port(ctx, new_cell.get(), "C1", PORT_IN);
+        add_port(ctx, new_cell.get(), "D1", PORT_IN);
+
+        add_port(ctx, new_cell.get(), "S0", PORT_OUT);
+        add_port(ctx, new_cell.get(), "S1", PORT_OUT);
+        add_port(ctx, new_cell.get(), "COUT", PORT_OUT);
+
     } else if (type == ctx->id("DCCA")) {
         add_port(ctx, new_cell.get(), "CLKI", PORT_IN);
         add_port(ctx, new_cell.get(), "CLKO", PORT_OUT);

--- a/ecp5/cells.h
+++ b/ecp5/cells.h
@@ -48,6 +48,7 @@ inline bool is_l6mux(const BaseCtx *ctx, const CellInfo *cell) { return cell->ty
 
 void ff_to_slice(Context *ctx, CellInfo *ff, CellInfo *lc, int index, bool driven_by_lut);
 void lut_to_slice(Context *ctx, CellInfo *lut, CellInfo *lc, int index);
+void ccu2c_to_slice(Context *ctx, CellInfo *ccu, CellInfo *lc);
 
 NEXTPNR_NAMESPACE_END
 

--- a/ecp5/pack.cc
+++ b/ecp5/pack.cc
@@ -371,7 +371,7 @@ class Ecp5Packer
         std::unique_ptr<CellInfo> feedout = create_ecp5_cell(ctx, ctx->id("CCU2C"));
         feedout->params[ctx->id("INIT0")] = "0";
         feedout->params[ctx->id("INIT1")] = "10"; // LUT4 = 0; LUT2 = A
-        feedout->params[ctx->id("INJECT1_0")] = "YES";
+        feedout->params[ctx->id("INJECT1_0")] = "NO";
         feedout->params[ctx->id("INJECT1_1")] = "NO";
 
         PortRef carry_drv = carry->driver;

--- a/ecp5/pack.cc
+++ b/ecp5/pack.cc
@@ -493,7 +493,7 @@ class Ecp5Packer
             }
         }
 
-        std::vector<std::vector<CellInfo*>> packed_chains;
+        std::vector<std::vector<CellInfo *>> packed_chains;
 
         // Chain packing
         for (auto &chain : all_chains) {
@@ -797,6 +797,13 @@ void Arch::assignArchInfo()
     for (auto cell : sorted(cells)) {
         CellInfo *ci = cell.second;
         if (ci->type == id_TRELLIS_SLICE) {
+
+            ci->sliceInfo.using_dff = false;
+            if (ci->ports.count(id_Q0) && ci->ports[id_Q0].net != nullptr)
+                ci->sliceInfo.using_dff = true;
+            if (ci->ports.count(id_Q1) && ci->ports[id_Q1].net != nullptr)
+                ci->sliceInfo.using_dff = true;
+
             if (ci->ports.count(id_CLK) && ci->ports[id_CLK].net != nullptr)
                 ci->sliceInfo.clk_sig = ci->ports[id_CLK].net->name;
             else

--- a/ecp5/pack.cc
+++ b/ecp5/pack.cc
@@ -108,7 +108,8 @@ class Ecp5Packer
     }
 
     // Return whether or not an FF can be added to a tile (pairing checks must also be done using the fn above)
-    bool can_add_ff_to_file(const std::vector<CellInfo *> &tile_ffs, CellInfo *ff0) {
+    bool can_add_ff_to_file(const std::vector<CellInfo *> &tile_ffs, CellInfo *ff0)
+    {
         for (const auto &existing : tile_ffs) {
             if (net_or_nullptr(existing, ctx->id("CLK")) != net_or_nullptr(ff0, ctx->id("CLK")))
                 return false;
@@ -459,19 +460,19 @@ class Ecp5Packer
         return chains;
     }
 
-
     // Pack carries and set up appropriate relative constraints
-    void pack_carries() {
+    void pack_carries()
+    {
         log_info("Packing carries...\n");
-        auto chains = find_chains(ctx, [](const Context *ctx, const CellInfo *cell) {
-            return is_carry(ctx, cell);
-        }, [](const Context *ctx, const CellInfo *cell) {
-            return net_driven_by(ctx, cell->ports.at(ctx->id("CIN")).net, is_carry, ctx->id("COUT"));
-        }, [](const Context *ctx, const CellInfo *cell) {
-            return net_only_drives(ctx, cell->ports.at(ctx->id("COUT")).net, is_carry,
-                                   ctx->id("CIN"), false);
-        }, 1);
-
+        auto chains = find_chains(
+                ctx, [](const Context *ctx, const CellInfo *cell) { return is_carry(ctx, cell); },
+                [](const Context *ctx, const CellInfo *cell) {
+                    return net_driven_by(ctx, cell->ports.at(ctx->id("CIN")).net, is_carry, ctx->id("COUT"));
+                },
+                [](const Context *ctx, const CellInfo *cell) {
+                    return net_only_drives(ctx, cell->ports.at(ctx->id("COUT")).net, is_carry, ctx->id("CIN"), false);
+                },
+                1);
     }
 
     // Pack LUTs that have been paired together

--- a/ice40/chains.cc
+++ b/ice40/chains.cc
@@ -21,51 +21,13 @@
 #include <algorithm>
 #include <vector>
 #include "cells.h"
+#include "chain_utils.h"
 #include "design_utils.h"
 #include "log.h"
 #include "place_common.h"
 #include "util.h"
 
 NEXTPNR_NAMESPACE_BEGIN
-
-struct CellChain
-{
-    std::vector<CellInfo *> cells;
-};
-
-// Generic chain finder
-template <typename F1, typename F2, typename F3>
-std::vector<CellChain> find_chains(const Context *ctx, F1 cell_type_predicate, F2 get_previous, F3 get_next,
-                                   size_t min_length = 2)
-{
-    std::set<IdString> chained;
-    std::vector<CellChain> chains;
-    for (auto cell : sorted(ctx->cells)) {
-        if (chained.find(cell.first) != chained.end())
-            continue;
-        CellInfo *ci = cell.second;
-        if (cell_type_predicate(ctx, ci)) {
-            CellInfo *start = ci;
-            CellInfo *prev_start = ci;
-            while (prev_start != nullptr) {
-                start = prev_start;
-                prev_start = get_previous(ctx, start);
-            }
-            CellChain chain;
-            CellInfo *end = start;
-            while (end != nullptr) {
-                chain.cells.push_back(end);
-                end = get_next(ctx, end);
-            }
-            if (chain.cells.size() >= min_length) {
-                chains.push_back(chain);
-                for (auto c : chain.cells)
-                    chained.insert(c->name);
-            }
-        }
-    }
-    return chains;
-}
 
 class ChainConstrainer
 {


### PR DESCRIPTION
This adds carry support for ECP5 to the packer and bitstream gen (using relative placement constraints). Tested with a few examples including picorv32.