### PR TITLE
Error reporting improvements

### DIFF
--- a/common/rulecheck.cc
+++ b/common/rulecheck.cc
@@ -9,7 +9,7 @@ bool check_all_nets_driven(Context *ctx)
 {
     const bool debug = false;
 
-    log_info("Rule checker, Verifying pre-placed design\n");
+    log_info("Rule checker, verifying imported design\n");
 
     for (auto &cell_entry : ctx->cells) {
         CellInfo *cell = cell_entry.second.get();

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -670,7 +670,8 @@ TimingPortClass Arch::getPortTimingClass(const CellInfo *cell, IdString port, in
         }
         return TMG_IGNORE;
     } else {
-        NPNR_ASSERT_FALSE_STR("no timing data for cell type '" + cell->type.str(this) + "'");
+        log_error("cell type '%s' is unsupported (instantiated as '%s')\n", cell->type.c_str(this),
+                  cell->name.c_str(this));
     }
 }
 

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -951,7 +951,7 @@ TimingPortClass Arch::getPortTimingClass(const CellInfo *cell, IdString port, in
             return TMG_IGNORE;
         return TMG_ENDPOINT;
     }
-    log_error("no timing info for port '%s' of cell type '%s'\n", port.c_str(this), cell->type.c_str(this));
+    log_error("cell type '%s' is unsupported (instantiated as '%s')\n", cell->type.c_str(this), cell->name.c_str(this));
 }
 
 TimingClockingInfo Arch::getPortClockingInfo(const CellInfo *cell, IdString port, int index) const

--- a/ice40/pack.cc
+++ b/ice40/pack.cc
@@ -478,6 +478,9 @@ static void pack_io(Context *ctx)
             }
             packed_cells.insert(ci->name);
             std::copy(ci->attrs.begin(), ci->attrs.end(), std::inserter(sb->attrs, sb->attrs.begin()));
+            if (!sb->attrs.count(ctx->id("BEL")))
+                log_warning("IO '%s' is not constrained to a pin and will be automatically placed\n",
+                            ci->name.c_str(ctx));
         } else if (is_sb_io(ctx, ci) || is_sb_gb_io(ctx, ci)) {
             NetInfo *net = ci->ports.at(ctx->id("PACKAGE_PIN")).net;
             if ((net != nullptr) && (net->users.size() > 1))
@@ -520,12 +523,8 @@ static bool is_logic_port(BaseCtx *ctx, const PortRef &port)
 
 static void insert_global(Context *ctx, NetInfo *net, bool is_reset, bool is_cen, bool is_logic, int fanout)
 {
-    log_info("promoting %s%s%s%s (fanout %d)\n",
-             net->name.c_str(ctx),
-             is_reset ? " [reset]" : "",
-             is_cen   ? " [cen]"   : "",
-             is_logic ? " [logic]" : "",
-             fanout);
+    log_info("promoting %s%s%s%s (fanout %d)\n", net->name.c_str(ctx), is_reset ? " [reset]" : "",
+             is_cen ? " [cen]" : "", is_logic ? " [logic]" : "", fanout);
 
     std::string glb_name = net->name.str(ctx) + std::string("_$glb_") + (is_reset ? "sr" : (is_cen ? "ce" : "clk"));
     std::unique_ptr<CellInfo> gb = create_ice_cell(ctx, ctx->id("SB_GB"), "$gbuf_" + glb_name);

--- a/json/jsonparse.cc
+++ b/json/jsonparse.cc
@@ -594,7 +594,11 @@ void json_import_cell(Context *ctx, string modname, const std::vector<IdString> 
                                   if (type == PORT_IN || type == PORT_INOUT) {
                                       net->users.push_back(pr);
                                   } else if (type == PORT_OUT) {
-                                      assert(net->driver.cell == nullptr);
+                                      if (net->driver.cell != nullptr)
+                                          log_error("multiple drivers on net '%s' (%s.%s and %s.%s)\n",
+                                                    net->name.c_str(ctx), net->driver.cell->name.c_str(ctx),
+                                                    net->driver.port.c_str(ctx), pr.cell->name.c_str(ctx),
+                                                    pr.port.c_str(ctx));
                                       net->driver = pr;
                                   }
                               }


### PR DESCRIPTION
- Replace assertion failure for multiple drivers with a precise error
- Replace the "no timing data" error (the first time that unknown cell types present a problem) with an "unsupported cell type" error that provides a clearer path to a solution in most cases
 - Remove the inaccurate "pre-placed design" in rulecheck
 - Add a warning for IO pins without a constraint, as this is often a bug in the design 