### PR TITLE
ice40: Finer-grained control of global promotion

### DIFF
--- a/ice40/main.cc
+++ b/ice40/main.cc
@@ -65,6 +65,9 @@ po::options_description Ice40CommandHandler::getArchOptions()
     specific.add_options()("pcf", po::value<std::string>(), "PCF constraints file to ingest");
     specific.add_options()("asc", po::value<std::string>(), "asc bitstream file to write");
     specific.add_options()("read", po::value<std::string>(), "asc bitstream file to read");
+    specific.add_options()("promote-logic",
+                           "enable promotion of 'logic' globals (in addition to clk/ce/sr by default)");
+    specific.add_options()("no-promote-globals", "disable all global promotion");
     specific.add_options()("tmfuzz", "run path delay estimate fuzzer");
     return specific;
 }
@@ -152,7 +155,13 @@ std::unique_ptr<Context> Ice40CommandHandler::createContext()
     if (vm.count("package"))
         chipArgs.package = vm["package"].as<std::string>();
 
-    return std::unique_ptr<Context>(new Context(chipArgs));
+    auto ctx = std::unique_ptr<Context>(new Context(chipArgs));
+
+    if (vm.count("promote-logic"))
+        ctx->settings[ctx->id("promote_logic")] = "1";
+    if (vm.count("no-promote-globals"))
+        ctx->settings[ctx->id("no_promote_globals")] = "1";
+    return ctx;
 }
 
 int main(int argc, char *argv[])

--- a/ice40/pack.cc
+++ b/ice40/pack.cc
@@ -637,7 +637,8 @@ static void promote_globals(Context *ctx)
                                              });
         if (global_clock->second == 0 && prom_logics < 4 && global_logic->second > logic_fanout_thresh &&
             (global_logic->second > global_cen->second || prom_cens >= cens_available) &&
-            (global_logic->second > global_reset->second || prom_resets >= resets_available)) {
+            (global_logic->second > global_reset->second || prom_resets >= resets_available) &&
+            bool_or_default(ctx->settings, ctx->id("promote_logic"), false)) {
             NetInfo *logicnet = ctx->nets[global_logic->first].get();
             insert_global(ctx, logicnet, false, false, true);
             ++prom_globals;
@@ -1119,7 +1120,8 @@ bool Arch::pack()
         pack_carries(ctx);
         pack_ram(ctx);
         pack_special(ctx);
-        promote_globals(ctx);
+        if (!bool_or_default(ctx->settings, ctx->id("no_promote_globals"), false))
+            promote_globals(ctx);
         ctx->assignArchInfo();
         constrain_chains(ctx);
         ctx->assignArchInfo();


### PR DESCRIPTION
 - Disable promotion of 'logic' globals for now, at least until we have a better heuristic for this, and require `--promote-logic` to enable it
 - Add `--no-promote-globals` to disable all automatic global promotion