### PR TITLE
common/placer1: In random pick, only use grid if there is more than 64 BELs

### DIFF
--- a/common/placer1.h
+++ b/common/placer1.h
@@ -28,6 +28,7 @@ struct Placer1Cfg : public Settings
 {
     Placer1Cfg(Context *ctx);
     float constraintWeight;
+    int minBelsForGridPick;
 };
 
 extern bool placer1(Context *ctx, Placer1Cfg cfg);


### PR DESCRIPTION
If you have a large grid and very few BELs of a given type, picking a
random grid location yields very little odds of finding a BEL of that
type.

So for those, just put all of them at (0,0) and do a true random pick.

Fixes #127 

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>