### PR TITLE
ice40: raise CE global promotion threshold

### DIFF
--- a/ice40/pack.cc
+++ b/ice40/pack.cc
@@ -565,7 +565,7 @@ static void promote_globals(Context *ctx)
 {
     log_info("Promoting globals..\n");
     const int logic_fanout_thresh = 15;
-    const int enable_fanout_thresh = 5;
+    const int enable_fanout_thresh = 15;
     std::map<IdString, int> clock_count, reset_count, cen_count, logic_count;
     for (auto net : sorted(ctx->nets)) {
         NetInfo *ni = net.second;


### PR DESCRIPTION
On UP5K (at least), any promoted global introduces a significant timing hit, around 4.8 to 6.1 ns. If I am trying to reach a ~35 MHz frequency target in a clock domain (which is about as much as possible to achieve on UP5K), this virtually always breaks timing.

The current threshold is smaller than even a single CLB, which seems obviously wrong. The new threshold would not promote any CE that feeds less three CLBs worth of logic to a global. This is probably still too small, but I'm not sure how to arrive at a proper value.