### PR TITLE
ice40: Add PCF support for -pullup, -pullup_resistor and -nowarn

### DIFF
--- a/ice40/bitstream.cc
+++ b/ice40/bitstream.cc
@@ -527,10 +527,23 @@ void write_asc(const Context *ctx, std::ostream &out)
                 }
 
                 if (ctx->args.type == ArchArgs::UP5K) {
+                    std::string pullup_resistor = "100K";
+                    if (cell.second->attrs.count(ctx->id("PULLUP_RESISTOR")))
+                        pullup_resistor = cell.second->attrs.at(ctx->id("PULLUP_RESISTOR"));
+                    NPNR_ASSERT(pullup_resistor == "100K" || pullup_resistor == "10K" || pullup_resistor == "6P8K" ||
+                                pullup_resistor == "3P3K");
                     if (iez == 0) {
-                        set_config(ti, config.at(iey).at(iex), "IoCtrl.cf_bit_39", !pullup);
+                        set_config(ti, config.at(iey).at(iex), "IoCtrl.cf_bit_39",
+                                   (!pullup) || (pullup_resistor != "100K"));
+                        set_config(ti, config.at(iey).at(iex), "IoCtrl.cf_bit_36", pullup && pullup_resistor == "3P3K");
+                        set_config(ti, config.at(iey).at(iex), "IoCtrl.cf_bit_37", pullup && pullup_resistor == "6P8K");
+                        set_config(ti, config.at(iey).at(iex), "IoCtrl.cf_bit_38", pullup && pullup_resistor == "10K");
                     } else if (iez == 1) {
-                        set_config(ti, config.at(iey).at(iex), "IoCtrl.cf_bit_35", !pullup);
+                        set_config(ti, config.at(iey).at(iex), "IoCtrl.cf_bit_35",
+                                   (!pullup) || (pullup_resistor != "100K"));
+                        set_config(ti, config.at(iey).at(iex), "IoCtrl.cf_bit_32", pullup && pullup_resistor == "3P3K");
+                        set_config(ti, config.at(iey).at(iex), "IoCtrl.cf_bit_33", pullup && pullup_resistor == "6P8K");
+                        set_config(ti, config.at(iey).at(iex), "IoCtrl.cf_bit_34", pullup && pullup_resistor == "10K");
                     }
                 }
             } else {

--- a/ice40/pcf.cc
+++ b/ice40/pcf.cc
@@ -47,17 +47,43 @@ bool apply_pcf(Context *ctx, std::string filename, std::istream &in)
             if (words.size() == 0)
                 continue;
             std::string cmd = words.at(0);
+            bool nowarn = false;
             if (cmd == "set_io") {
                 size_t args_end = 1;
-                while (args_end < words.size() && words.at(args_end).at(0) == '-')
+                std::vector<std::pair<IdString, std::string>> extra_attrs;
+                while (args_end < words.size() && words.at(args_end).at(0) == '-') {
+                    const auto &setting = words.at(args_end);
+                    if (setting == "-pullup") {
+                        const auto &value = words.at(++args_end);
+                        if (value == "yes" || value == "1")
+                            extra_attrs.emplace_back(std::make_pair(ctx->id("PULLUP"), "1"));
+                        else if (value == "no" || value == "0")
+                            extra_attrs.emplace_back(std::make_pair(ctx->id("PULLUP"), "0"));
+                        else
+                            log_error("Invalid value '%s' for -pullup (on line %d)\n", value.c_str(), lineno);
+                    } else if (setting == "-pullup_resistor") {
+                        const auto &value = words.at(++args_end);
+                        if (ctx->args.type != ArchArgs::UP5K)
+                            log_error("Pullup resistance can only be set on UP5K (on line %d)\n", lineno);
+                        if (value != "3P3K" && value != "6P8K" && value != "10K" && value != "100K")
+                            log_error("Invalid value '%s' for -pullup_resistor (on line %d)\n", value.c_str(), lineno);
+                        extra_attrs.emplace_back(std::make_pair(ctx->id("PULLUP_RESISTOR"), value));
+                    } else if (setting == "-nowarn") {
+                        nowarn = true;
+                    } else if (setting == "--warn-no-port") {
+                    } else {
+                        log_warning("Ignoring PCF setting '%s' (on line %d)\n", setting.c_str(), lineno);
+                    }
                     args_end++;
+                }
                 if (args_end >= words.size() - 1)
                     log_error("expected PCF syntax 'set_io cell pin' (on line %d)\n", lineno);
                 std::string cell = words.at(args_end);
                 std::string pin = words.at(args_end + 1);
                 auto fnd_cell = ctx->cells.find(ctx->id(cell));
                 if (fnd_cell == ctx->cells.end()) {
-                    log_warning("unmatched constraint '%s' (on line %d)\n", cell.c_str(), lineno);
+                    if (!nowarn)
+                        log_warning("unmatched constraint '%s' (on line %d)\n", cell.c_str(), lineno);
                 } else {
                     BelId pin_bel = ctx->getPackagePinBel(pin);
                     if (pin_bel == BelId())
@@ -67,6 +93,8 @@ bool apply_pcf(Context *ctx, std::string filename, std::istream &in)
                     fnd_cell->second->attrs[ctx->id("BEL")] = ctx->getBelName(pin_bel).str(ctx);
                     log_info("constrained '%s' to bel '%s'\n", cell.c_str(),
                              fnd_cell->second->attrs[ctx->id("BEL")].c_str());
+                    for (const auto &attr : extra_attrs)
+                        fnd_cell->second->attrs[attr.first] = attr.second;
                 }
             } else {
                 log_error("unsupported PCF command '%s' (on line %d)\n", cmd.c_str(), lineno);


### PR DESCRIPTION
Fixes #188; also adds support (including in bitstream gen) for up5k configurable pullup strength, support for PCF `-nowarn` to suppress the warning for unmatched constraints, and a warning for unknown PCF settings.