### PR TITLE
ice40: Add timing data for all IO modes

### DIFF
--- a/ice40/archdefs.h
+++ b/ice40/archdefs.h
@@ -151,6 +151,8 @@ struct ArchCellInfo
         {
             bool lvds;
             bool global;
+            bool negtrig;
+            int pintype;
             // TODO: clk packing checks...
         } ioInfo;
         struct


### PR DESCRIPTION
In particular, DDR inputs and outputs are now correctly considered register inputs/outputs with the appropriate clock domain and edge for timing analysis purposes.

Sample timing report on CSI-2 Rx:

```
Info: Critical path report for clock 'csi_rx_i.dphy_clk' (negedge -> posedge):
Info: curr total
Info:  1.0  1.0  Source $techmap\csi_rx_i.$genblock$../../link/csi_rx_ice40.v:110$333[1].\data_iobuf.D_IN_1
Info:  3.8  4.8    Net raw_ddr[3] budget 40.561001 ns (9,31) -> (5,26)
Info:                Sink $auto$simplemap.cc:496:simplemap_adff$3550_DFFLC.I0
Info:  0.1  4.9  Setup $auto$simplemap.cc:496:simplemap_adff$3550_DFFLC.I0
Info: 1.1 ns logic, 3.8 ns routing
```

The Fmax for this path is also correctly given as 102MHz (halved because it is between different clock edges).