### PR TITLE
[timing] Path related fixes

### DIFF
--- a/common/timing.cc
+++ b/common/timing.cc
@@ -267,8 +267,7 @@ struct Timing
                     auto net_delay = net_delays ? ctx->getNetinfoRouteDelay(net, usr) : delay_t();
                     auto usr_arrival = net_arrival + net_delay;
 
-                    if (portClass == TMG_REGISTER_INPUT || portClass == TMG_ENDPOINT || portClass == TMG_IGNORE ||
-                        portClass == TMG_CLOCK_INPUT) {
+                    if (portClass == TMG_ENDPOINT || portClass == TMG_IGNORE || portClass == TMG_CLOCK_INPUT) {
                         // Skip
                     } else {
                         auto budget_override = ctx->getBudgetOverride(net, usr, net_delay);

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -841,8 +841,11 @@ struct Arch : BaseCtx
     // -------------------------------------------------
 
     // Get the delay through a cell from one port to another, returning false
-    // if no path exists
+    // if no path exists. This only considers combinational delays, as required by the Arch API
     bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const;
+    // getCellDelayInternal is similar to the above, but without false path checks and including clock to out delays
+    // for internal arch use only
+    bool getCellDelayInternal(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const;
     // Get the port class, also setting clockInfoCount to the number of TimingClockingInfos associated with a port
     TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const;
     // Get the TimingClockingInfo of a port


### PR DESCRIPTION
 - Consider combinational fanout from ports that are also register inputs (e.g. iCE40 carry chains/LUTCascade mixed with registers)
 - Remove false paths through logic cells with register enabled, that the above would otherwise reveal
 - Fix timing classification of PLLOUTGLOBAL