### PR TITLE
ice40: Carry chain optimisations

### DIFF
--- a/ice40/chains.cc
+++ b/ice40/chains.cc
@@ -163,29 +163,31 @@ class ChainConstrainer
 
     void process_carries()
     {
-        std::vector<CellChain> carry_chains =
-                find_chains(ctx, [](const Context *ctx, const CellInfo *cell) { return is_lc(ctx, cell); },
-                            [](const Context *ctx, const
+        std::vector<CellChain> carry_chains = find_chains(
+                ctx, [](const Context *ctx, const CellInfo *cell) { return is_lc(ctx, cell); },
+                [](const Context *ctx, const
 
-                               CellInfo *cell) {
-                                CellInfo *carry_prev =
-                                        net_driven_by(ctx, cell->ports.at(ctx->id("CIN")).net, is_lc, ctx->id("COUT"));
-                                if (carry_prev != nullptr)
-                                    return carry_prev;
-                                /*CellInfo *i3_prev = net_driven_by(ctx, cell->ports.at(ctx->id("I3")).net, is_lc,
-                                ctx->id("COUT")); if (i3_prev != nullptr) return i3_prev;*/
-                                return (CellInfo *)nullptr;
-                            },
-                            [](const Context *ctx, const CellInfo *cell) {
-                                CellInfo *carry_next = net_only_drives(ctx, cell->ports.at(ctx->id("COUT")).net, is_lc,
-                                                                       ctx->id("CIN"), false);
-                                if (carry_next != nullptr)
-                                    return carry_next;
-                                /*CellInfo *i3_next =
-                                        net_only_drives(ctx, cell->ports.at(ctx->id("COUT")).net, is_lc, ctx->id("I3"),
-                                false); if (i3_next != nullptr) return i3_next;*/
-                                return (CellInfo *)nullptr;
-                            });
+                   CellInfo *cell) {
+                    CellInfo *carry_prev =
+                            net_driven_by(ctx, cell->ports.at(ctx->id("CIN")).net, is_lc, ctx->id("COUT"));
+                    if (carry_prev != nullptr)
+                        return carry_prev;
+                    CellInfo *i3_prev = net_driven_by(ctx, cell->ports.at(ctx->id("I3")).net, is_lc, ctx->id("COUT"));
+                    if (i3_prev != nullptr)
+                        return i3_prev;
+                    return (CellInfo *)nullptr;
+                },
+                [](const Context *ctx, const CellInfo *cell) {
+                    CellInfo *carry_next =
+                            net_only_drives(ctx, cell->ports.at(ctx->id("COUT")).net, is_lc, ctx->id("CIN"), false);
+                    if (carry_next != nullptr)
+                        return carry_next;
+                    CellInfo *i3_next =
+                            net_only_drives(ctx, cell->ports.at(ctx->id("COUT")).net, is_lc, ctx->id("I3"), false);
+                    if (i3_next != nullptr)
+                        return i3_next;
+                    return (CellInfo *)nullptr;
+                });
         std::unordered_set<IdString> chained;
         for (auto &base_chain : carry_chains) {
             for (auto c : base_chain.cells)

--- a/ice40/chains.cc
+++ b/ice40/chains.cc
@@ -134,11 +134,13 @@ class ChainConstrainer
 
             // Find the user corresponding to the next CIN
             int replaced_ports = 0;
-            log_info("cell: %s\n", cin_cell->name.c_str(ctx));
+            if (ctx->debug)
+                log_info("cell: %s\n", cin_cell->name.c_str(ctx));
             for (auto port : {id_CIN, id_I3}) {
                 auto &usr = lc->ports.at(id_O).net->users;
-                for (auto user : usr)
-                    log_info("%s.%s\n", user.cell->name.c_str(ctx), user.port.c_str(ctx));
+                if (ctx->debug)
+                    for (auto user : usr)
+                        log_info("%s.%s\n", user.cell->name.c_str(ctx), user.port.c_str(ctx));
                 auto fnd_user = std::find_if(usr.begin(), usr.end(),
                                              [&](const PortRef &pr) { return pr.cell == cin_cell && pr.port == port; });
                 if (fnd_user != usr.end()) {

--- a/ice40/chains.cc
+++ b/ice40/chains.cc
@@ -62,7 +62,7 @@ class ChainConstrainer
             bool split_chain = (!ctx->logicCellsCompatible(tile.data(), tile.size())) ||
                                (int(chains.back().cells.size()) > max_length);
             if (split_chain) {
-                CellInfo *passout = make_carry_pass_out(cell->ports.at(ctx->id("COUT")));
+                CellInfo *passout = make_carry_pass_out((*(curr_cell - 1))->ports.at(ctx->id("COUT")));
                 tile.pop_back();
                 chains.back().cells.back() = passout;
                 start_of_chain = true;


### PR DESCRIPTION
 - @smunaut 's suggestion to include 'I3-only' connectivity during chain finding
 - Pass carry up the chain when inserting a feed-through LC to avoid the need to split the chain