### PR TITLE
README: further specify required Boost packages for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ of the selected architecture:
 - Qt5 or later (`qt5-default` for Ubuntu 16.04)
 - Python 3.5 or later, including development libraries (`python3-dev` for Ubuntu)
   - on Windows make sure to install same version as supported by [vcpkg](https://github.com/Microsoft/vcpkg/blob/master/ports/python3/CONTROL)
-- Boost libraries (`libboost-dev` or `libboost-all-dev` for Ubuntu)
+- Boost libraries (`libboost-dev libboost-filesystem-dev libboost-thread-dev libboost-program-options-dev libboost-python-dev libboost-dev` or `libboost-all-dev` for Ubuntu)
 - Latest git Yosys is required to synthesise the demo design
 - For building on Windows with MSVC, usage of vcpkg is advised for dependency installation.
   - For 32 bit builds: `vcpkg install boost-filesystem boost-program-options boost-thread boost-python qt5-base`


### PR DESCRIPTION
UWhen installing Boost, you can either install libboost-all-dev, or install
just the required packages.

Previously, `libboost-dev` was the only required package listed.

This adds `libboost-filesystem-dev libboost-thread-dev libboost-program-options-dev
libboost-python-dev` to the list of required packages.

It addresses issue #128.

Signed-off-by: Sean Cross <sean@xobs.io>