### PR TITLE
ci: implement using CirrusCI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,8 +1,11 @@
 task:
-  name: build-ubuntu1604
+  name: build-test-ubuntu1604
   container:
     cpu: 4
     memory: 12
     dockerfile: .cirrus/Dockerfile.ubuntu16.04
 
-  build_script: mkdir build && cd build && cmake .. -DARCH=all -DTRELLIS_ROOT=/usr/local/src/prjtrellis && make -j $(nproc)
+  build_script: mkdir build && cd build && cmake .. -DARCH=all -DTRELLIS_ROOT=/usr/local/src/prjtrellis -DBUILD_TESTS=on && make -j $(nproc)
+  test_generic_script: ./nextpnr-generic-test
+  test_ice40_script: ./nextpnr-ice40-test
+  test_ecp5_script: ./nextpnr-ecp5-test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ task:
   name: build-ubuntu1604
   container:
     cpu: 4
-    memory: 8
+    memory: 12
     dockerfile: .cirrus/Dockerfile.ubuntu16.04
 
   build_script: mkdir build && cd build && cmake .. -DARCH=all -DTRELLIS_ROOT=/usr/local/src/prjtrellis && make -j $(nproc)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,8 @@
+task:
+  name: build-ubuntu1604
+  container:
+    cpu: 4
+    memory: 8
+    dockerfile: .cirrus/Dockerfile.ubuntu16.04
+
+  build_script: mkdir build && cd build && cmake .. -DARCH=all -DTRELLIS_ROOT=/usr/local/src/prjtrellis && make -j $(nproc)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,10 +2,10 @@ task:
   name: build-test-ubuntu1604
   container:
     cpu: 4
-    memory: 12
+    memory: 16
     dockerfile: .cirrus/Dockerfile.ubuntu16.04
 
   build_script: mkdir build && cd build && cmake .. -DARCH=all -DTRELLIS_ROOT=/usr/local/src/prjtrellis -DBUILD_TESTS=on && make -j $(nproc)
-  test_generic_script: ./nextpnr-generic-test
-  test_ice40_script: ./nextpnr-ice40-test
-  test_ecp5_script: ./nextpnr-ecp5-test
+  test_generic_script: cd build && ./nextpnr-generic-test
+  test_ice40_script: cd build && ./nextpnr-ice40-test
+  test_ecp5_script: cd build && ./nextpnr-ecp5-test

--- a/.cirrus/Dockerfile.ubuntu16.04
+++ b/.cirrus/Dockerfile.ubuntu16.04
@@ -1,0 +1,33 @@
+FROM ubuntu:xenial-20181113
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN set -e -x ;\
+    apt-get -y update ;\
+    apt-get -y upgrade ;\
+    apt-get -y install \
+        build-essential cmake clang python3-dev libboost-all-dev qt5-default git
+
+RUN set -e -x ;\
+    apt-get -y install \
+        libftdi-dev pkg-config
+
+RUN set -e -x ;\
+    mkdir -p /usr/local/src ;\
+    cd /usr/local/src ;\
+    git clone --recursive https://github.com/cliffordwolf/icestorm.git ;\
+    cd icestorm ;\
+    git reset --hard 9671b760f84ca4006f0ef101a3e3b201df4eabb5 ;\
+    make -j $(nproc) ;\
+    make install
+
+RUN set -e -x ;\
+    mkdir -p /usr/local/src ;\
+    cd /usr/local/src ;\
+    git clone --recursive https://github.com/SymbiFlow/prjtrellis.git ;\
+    cd prjtrellis ;\
+    git reset --hard de035a6e5e5818804a66b9408f0ad381b10957db ;\
+    cd libtrellis ;\
+    cmake -DCMAKE_INSTALL_PREFIX=/usr . ;\
+    make -j $(nproc) ;\
+    make install


### PR DESCRIPTION
This is a replacement for #67 . It currently builds nextpnr for all architectures and runs their respective test binaries.