### PR TITLE
Fix legalise

### DIFF
--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -191,7 +191,7 @@ struct Loc
     Loc(int x, int y, int z) : x(x), y(y), z(z) {}
 
     bool operator==(const Loc &other) const { return (x == other.x) && (y == other.y) && (z == other.z); }
-    bool operator!=(const Loc &other) const { return (x != other.x) || (y != other.y) || (z == other.z); }
+    bool operator!=(const Loc &other) const { return (x != other.x) || (y != other.y) || (z != other.z); }
 };
 
 NEXTPNR_NAMESPACE_END

--- a/common/place_common.cc
+++ b/common/place_common.cc
@@ -473,7 +473,7 @@ class ConstraintLegaliseWorker
                 return false;
             }
         }
-        print_stats("after legalising chains");
+        print_stats("legalising chains");
         for (auto rippedCell : rippedCells) {
             bool res = place_single_cell(ctx, ctx->cells.at(rippedCell).get(), true);
             if (!res) {
@@ -481,7 +481,7 @@ class ConstraintLegaliseWorker
                 return false;
             }
         }
-        print_stats("after replacing ripped up cells");
+        print_stats("replacing ripped up cells");
         for (auto cell : sorted(ctx->cells))
             if (get_constraints_distance(ctx, cell.second) != 0)
                 log_error("constraint satisfaction check failed for cell '%s' at Bel '%s'\n", cell.first.c_str(ctx),

--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -245,16 +245,18 @@ class SAPlacer
             // Once cooled below legalise threshold, run legalisation and start requiring
             // legal moves only
             if (temp < legalise_temp && require_legal) {
-                legalise_relative_constraints(ctx);
-                require_legal = false;
-                autoplaced.clear();
-                for (auto cell : sorted(ctx->cells)) {
-                    if (cell.second->belStrength < STRENGTH_STRONG)
-                        autoplaced.push_back(cell.second);
+                if (legalise_relative_constraints(ctx)) {
+                    // Only increase temperature if something was moved
+                    autoplaced.clear();
+                    for (auto cell : sorted(ctx->cells)) {
+                        if (cell.second->belStrength < STRENGTH_STRONG)
+                            autoplaced.push_back(cell.second);
+                    }
+                    temp = post_legalise_temp;
+                    diameter *= post_legalise_dia_scale;
+                    ctx->shuffle(autoplaced);
                 }
-                temp = post_legalise_temp;
-                diameter *= post_legalise_dia_scale;
-                ctx->shuffle(autoplaced);
+                require_legal = false;
 
                 // Legalisation is a big change so force a slack redistribution here
                 if (ctx->slack_redist_iter > 0)

--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -244,9 +244,9 @@ class SAPlacer
             }
             // Once cooled below legalise threshold, run legalisation and start requiring
             // legal moves only
-            if (temp < legalise_temp && !require_legal) {
+            if (temp < legalise_temp && require_legal) {
                 legalise_relative_constraints(ctx);
-                require_legal = true;
+                require_legal = false;
                 autoplaced.clear();
                 for (auto cell : sorted(ctx->cells)) {
                     if (cell.second->belStrength < STRENGTH_STRONG)
@@ -486,7 +486,7 @@ class SAPlacer
     std::unordered_map<IdString, int> bel_types;
     std::vector<std::vector<std::vector<std::vector<BelId>>>> fast_bels;
     std::unordered_set<BelId> locked_bels;
-    bool require_legal = false;
+    bool require_legal = true;
     const float legalise_temp = 1;
     const float post_legalise_temp = 10;
     const float post_legalise_dia_scale = 1.5;

--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -255,12 +255,12 @@ class SAPlacer
                     temp = post_legalise_temp;
                     diameter *= post_legalise_dia_scale;
                     ctx->shuffle(autoplaced);
+
+                    // Legalisation is a big change so force a slack redistribution here
+                    if (ctx->slack_redist_iter > 0)
+                        assign_budget(ctx, true /* quiet */);
                 }
                 require_legal = false;
-
-                // Legalisation is a big change so force a slack redistribution here
-                if (ctx->slack_redist_iter > 0)
-                    assign_budget(ctx, true /* quiet */);
             } else if (ctx->slack_redist_iter > 0 && iter % ctx->slack_redist_iter == 0) {
                 assign_budget(ctx, true /* quiet */);
             }


### PR DESCRIPTION
Loc::operator!=() had a typo in thus legaliser was not reporting correct stats.
Furthermore, legaliser now returns bool indicating whether something moved or not, which determines whether placer1's temperature should be increased.