### PR TITLE
Adding criticality calculation and experimental timing optimisation pass

### DIFF
--- a/common/timing.cc
+++ b/common/timing.cc
@@ -91,6 +91,7 @@ struct NetCriticalityInfo
     // One each per user
     std::vector<delay_t> slack;
     std::vector<float> criticality;
+    unsigned max_path_length = 0;
 };
 
 typedef std::unordered_map<ClockPair, CriticalPath> CriticalPathMap;
@@ -597,6 +598,7 @@ struct Timing
                         float criticality = 1.0 - ((nc.slack.at(i) - worst_slack.at(startdomain.first)) / dmax);
                         nc.criticality.at(i) = std::max(nc.criticality.at(i), criticality);
                     }
+                    nc.max_path_length = std::max(nc.max_path_length, nd.max_path_length);
                 }
             }
         }

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -566,16 +566,20 @@ struct Timing
                     auto &nc = (*net_crit)[net->name];
                     if (nc.slack.empty())
                         nc.slack.resize(net->users.size(), std::numeric_limits<delay_t>::max());
+#if 0
                     if (ctx->debug)
                         log_info("Net %s cd %s\n", net->name.c_str(ctx), startdomain.first.clock.c_str(ctx));
+#endif
                     for (size_t i = 0; i < net->users.size(); i++) {
                         delay_t slack = nd.min_required.at(i) -
                                         (nd.max_arrival + ctx->getNetinfoRouteDelay(net, net->users.at(i)));
+#if 0
                         if (ctx->debug)
                             log_info("    user %s.%s required %.02fns arrival %.02f route %.02f slack %.02f\n",
                                     net->users.at(i).cell->name.c_str(ctx), net->users.at(i).port.c_str(ctx),
                                     ctx->getDelayNS(nd.min_required.at(i)), ctx->getDelayNS(nd.max_arrival),
                                     ctx->getDelayNS(ctx->getNetinfoRouteDelay(net, net->users.at(i))), ctx->getDelayNS(slack));
+#endif
                         if (worst_slack.count(startdomain.first))
                             worst_slack.at(startdomain.first) = std::min(worst_slack.at(startdomain.first), slack);
                         else
@@ -612,7 +616,7 @@ struct Timing
                     nc.cd_worst_slack = std::min(nc.cd_worst_slack, worst_slack.at(startdomain.first));
                 }
             }
-
+#if 0
             if (ctx->debug) {
                 for (auto &nc : *net_crit) {
                     NetInfo *net = ctx->nets.at(nc.first).get();
@@ -628,6 +632,7 @@ struct Timing
                     log_break();
                 }
             }
+#endif
         }
         return min_slack;
     }

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -85,8 +85,6 @@ struct CriticalPath
     delay_t path_period;
 };
 
-
-
 typedef std::unordered_map<ClockPair, CriticalPath> CriticalPathMap;
 typedef std::unordered_map<IdString, NetCriticalityInfo> NetCriticalityMap;
 
@@ -914,7 +912,8 @@ void timing_analysis(Context *ctx, bool print_histogram, bool print_fmax, bool p
     }
 }
 
