### PR TITLE
ice40: Don't create PLLOUT_B buffer for single-output PLL variants

### DIFF
--- a/ice40/pack.cc
+++ b/ice40/pack.cc
@@ -1063,7 +1063,12 @@ static void pack_special(Context *ctx)
                     create_ice_cell(ctx, ctx->id("ICESTORM_PLL"), ci->name.str(ctx) + "_PLL");
             packed->attrs[ctx->id("TYPE")] = ci->type.str(ctx);
             packed_cells.insert(ci->name);
-
+            if (!is_sb_pll40_dual(ctx, ci)) {
+                // Remove second output, so a buffer isn't created for it, for these
+                // cell types with only one output
+                packed->ports.erase(ctx->id("PLLOUT_B"));
+                packed->ports.erase(ctx->id("PLLOUT_B_GLOBAL"));
+            }
             for (auto attr : ci->attrs)
                 packed->attrs[attr.first] = attr.second;
             for (auto param : ci->params)


### PR DESCRIPTION
Fixes #229 

For single-output PLL variants, we were only checking for conflicts with the first output; but still creating SB_GBs for both outputs.