### PR TITLE
Tidy up logging code, add log file support, make timing failures non-fatal errors

### DIFF
--- a/common/command.cc
+++ b/common/command.cc
@@ -270,7 +270,7 @@ int CommandHandler::executeMain(std::unique_ptr<Context> ctx)
     deinit_python();
 #endif
 
-    return 0;
+    return had_nonfatal_error ? 1 : 0;
 }
 
 void CommandHandler::conflicting_options(const boost::program_options::variables_map &vm, const char *opt1,

--- a/common/command.h
+++ b/common/command.h
@@ -66,6 +66,7 @@ class CommandHandler
     int argc;
     char **argv;
     ProjectHandler project;
+    std::ofstream logfile;
 };
 
 NEXTPNR_NAMESPACE_END

--- a/common/log.cc
+++ b/common/log.cc
@@ -32,18 +32,12 @@ NEXTPNR_NAMESPACE_BEGIN
 
 NPNR_NORETURN void logv_error(const char *format, va_list ap) NPNR_ATTRIBUTE(noreturn);
 
-std::vector<FILE *> log_files;
-std::vector<std::ostream *> log_streams;
-FILE *log_errfile = NULL;
+std::vector<std::pair<std::ostream *, LogLevel>> log_streams;
 log_write_type log_write_function = nullptr;
 
-bool log_error_stderr = false;
-bool log_cmd_error_throw = false;
-bool log_quiet_warnings = false;
 std::string log_last_error;
 void (*log_error_atexit)() = NULL;
 
-// static bool next_print_log = false;
 static int log_newline_count = 0;
 
 std::string stringf(const char *fmt, ...)
@@ -88,7 +82,7 @@ std::string vstringf(const char *fmt, va_list ap)
     return string;
 }
 
-void logv(const char *format, va_list ap)
+void logv(const char *format, va_list ap, LogLevel level = LogLevel::LOG)
 {
     //
     // Trim newlines from the beginning
@@ -108,90 +102,50 @@ void logv(const char *format, va_list ap)
     else
         log_newline_count = str.size() - nnl_pos - 1;
 
-    for (auto f : log_files)
-        fputs(str.c_str(), f);
-
     for (auto f : log_streams)
-        *f << str;
+        if (f.second <= level)
+            *f.first << str;
     if (log_write_function)
         log_write_function(str);
 }
 
-void logv_info(const char *format, va_list ap)
+void log_with_level(LogLevel level, const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    logv(format, ap, level);
+    va_end(ap);
+}
+
+void logv_prefixed(const char *prefix, const char *format, va_list ap, LogLevel level)
 {
     std::string message = vstringf(format, ap);
 
-    log_always("Info: %s", message.c_str());
+    log_with_level(level, "%s%s", prefix, message.c_str());
     log_flush();
-}
-
-void logv_warning(const char *format, va_list ap)
-{
-    std::string message = vstringf(format, ap);
-
-    log_always("Warning: %s", message.c_str());
-    log_flush();
-}
-
-void logv_warning_noprefix(const char *format, va_list ap)
-{
-    std::string message = vstringf(format, ap);
-
-    log_always("%s", message.c_str());
-}
-
-void logv_error(const char *format, va_list ap)
-{
-#ifdef EMSCRIPTEN
-    auto backup_log_files = log_files;
-#endif
-
-    if (log_errfile != NULL)
-        log_files.push_back(log_errfile);
-
-    if (log_error_stderr)
-        for (auto &f : log_files)
-            if (f == stdout)
-                f = stderr;
-
-    log_last_error = vstringf(format, ap);
-    log_always("ERROR: %s", log_last_error.c_str());
-    log_flush();
-
-    if (log_error_atexit)
-        log_error_atexit();
-
-#ifdef EMSCRIPTEN
-    log_files = backup_log_files;
-#endif
-    throw log_execution_error_exception();
 }
 
 void log_always(const char *format, ...)
 {
     va_list ap;
     va_start(ap, format);
-    logv(format, ap);
+    logv(format, ap, LogLevel::ALWAYS);
     va_end(ap);
 }
 
 void log(const char *format, ...)
 {
-    if (log_quiet_warnings)
-        return;
     va_list ap;
     va_start(ap, format);
-    logv(format, ap);
+    logv(format, ap, LogLevel::LOG);
     va_end(ap);
 }
 
 void log_info(const char *format, ...)
 {
-    if (log_quiet_warnings)
-        return;
     va_list ap;
     va_start(ap, format);
-    logv_info(format, ap);
+    logv_prefixed("Info: ", format, ap, LogLevel::INFO);
     va_end(ap);
 }
 