-void get_criticalities(Context *ctx, NetCriticalityMap *net_crit) {
+void get_criticalities(Context *ctx, NetCriticalityMap *net_crit)
+{
     CriticalPathMap crit_paths;
     net_crit->clear();
     Timing timing(ctx, true, true, &crit_paths, nullptr, net_crit);

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -472,6 +472,8 @@ struct Timing
                     auto &nd = startdomain.second;
                     if (nd.false_startpoint)
                         continue;
+                    if (startdomain.first.clock == async_clock)
+                        continue;
                     const delay_t net_length_plus_one = nd.max_path_length + 1;
                     auto &net_min_remaining_budget = nd.min_remaining_budget;
                     if (nd.min_required.empty())
@@ -555,6 +557,8 @@ struct Timing
                 const NetInfo *net = net_entry.first;
                 for (auto &startdomain : net_entry.second) {
                     auto &nd = startdomain.second;
+                    if (startdomain.first.clock == async_clock)
+                        continue;
                     if (nd.min_required.empty())
                         continue;
                     auto &nc = (*net_crit)[net->name];
@@ -575,6 +579,8 @@ struct Timing
             for (auto &net_entry : net_data) {
                 const NetInfo *net = net_entry.first;
                 for (auto &startdomain : net_entry.second) {
+                    if (startdomain.first.clock == async_clock)
+                        continue;
                     auto &nd = startdomain.second;
                     if (nd.min_required.empty())
                         continue;
@@ -588,7 +594,7 @@ struct Timing
                         continue;
                     delay_t dmax = crit_path->at(ClockPair{startdomain.first, startdomain.first}).path_delay;
                     for (size_t i = 0; i < net->users.size(); i++) {
-                        float criticality = 1.0 - ((nc.slack.at(i) - worst_slack.at(startdomain.first)) / dmax);
+                        float criticality = 1.0f - (float(nc.slack.at(i) - worst_slack.at(startdomain.first)) / dmax);
                         nc.criticality.at(i) = std::max(nc.criticality.at(i), criticality);
                     }
                     nc.max_path_length = std::max(nc.max_path_length, nd.max_path_length);

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -96,8 +96,8 @@ struct Timing
     delay_t min_slack;
     CriticalPathMap *crit_path;
     DelayFrequency *slack_histogram;
-    IdString async_clock;
     NetCriticalityMap *net_crit;
+    IdString async_clock;
 
     struct TimingData
     {
@@ -472,8 +472,6 @@ struct Timing
                         continue;
                     if (startdomain.first.clock == async_clock)
                         continue;
-                    const delay_t net_length_plus_one = nd.max_path_length + 1;
-                    auto &net_min_remaining_budget = nd.min_remaining_budget;
                     if (nd.min_required.empty())
                         nd.min_required.resize(net->users.size(), std::numeric_limits<delay_t>::max());
                     delay_t net_min_required = std::numeric_limits<delay_t>::max();
@@ -584,7 +582,7 @@ struct Timing
                             worst_slack.at(startdomain.first) = std::min(worst_slack.at(startdomain.first), slack);
                         else
                             worst_slack[startdomain.first] = slack;
-                        nc.slack.at(i) = std::min(nc.slack.at(i), slack);
+                        nc.slack.at(i) = slack;
                     }
                     if (ctx->debug)
                         log_break();
@@ -610,10 +608,10 @@ struct Timing
                     delay_t dmax = crit_path->at(ClockPair{startdomain.first, startdomain.first}).path_delay;
                     for (size_t i = 0; i < net->users.size(); i++) {
                         float criticality = 1.0f - (float(nc.slack.at(i) - worst_slack.at(startdomain.first)) / dmax);
-                        nc.criticality.at(i) = std::max(nc.criticality.at(i), criticality);
+                        nc.criticality.at(i) = criticality;
                     }
-                    nc.max_path_length = std::max(nc.max_path_length, nd.max_path_length);
-                    nc.cd_worst_slack = std::min(nc.cd_worst_slack, worst_slack.at(startdomain.first));
+                    nc.max_path_length = nd.max_path_length;
+                    nc.cd_worst_slack = worst_slack.at(startdomain.first);
                 }
             }
 #if 0

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -85,14 +85,7 @@ struct CriticalPath
     delay_t path_period;
 };
 
-// Data for the timing optimisation algorithm
-struct NetCriticalityInfo
-{
-    // One each per user
-    std::vector<delay_t> slack;
-    std::vector<float> criticality;
-    unsigned max_path_length = 0;
-};
+
 
 typedef std::unordered_map<ClockPair, CriticalPath> CriticalPathMap;
 typedef std::unordered_map<IdString, NetCriticalityInfo> NetCriticalityMap;
@@ -599,6 +592,7 @@ struct Timing
                         nc.criticality.at(i) = std::max(nc.criticality.at(i), criticality);
                     }
                     nc.max_path_length = std::max(nc.max_path_length, nd.max_path_length);
+                    nc.cd_worst_slack = std::min(nc.cd_worst_slack, worst_slack.at(startdomain.first));
                 }
             }
         }
@@ -912,6 +906,13 @@ void timing_analysis(Context *ctx, bool print_histogram, bool print_fmax, bool p
                      std::string(bins[i] * bar_width / max_freq, '*').c_str(),
                      (bins[i] * bar_width) % max_freq > 0 ? '+' : ' ');
     }
+}
+
+void get_criticalities(Context *ctx, NetCriticalityMap *net_crit) {
+    CriticalPathMap crit_paths;
+    net_crit->clear();
+    Timing timing(ctx, true, true, &crit_paths, nullptr, net_crit);
+    timing.walk_paths();
 }
 
 NEXTPNR_NAMESPACE_END

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -599,6 +599,22 @@ struct Timing
                     nc.cd_worst_slack = std::min(nc.cd_worst_slack, worst_slack.at(startdomain.first));
                 }
             }
