### PR TITLE
Mark getArchOptions as override in derived classes

### DIFF
--- a/ecp5/main.cc
+++ b/ecp5/main.cc
@@ -40,7 +40,7 @@ class ECP5CommandHandler : public CommandHandler
     void customBitstream(Context *ctx) override;
 
   protected:
-    po::options_description getArchOptions();
+    po::options_description getArchOptions() override;
 };
 
 ECP5CommandHandler::ECP5CommandHandler(int argc, char **argv) : CommandHandler(argc, argv) {}

--- a/generic/main.cc
+++ b/generic/main.cc
@@ -37,7 +37,7 @@ class GenericCommandHandler : public CommandHandler
     void customBitstream(Context *ctx) override;
 
   protected:
-    po::options_description getArchOptions();
+    po::options_description getArchOptions() override;
 };
 
 GenericCommandHandler::GenericCommandHandler(int argc, char **argv) : CommandHandler(argc, argv) {}

--- a/ice40/main.cc
+++ b/ice40/main.cc
@@ -43,7 +43,7 @@ class Ice40CommandHandler : public CommandHandler
     void customBitstream(Context *ctx) override;
 
   protected:
-    po::options_description getArchOptions();
+    po::options_description getArchOptions() override;
 };
 
 Ice40CommandHandler::Ice40CommandHandler(int argc, char **argv) : CommandHandler(argc, argv) {}


### PR DESCRIPTION
Clang on macOS was warning about the missing override identifier.