### PR TITLE
Improve error reporting of failure to open JSON file

### DIFF
--- a/json/jsonparse.cc
+++ b/json/jsonparse.cc
@@ -749,6 +749,10 @@ bool parse_json_file(std::istream &f, std::string &filename, Context *ctx)
 {
     try {
         using namespace JsonParser;
+
+        if (!f)
+            log_error("failed to open JSON file.\n");
+
         int lineno = 1;
 
         JsonNode root(f, lineno);


### PR DESCRIPTION
no missing.json file present

before
```
nextpnr-ice40 --lp384 --json missing.json --pcf constraints.pcf --asc fine.asc
ERROR: Unexpected EOF in JSON file.
ERROR: Loading design failed.
```

after
```
nextpnr-ice40 --lp384 --json missing.json --pcf constraints.pcf --asc fine.asc
ERROR: failed to open JSON file.
ERROR: Loading design failed.
```