+
+            if (ctx->debug) {
+                for (auto &nc : *net_crit) {
+                    NetInfo *net = ctx->nets.at(nc.first).get();
+                    log_info("Net %s maxlen %d worst_slack %.02fns: \n", nc.first.c_str(ctx), nc.second.max_path_length,
+                             ctx->getDelayNS(nc.second.cd_worst_slack));
+                    if (!nc.second.criticality.empty() && !nc.second.slack.empty()) {
+                        for (size_t i = 0; i < net->users.size(); i++) {
+                            log_info("   user %s.%s slack %.02fns crit %.03f\n", net->users.at(i).cell->name.c_str(ctx),
+                                     net->users.at(i).port.c_str(ctx), ctx->getDelayNS(nc.second.slack.at(i)),
+                                     nc.second.criticality.at(i));
+                        }
+                    }
+                    log_break();
+                }
+            }
         }
         return min_slack;
     }

--- a/common/timing.h
+++ b/common/timing.h
@@ -32,6 +32,19 @@ void assign_budget(Context *ctx, bool quiet = false);
 void timing_analysis(Context *ctx, bool slack_histogram = true, bool print_fmax = true, bool print_path = false,
                      bool warn_on_failure = false);
 
+// Data for the timing optimisation algorithm
+struct NetCriticalityInfo
+{
+    // One each per user
+    std::vector<delay_t> slack;
+    std::vector<float> criticality;
+    unsigned max_path_length = 0;
+    delay_t cd_worst_slack = std::numeric_limits<delay_t>::max();
+};
+
+typedef std::unordered_map<IdString, NetCriticalityInfo> NetCriticalityMap;
+void get_criticalities(Context *ctx, NetCriticalityMap *net_crit);
+
 NEXTPNR_NAMESPACE_END
 
 #endif

--- a/common/timing_opt.cc
+++ b/common/timing_opt.cc
@@ -1,0 +1,42 @@
+/*
+ *  nextpnr -- Next Generation Place and Route
+ *
+ *  Copyright (C) 2018  David Shah <david@symbioticeda.com>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+/*
+ * Timing-optimised detailed placement algorithm
+ * Based on "An Effective Timing-Driven Detailed Placement Algorithm for FPGAs"
+ * https://www.cerc.utexas.edu/utda/publications/C205.pdf
+ */
+
+#include "timing_opt.h"
+#include "nextpnr.h"
+NEXTPNR_NAMESPACE_BEGIN
+
+class TimingOptimiser
+{
+  public:
+    TimingOptimiser(Context *ctx) : ctx(ctx){};
+    bool optimise() {}
+
+  private:
+    Context *ctx;
+};
+
+bool timing_opt(Context *ctx, TimingOptCfg cfg) { return TimingOptimiser(ctx).optimise(); }
+
+NEXTPNR_NAMESPACE_END

--- a/common/timing_opt.cc
+++ b/common/timing_opt.cc
@@ -466,7 +466,7 @@ class TimingOptimiser
         }
 
         IdString last_cell;
