### PR TITLE
[WIP] Allow timing graph to be visualised by outputting as DOT file

### DIFF
--- a/common/timing.cc
+++ b/common/timing.cc
@@ -642,7 +642,14 @@ struct Timing
             log_info("Writing timing.dot\n");
             std::ofstream f("timing.dot");
             f << "digraph T {" << std::endl;
-            f << "\tlabel=\"clk_period=" << clk_period << "\";" << std::endl;
+            f << "\tlabel=<<font point-size=\"32\">clk_period=" << clk_period << "</font>"
+              << "<font point-size=\"24\"><i>"
+              << "<br/><b>Nodes</b>  represent ports, clustered by their cells, and annotated with max arrival times."
+              << "<br/><b>Filled nodes</b>  represent timing start points (i.e. flip-flops)."
+              << "<br/><b>Solid edges</b>  represent inter-cell delays (i.e. nets) and are annotated with net name at its center, as well as net delay/budget at its head."
+              << "<br/><b>Dotted edges</b>  represent intra-cell delays and are annotated with this value."
+              << "</i></font>>;"
+              << std::endl;
             f << "\tlabelloc=t;" << std::endl;
             // Use the new ranking algorithm in dot to allow ranking of nodes across clusters
             f << "\tnewrank=true;" << std::endl;
@@ -699,9 +706,9 @@ struct Timing
                         output_ports.push_back(port.first);
                         // Label port
                         f << "\t\t" << "\"" << cell.second->name.str(ctx) << "." << port.first.str(ctx) << "\" [label = \"" << port.first.str(ctx);
-                        for (const auto &i : net_data.at(port.second.net)) {
+                        // A:d for each clock event, label node with event as well as max arrival time
+                        for (const auto &i : net_data.at(port.second.net))
                             f << "\\n" << (i.first.edge == RISING_EDGE ? "posedge" : "negedge") << " " << i.first.clock.str(ctx) << " @ " << i.second.max_arrival;
-                        }
                         f << "\"";
                         // IOB outputs are startpoints
                         if (ctx->getBelIOB(cell.second->bel))

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -696,8 +696,11 @@ struct Timing
                             if (usr.cell != cell.second.get() || usr.port != port.first)
                                 continue;
                             // And for each clock event, label node with event as well as max arrival time
-                            for (const auto &i : net_data.at(port.second.net))
-                                f << "\\n" << (i.first.edge == RISING_EDGE ? "posedge" : "negedge") << " " << i.first.clock.str(ctx) << " @ " << i.second.max_arrival + ctx->getNetinfoRouteDelay(port.second.net, usr);
+                            auto it = net_data.find(port.second.net);
+                            if (it != net_data.end()) {
+                                for (const auto &i : it->second)
+                                    f << "\\n" << (i.first.edge == RISING_EDGE ? "posedge" : "negedge") << " " << i.first.clock.str(ctx) << " @ " << i.second.max_arrival + ctx->getNetinfoRouteDelay(port.second.net, usr);
+                            }
                             break;
                         }
                         f << "\"]" << std::endl;
@@ -706,9 +709,12 @@ struct Timing
                         output_ports.push_back(port.first);
                         // Label port
                         f << "\t\t" << "\"" << cell.second->name.str(ctx) << "." << port.first.str(ctx) << "\" [label = \"" << port.first.str(ctx);
-                        // A:d for each clock event, label node with event as well as max arrival time
-                        for (const auto &i : net_data.at(port.second.net))
-                            f << "\\n" << (i.first.edge == RISING_EDGE ? "posedge" : "negedge") << " " << i.first.clock.str(ctx) << " @ " << i.second.max_arrival;
+                        // And for each clock event, label node with event as well as max arrival time
+                        auto it = net_data.find(port.second.net);
+                        if (it != net_data.end()) {
+                            for (const auto &i : it->second)
+                                f << "\\n" << (i.first.edge == RISING_EDGE ? "posedge" : "negedge") << " " << i.first.clock.str(ctx) << " @ " << i.second.max_arrival;
+                        }
                         f << "\"";
                         // IOB outputs are startpoints
                         if (ctx->getBelIOB(cell.second->bel))

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -433,7 +433,7 @@ Run the placer.
 
 ### bool route()
 
-run the router.
+Run the router.
 
 Graphics Methods
 ----------------