@@ -199,15 +153,7 @@ void log_warning(const char *format, ...)
 {
     va_list ap;
     va_start(ap, format);
-    logv_warning(format, ap);
-    va_end(ap);
-}
-
-void log_warning_noprefix(const char *format, ...)
-{
-    va_list ap;
-    va_start(ap, format);
-    logv_warning_noprefix(format, ap);
+    logv_prefixed("Warning: ", format, ap, LogLevel::WARNING);
     va_end(ap);
 }
 
@@ -215,41 +161,26 @@ void log_error(const char *format, ...)
 {
     va_list ap;
     va_start(ap, format);
-    logv_error(format, ap);
-}
+    logv_prefixed("ERROR: ", format, ap, LogLevel::ERROR);
 
-void log_cmd_error(const char *format, ...)
-{
-    va_list ap;
-    va_start(ap, format);
+    if (log_error_atexit)
+        log_error_atexit();
 
-    if (log_cmd_error_throw) {
-        log_last_error = vstringf(format, ap);
-        log_always("ERROR: %s", log_last_error.c_str());
-        log_flush();
-        throw log_cmd_error_exception();
-    }
-
-    logv_error(format, ap);
+    throw log_execution_error_exception();
 }
 
 void log_break()
 {
-    if (log_quiet_warnings)
-        return;
     if (log_newline_count < 2)
-        log_always("\n");
+        log("\n");
     if (log_newline_count < 2)
-        log_always("\n");
+        log("\n");
 }
 
 void log_flush()
 {
-    for (auto f : log_files)
-        fflush(f);
-
     for (auto f : log_streams)
-        f->flush();
+        f.first->flush();
 }
 
 NEXTPNR_NAMESPACE_END

--- a/common/log.cc
+++ b/common/log.cc
@@ -39,6 +39,7 @@ std::string log_last_error;
 void (*log_error_atexit)() = NULL;
 
 static int log_newline_count = 0;
+bool had_nonfatal_error = false;
 
 std::string stringf(const char *fmt, ...)
 {
@@ -175,6 +176,15 @@ void log_break()
         log("\n");
     if (log_newline_count < 2)
         log("\n");
+}
+
+void log_nonfatal_error(const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    logv_prefixed("ERROR: ", format, ap, LogLevel::ERROR);
+    va_end(ap);
+    had_nonfatal_error = true;
 }
 
 void log_flush()

--- a/common/log.h
+++ b/common/log.h
@@ -42,12 +42,18 @@ struct log_execution_error_exception
 {
 };
 
-extern std::vector<FILE *> log_files;
-extern std::vector<std::ostream *> log_streams;
-extern FILE *log_errfile;
+enum class LogLevel
+{
+    LOG,
+    INFO,
+    WARNING,
+    ERROR,
+    ALWAYS
+};
+
+extern std::vector<std::pair<std::ostream *, LogLevel>> log_streams;
 extern log_write_type log_write_function;
 
-extern bool log_quiet_warnings;
 extern std::string log_last_error;
 extern void (*log_error_atexit)();
 
@@ -59,9 +65,7 @@ void log(const char *format, ...) NPNR_ATTRIBUTE(format(printf, 1, 2));
 void log_always(const char *format, ...) NPNR_ATTRIBUTE(format(printf, 1, 2));
 void log_info(const char *format, ...) NPNR_ATTRIBUTE(format(printf, 1, 2));
 void log_warning(const char *format, ...) NPNR_ATTRIBUTE(format(printf, 1, 2));
-void log_warning_noprefix(const char *format, ...) NPNR_ATTRIBUTE(format(printf, 1, 2));
 NPNR_NORETURN void log_error(const char *format, ...) NPNR_ATTRIBUTE(format(printf, 1, 2), noreturn);
-NPNR_NORETURN void log_cmd_error(const char *format, ...) NPNR_ATTRIBUTE(format(printf, 1, 2), noreturn);
 
 void log_break();
 void log_flush();
