### PR TITLE
Search for trellis in /usr/local/share/trellis if not specified with …

### DIFF
--- a/ecp5/family.cmake
+++ b/ecp5/family.cmake
@@ -2,11 +2,11 @@
 set(devices 25k 45k 85k)
 
 if (NOT DEFINED TRELLIS_ROOT)
-    message(FATAL_ERROR "you must define TRELLIS_ROOT using -DTRELLIS_ROOT=/path/to/prjtrellis for ECP5 support")
+    message(STATUS "TRELLIS_ROOT not defined using -DTRELLIS_ROOT=/path/to/prjtrellis. Default to /usr/local/share/trellis")
+    set(TRELLIS_ROOT "/usr/local/share/trellis")
 endif()
 
-
-file( GLOB found_pytrellis ${TRELLIS_ROOT}/libtrellis/pytrellis.*)
+file(GLOB found_pytrellis ${TRELLIS_ROOT}/libtrellis/pytrellis.*)
 
 if ("${found_pytrellis}" STREQUAL "")
     message(FATAL_ERROR "failed to find pytrellis library in ${TRELLIS_ROOT}/libtrellis/")


### PR DESCRIPTION
…-DTRELLIS_ROOT

With my pull-request for prjtrellis (https://github.com/SymbiFlow/prjtrellis/pull/58) it will put all required stuff for building nextpnr in the share folder.

This pull-request aims to have a similar behaviour like for icestorm, where nextpnr always looks in /usr/local/share/icebox: 
`set(ICEBOX_ROOT "/usr/local/share/icebox" CACHE STRING "icebox location root")`

The `message(STATUS ...)` could be removed as well. This was only intended to note for the change.
