### PR TITLE
Allow running Python scripts for all points in flow

### DIFF
--- a/common/command.h
+++ b/common/command.h
@@ -53,6 +53,7 @@ class CommandHandler
     void setupContext(Context *ctx);
     int executeMain(std::unique_ptr<Context> ctx);
     po::options_description getGeneralOptions();
+    void run_script_hook(const std::string &name);
 
   protected:
     po::variables_map vm;


### PR DESCRIPTION
This implements the following changes:
 - `--run` now runs a Python script replacing the default flow (previously this ran the script at the end of the flow)
- New options `--pre-pack`, `--pre-place`, `--pre-route`, and --`post-route` allow running Python scripts at a specific point in the default flow, while still running the default flow normally. This will allow Python scripts to be used as a way of implementing constraints.