@@ -75,7 +79,6 @@ static inline void log_assert_worker(bool cond, const char *expr, const char *fi
     NEXTPNR_NAMESPACE_PREFIX log_assert_worker(_assert_expr_, #_assert_expr_, __FILE__, __LINE__)
 
 #define log_abort() log_error("Abort in %s:%d.\n", __FILE__, __LINE__)
-#define log_ping() log("-- %s:%d %s --\n", __FILE__, __LINE__, __PRETTY_FUNCTION__)
 
 NEXTPNR_NAMESPACE_END
 

--- a/common/log.h
+++ b/common/log.h
@@ -56,6 +56,7 @@ extern log_write_type log_write_function;
 
 extern std::string log_last_error;
 extern void (*log_error_atexit)();
+extern bool had_nonfatal_error;
 
 std::string stringf(const char *fmt, ...);
 std::string vstringf(const char *fmt, va_list ap);
@@ -66,7 +67,7 @@ void log_always(const char *format, ...) NPNR_ATTRIBUTE(format(printf, 1, 2));
 void log_info(const char *format, ...) NPNR_ATTRIBUTE(format(printf, 1, 2));
 void log_warning(const char *format, ...) NPNR_ATTRIBUTE(format(printf, 1, 2));
 NPNR_NORETURN void log_error(const char *format, ...) NPNR_ATTRIBUTE(format(printf, 1, 2), noreturn);
-
+void log_nonfatal_error(const char *format, ...) NPNR_ATTRIBUTE(format(printf, 1, 2));
 void log_break();
 void log_flush();
 

--- a/common/router1.cc
+++ b/common/router1.cc
@@ -812,7 +812,8 @@ bool router1(Context *ctx, const Router1Cfg &cfg)
 #endif
 
         log_info("Checksum: 0x%08x\n", ctx->checksum());
-        timing_analysis(ctx, true /* slack_histogram */, true /* print_fmax */, true /* print_path */);
+        timing_analysis(ctx, true /* slack_histogram */, true /* print_fmax */, true /* print_path */,
+                        true /* warn_on_failure */);
 
         ctx->unlock();
         return true;

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -698,7 +698,7 @@ void timing_analysis(Context *ctx, bool print_histogram, bool print_fmax, bool p
                 log_info("Max frequency for clock %*s'%s': %.02f MHz (%s at %.02f MHz)\n", width, "",
                          clock_name.c_str(), clock_fmax[clock.first], passed ? "PASS" : "FAIL", target);
             else
-                log_warning("Max frequency for clock %*s'%s': %.02f MHz (%s at %.02f MHz)\n", width, "",
+                log_nonfatal_error("Max frequency for clock %*s'%s': %.02f MHz (%s at %.02f MHz)\n", width, "",
                             clock_name.c_str(), clock_fmax[clock.first], passed ? "PASS" : "FAIL", target);
         }
         for (auto &eclock : empty_clocks) {

--- a/common/timing.h
+++ b/common/timing.h
@@ -29,7 +29,8 @@ void assign_budget(Context *ctx, bool quiet = false);
 
 // Perform timing analysis and print out the fmax, and optionally the
 //    critical path
-void timing_analysis(Context *ctx, bool slack_histogram = true, bool print_fmax = true, bool print_path = false);
+void timing_analysis(Context *ctx, bool slack_histogram = true, bool print_fmax = true, bool print_path = false,
+                     bool warn_on_failure = false);
 
 NEXTPNR_NAMESPACE_END
 

--- a/gui/basewindow.cc
+++ b/gui/basewindow.cc
@@ -44,7 +44,6 @@ BaseMainWindow::BaseMainWindow(std::unique_ptr<Context> context, ArchArgs args, 
     initBasenameResource();
     qRegisterMetaType<std::string>();
 
-    log_files.clear();
     log_streams.clear();
 
     setObjectName("BaseMainWindow");


### PR DESCRIPTION
Fixes #136 and #137 

Adds the `--log`/`-l` option, similar to Yosys, to write a log file which contains all messages even if `-q` is set to limit what is printed to the console.

This also attempts to make the log code more orthogonal, adding the concept of log levels and removing some ugliness such as vectors of both C file pointers and C++ streams.

Timing failures are now printed as warnings in post-route timing analysis.