-        const int d = 5; // FIXME: how to best determine d
+        const int d = 2; // FIXME: how to best determine d
         for (auto cell : path_cells) {
             // FIXME: when should we allow swapping due to a lack of candidates
             find_neighbours(ctx->cells[cell].get(), last_cell, d, false);

--- a/common/timing_opt.cc
+++ b/common/timing_opt.cc
@@ -34,6 +34,83 @@ class TimingOptimiser
     bool optimise() {}
 
   private:
+    // Ratio of available to already-candidates to begin borrowing
+    const float borrow_thresh = 0.2;
+
+    bool check_cell_delay_limits(CellInfo *cell) {
+        
+    }
+
+    bool acceptable_bel_candidate(CellInfo *cell, BelId newBel) {
+        bool result = true;
+        // At the moment we have to actually do the swap to get an accurate legality result
+        // Switching to macro swaps might help with this
+        BelId oldBel = cell->bel;
+        CellInfo *other_cell = ctx->getBoundBelCell(newBel);
+        if (other_cell != nullptr && other_cell->belStrength > STRENGTH_WEAK) {
+            return false;
+        }
+
+        ctx->bindBel(newBel, cell, STRENGTH_WEAK);
+        if (other_cell != nullptr) {
+            ctx->bindBel(oldBel, other_cell, STRENGTH_WEAK);
+        }
+        if (!ctx->isBelLocationValid(newBel) || ((other_cell != nullptr && !ctx->isBelLocationValid(oldBel)))) {
+            result = false;
+            goto unbind;
+        }
+
+
+
+unbind:
+        ctx->unbindBel(newBel);
+        if (other_cell != nullptr)
+            ctx->unbindBel(oldBel);
+        // Undo the swap
+        ctx->bindBel(oldBel, cell, STRENGTH_WEAK);
+        if (other_cell != nullptr) {
+            ctx->bindBel(newBel, other_cell, STRENGTH_WEAK);
+        }
+        return result;
+    }
+
+    void find_neighbours(CellInfo *cell, int d) {
+        BelId curr = cell->bel;
+        Loc curr_loc = ctx->getBelLocation(curr);
+        for (int dy = -d; dy <= d; dy++) {
+            for (int dx = -d; dx <= d; dx++) {
+                if (dx == 0 && dy == 0)
+                    continue;
+                // Go through all the Bels at this location
+                // First, find all bels of the correct type that are either unbound or bound normally
+                // Strongly bound bels are ignored
+                // FIXME: This means that we cannot touch carry chains or similar relatively constrained macros
+                std::vector<BelId> free_bels_at_loc;
+                std::vector<BelId> bound_bels_at_loc;
+                for (auto bel : ctx->getBelsByTile(curr_loc.x + dx, curr_loc.y + dy)) {
+                    if (ctx->getBelType(bel) != cell->type)
+                        continue;
+                    CellInfo *bound = ctx->getBoundBelCell(bel);
+                    if (bound == nullptr) {
+                        free_bels_at_loc.push_back(bel);
+                    } else if (bound->belStrength <= STRENGTH_WEAK) {
+                        bound_bels_at_loc.push_back(bel);
+                    }
+                }
+                bool found = false;
+
+                if (found)
+                    continue;
+            }
+        }
+    }
+
+    // Current candidate Bels for cells (linked in both direction>
+    std::vector<IdString> path_cells;
+    std::unordered_map<IdString, std::unordered_set<BelId>> cell_neighbour_bels;
+    std::unordered_map<BelId, std::unordered_set<IdString>> bel_candidate_cells;
+    // Map net users to net delay limit
+    std::unordered_map<IdString, std::vector<delay_t>> max_net_delay;
     Context *ctx;
 };
 

--- a/common/timing_opt.h
+++ b/common/timing_opt.h
@@ -18,6 +18,7 @@
  */
 
 #include "nextpnr.h"
+#include "settings.h"
 
 NEXTPNR_NAMESPACE_BEGIN
 
@@ -26,7 +27,7 @@ struct TimingOptCfg : public Settings
     // The timing optimiser will *only* optimise cells of these types
     // Normally these would only be logic cells (or tiles if applicable), the algorithm makes little sense
     // for other cell types
-    std::unordered_set<IdString> cellTypes;
+    std::unordered_set<IdString> cellTypes;
 };
 
 extern bool timing_opt(Context *ctx, TimingOptCfg cfg);

--- a/common/timing_opt.h
+++ b/common/timing_opt.h
@@ -23,6 +23,10 @@ NEXTPNR_NAMESPACE_BEGIN
 
 struct TimingOptCfg : public Settings
 {
+    // The timing optimiser will *only* optimise cells of these types
+    // Normally these would only be logic cells (or tiles if applicable), the algorithm makes little sense
+    // for other cell types
+    std::unordered_set<IdString> cellTypes;
 };
 
 extern bool timing_opt(Context *ctx, TimingOptCfg cfg);