@@ -481,6 +481,13 @@ Return the _clocking info_ (including port name of clock, clock polarity and set
 port. Where ports have more than one clock edge associated with them (such as DDR outputs), `index` can be used to obtain
 information for all edges. `index` must be in [0, clockInfoCount), behaviour is undefined otherwise.
 
+Net Methods
+------------------
+
+### bool isGlobalNet(const NetInfo *net) const
+
+Returns true if the given net is driven by a global buffer.
+
 Placer Methods
 --------------
 
@@ -492,5 +499,5 @@ a certain number of different clock signals allowed for a group of bels.
 
 ### bool isBelLocationValid(BelId bel) const
 
-Returns true if a bell in the current configuration is valid, i.e. if
+Returns true if a bel in the current configuration is valid, i.e. if
 `isValidBelForCell()` would return true for the current mapping.

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -115,6 +115,10 @@ Return a list of all bels at the give X/Y location.
 
 Returns true if the given bel is a global buffer. A global buffer does not "pull in" other cells it drives to be close to the location of the global buffer.
 
+### bool getBelIOB(BelId bel) const
+
+Returns true if the given bel is a IO block.
+
 ### uint32\_t getBelChecksum(BelId bel) const
 
 Return a (preferably unique) number that represents this bel. This is used in design state checksum calculations.

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -768,6 +768,13 @@ TimingClockingInfo Arch::getPortClockingInfo(const CellInfo *cell, IdString port
     return info;
 }
 
+bool Arch::isGlobalNet(const NetInfo *net) const
+{
+    if (net == nullptr)
+        return false;
+    return net->driver.cell != nullptr && net->driver.port == id_CLKO;
+}
+
 std::vector<std::pair<std::string, std::string>> Arch::getTilesAtLocation(int row, int col)
 {
     std::vector<std::pair<std::string, std::string>> ret;

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -955,7 +955,7 @@ struct Arch : BaseCtx
     TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const;
     // Get the TimingClockingInfo of a port
     TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const;
-    // Return true if a port is a net
+    // Return true if net is driven from global buffer
     bool isGlobalNet(const NetInfo *net) const;
 
     bool getDelayFromTimingDatabase(IdString tctype, IdString from, IdString to, DelayInfo &delay) const;

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -539,6 +539,7 @@ struct Arch : BaseCtx
     BelRange getBelsByTile(int x, int y) const;
 
     bool getBelGlobalBuf(BelId bel) const { return getBelType(bel) == id_DCCA; }
+    bool getBelIOB(BelId bel) const { return chip_info->bel_data[bel.index].type == ID_TRELLIS_IO; }
 
     bool checkBelAvail(BelId bel) const
     {

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -539,7 +539,7 @@ struct Arch : BaseCtx
     BelRange getBelsByTile(int x, int y) const;
 
     bool getBelGlobalBuf(BelId bel) const { return getBelType(bel) == id_DCCA; }
-    bool getBelIOB(BelId bel) const { return chip_info->bel_data[bel.index].type == ID_TRELLIS_IO; }
+    bool getBelIOB(BelId bel) const { return getBelType(bel) == ID_TRELLIS_IO; }
 
     bool checkBelAvail(BelId bel) const
     {

--- a/generic/arch.cc
+++ b/generic/arch.cc
@@ -224,6 +224,7 @@ BelId Arch::getBelByLocation(Loc loc) const
 const std::vector<BelId> &Arch::getBelsByTile(int x, int y) const { return bels_by_tile.at(x).at(y); }
 
 bool Arch::getBelGlobalBuf(BelId bel) const { return bels.at(bel).gb; }
+bool Arch::getBelIOB(BelId bel) const { return /* TODO */ false; }
 
 uint32_t Arch::getBelChecksum(BelId bel) const
 {

--- a/generic/arch.cc
+++ b/generic/arch.cc
@@ -474,6 +474,11 @@ TimingClockingInfo Arch::getPortClockingInfo(const CellInfo *cell, IdString port
     NPNR_ASSERT_FALSE("no clocking info for generic");
 }
 
+bool Arch::isGlobalNet(const NetInfo *net) const
+{
+    return false;
+}
+
 bool Arch::isValidBelForCell(CellInfo *cell, BelId bel) const { return true; }
 bool Arch::isBelLocationValid(BelId bel) const { return true; }
 

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -238,6 +238,8 @@ struct Arch : BaseCtx
     TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const;
     // Get the TimingClockingInfo of a port
     TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const;
+    // Return true if net is driven from global buffer
+    bool isGlobalNet(const NetInfo *net) const;
 
     bool isValidBelForCell(CellInfo *cell, BelId bel) const;
     bool isBelLocationValid(BelId bel) const;

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -150,6 +150,7 @@ struct Arch : BaseCtx
     BelId getBelByLocation(Loc loc) const;
     const std::vector<BelId> &getBelsByTile(int x, int y) const;
     bool getBelGlobalBuf(BelId bel) const;
+    bool getBelIOB(BelId bel) const;
     uint32_t getBelChecksum(BelId bel) const;
     void bindBel(BelId bel, CellInfo *cell, PlaceStrength strength);
     void unbindBel(BelId bel);

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -513,6 +513,7 @@ struct Arch : BaseCtx
     BelRange getBelsByTile(int x, int y) const;
 
     bool getBelGlobalBuf(BelId bel) const { return chip_info->bel_data[bel.index].type == ID_SB_GB; }
+    bool getBelIOB(BelId bel) const { return chip_info->bel_data[bel.index].type == ID_SB_IO; }
 
     IdString getBelType(BelId bel) const
     {

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -851,7 +851,7 @@ struct Arch : BaseCtx
     TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const;
     // Get the TimingClockingInfo of a port
     TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const;
-    // Return true if a port is a net
+    // Return true if net is driven from global buffer
     bool isGlobalNet(const NetInfo *net) const;
 
     // -------------------------------------------------


### PR DESCRIPTION
If `--debug`, (over)write out a "timing.dot" on each invocation of timing analysis.
Advisable to only use dot for small circuits.
[blinky example](https://github.com/YosysHQ/nextpnr/files/2800453/timing.pdf)

Needed a new Arch API: `Arch::getBelIOB(BelId)`