--- a/common/timing_opt.h
+++ b/common/timing_opt.h
@@ -1,0 +1,30 @@
+/*
+ *  nextpnr -- Next Generation Place and Route
+ *
+ *  Copyright (C) 2018  David Shah <david@symbioticeda.com>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "nextpnr.h"
+
+NEXTPNR_NAMESPACE_BEGIN
+
+struct TimingOptCfg : public Settings
+{
+};
+
+extern bool timing_opt(Context *ctx, TimingOptCfg cfg);
+
+NEXTPNR_NAMESPACE_END

--- a/common/timing_opt.h
+++ b/common/timing_opt.h
@@ -24,6 +24,8 @@ NEXTPNR_NAMESPACE_BEGIN
 
 struct TimingOptCfg : public Settings
 {
+    TimingOptCfg(Context *ctx) : Settings(ctx) {}
+
     // The timing optimiser will *only* optimise cells of these types
     // Normally these would only be logic cells (or tiles if applicable), the algorithm makes little sense
     // for other cell types

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -631,14 +631,13 @@ bool Arch::place()
 {
     if (!placer1(getCtx(), Placer1Cfg(getCtx())))
         return false;
-    if(bool_or_default(settings, id("opt_timing"), false)) {
+    if (bool_or_default(settings, id("opt_timing"), false)) {
         TimingOptCfg tocfg(getCtx());
         tocfg.cellTypes.insert(id_ICESTORM_LC);
         return timing_opt(getCtx(), tocfg);
     } else {
         return true;
     }
-
 }
 
 bool Arch::route() { return router1(getCtx(), Router1Cfg(getCtx())); }

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -26,8 +26,8 @@
 #include "nextpnr.h"
 #include "placer1.h"
 #include "router1.h"
-#include "util.h"
 #include "timing_opt.h"
+#include "util.h"
 
 NEXTPNR_NAMESPACE_BEGIN
 
@@ -627,8 +627,9 @@ bool Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay
 
 // -----------------------------------------------------------------------
 
-bool Arch::place() {
-    if(!placer1(getCtx(), Placer1Cfg(getCtx())))
+bool Arch::place()
+{
+    if (!placer1(getCtx(), Placer1Cfg(getCtx())))
         return false;
     TimingOptCfg tocfg(getCtx());
     tocfg.cellTypes.insert(id_ICESTORM_LC);

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -27,6 +27,7 @@
 #include "placer1.h"
 #include "router1.h"
 #include "util.h"
+#include "timing_opt.h"
 
 NEXTPNR_NAMESPACE_BEGIN
 
@@ -626,7 +627,13 @@ bool Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay
 
 // -----------------------------------------------------------------------
 
-bool Arch::place() { return placer1(getCtx(), Placer1Cfg(getCtx())); }
+bool Arch::place() {
+    if(!placer1(getCtx(), Placer1Cfg(getCtx())))
+        return false;
+    TimingOptCfg tocfg(getCtx());
+    tocfg.cellTypes.insert(id_ICESTORM_LC);
+    return timing_opt(getCtx(), tocfg);
+}
 
 bool Arch::route() { return router1(getCtx(), Router1Cfg(getCtx())); }
 

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -631,9 +631,14 @@ bool Arch::place()
 {
     if (!placer1(getCtx(), Placer1Cfg(getCtx())))
         return false;
-    TimingOptCfg tocfg(getCtx());
-    tocfg.cellTypes.insert(id_ICESTORM_LC);
-    return timing_opt(getCtx(), tocfg);
+    if(bool_or_default(settings, id("opt_timing"), false)) {
+        TimingOptCfg tocfg(getCtx());
+        tocfg.cellTypes.insert(id_ICESTORM_LC);
+        return timing_opt(getCtx(), tocfg);
+    } else {
+        return true;
+    }
+
 }
 
 bool Arch::route() { return router1(getCtx(), Router1Cfg(getCtx())); }

--- a/ice40/main.cc
+++ b/ice40/main.cc
@@ -68,6 +68,7 @@ po::options_description Ice40CommandHandler::getArchOptions()
     specific.add_options()("promote-logic",
                            "enable promotion of 'logic' globals (in addition to clk/ce/sr by default)");
     specific.add_options()("no-promote-globals", "disable all global promotion");
+    specific.add_options()("opt-timing", "run post-placement timing optimisation pass (experimental)");
     specific.add_options()("tmfuzz", "run path delay estimate fuzzer");
     return specific;
 }
@@ -161,6 +162,8 @@ std::unique_ptr<Context> Ice40CommandHandler::createContext()
         ctx->settings[ctx->id("promote_logic")] = "1";
     if (vm.count("no-promote-globals"))
         ctx->settings[ctx->id("no_promote_globals")] = "1";
+    if (vm.count("opt-timing"))
+        ctx->settings[ctx->id("opt_timing")] = "1";
     return ctx;
 }
 

--- a/ice40/picorv32_benchmark.py
+++ b/ice40/picorv32_benchmark.py
@@ -22,7 +22,7 @@ for i in range(num_runs):
         ascfile = "picorv32_work/picorv32_s{}.asc".format(run)
         if path.exists(ascfile):
             os.remove(ascfile)
-        result = subprocess.run(["../nextpnr-ice40", "--hx8k", "--seed", str(run), "--json", "picorv32.json", "--asc", ascfile, "--freq", "70"], stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+        result = subprocess.run(["../nextpnr-ice40", "--hx8k", "--seed", str(run), "--json", "picorv32.json", "--asc", ascfile, "--freq", "40", "--opt-timing"], stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
         if result.returncode != 0:
             print("Run {} failed!".format(run))
         else:


### PR DESCRIPTION
This adds `criticality` calculation (ie how close an arc is from becoming the critical path, in [0, 1]) to the timing analysis; and a highly experimental pass for optimising the critical path based on https://www.cerc.utexas.edu/utda/publications/C205.pdf