### PR TITLE
ecp5: Improve constraint-related error handling

### DIFF
--- a/ecp5/lpf.cc
+++ b/ecp5/lpf.cc
@@ -41,7 +41,9 @@ bool Arch::applyLPF(std::string filename, std::istream &in)
             log_error("failed to open LPF file\n");
         std::string line;
         std::string linebuf;
+        int lineno = 0;
         while (std::getline(in, line)) {
+            ++lineno;
             size_t cstart = line.find('#');
             if (cstart != std::string::npos)
                 line = line.substr(0, cstart);
@@ -61,15 +63,18 @@ bool Arch::applyLPF(std::string filename, std::istream &in)
                 if (words.size() >= 0) {
                     std::string verb = words.at(0);
                     if (verb == "BLOCK" || verb == "SYSCONFIG") {
-                        log_warning("    ignoring unsupported LPF command '%s'\n", command.c_str());
+                        if (words.size() != 2 || (words.at(1) != "ASYNCPATHS" && words.at(1) != "RESETPATHS"))
+                            log_warning("    ignoring unsupported LPF command '%s' (on line %d)\n", command.c_str(),
+                                        lineno);
                     } else if (verb == "FREQUENCY") {
+                        if (words.size() < 2)
+                            log_error("expected object type after FREQUENCY (on line %d)\n", lineno);
                         std::string etype = words.at(1);
                         if (etype == "PORT" || etype == "NET") {
-                            std::string target = words.at(2);
-                            if (target.at(0) == '\"') {
-                                NPNR_ASSERT(target.back() == '\"');
-                                target = target.substr(1, target.length() - 2);
-                            }
+                            if (words.size() < 4)
+                                log_error("expected frequency value and unit after 'FREQUENCY %s' (on line %d)\n",
+                                          etype.c_str(), lineno);
+                            std::string target = strip_quotes(words.at(2));
                             float freq = std::stof(words.at(3));
                             std::string unit = words.at(4);
                             if (unit == "MHz")
@@ -79,33 +84,40 @@ bool Arch::applyLPF(std::string filename, std::istream &in)
                             else if (unit == "Hz")
                                 freq /= 1.0e6;
                             else
-                                log_error("unsupported frequency unit '%s'\n", unit.c_str());
+                                log_error("unsupported frequency unit '%s' (on line %d)\n", unit.c_str(), lineno);
                             addClock(id(target), freq);
                         } else {
-                            log_warning("    ignoring unsupported LPF command '%s %s'\n", command.c_str(),
-                                        etype.c_str());
+                            log_warning("    ignoring unsupported LPF command '%s %s' (on line %d)\n", command.c_str(),
+                                        etype.c_str(), lineno);
                         }
                     } else if (verb == "LOCATE") {
-                        NPNR_ASSERT(words.at(1) == "COMP");
+                        if (words.size() < 5)
+                            log_error("expected syntax 'LOCATE COMP <port name> SITE <pin>' (on line %d)\n", lineno);
+                        if (words.at(1) != "COMP")
+                            log_error("expected 'COMP' after 'LOCATE' (on line %d)\n", lineno);
                         std::string cell = strip_quotes(words.at(2));
-                        NPNR_ASSERT(words.at(3) == "SITE");
+                        if (words.at(3) != "SITE")
+                            log_error("expected 'SITE' after 'LOCATE COMP %s' (on line %d)\n", cell.c_str(), lineno);
                         auto fnd_cell = cells.find(id(cell));
-                        if (fnd_cell == cells.end()) {
-                            log_warning("unmatched LPF 'LOCATE COMP' '%s'\n", cell.c_str());
-                        } else {
+                        if (fnd_cell != cells.end()) {
                             fnd_cell->second->attrs[id("LOC")] = strip_quotes(words.at(4));
                         }
                     } else if (verb == "IOBUF") {
-                        NPNR_ASSERT(words.at(1) == "PORT");
+                        if (words.size() < 3)
+                            log_error("expected syntax 'IOBUF PORT <port name> <attr>=<value>...' (on line %d)\n",
+                                      lineno);
+                        if (words.at(1) != "PORT")
+                            log_error("expected 'PORT' after 'IOBUF' (on line %d)\n", lineno);
                         std::string cell = strip_quotes(words.at(2));
                         auto fnd_cell = cells.find(id(cell));
-                        if (fnd_cell == cells.end()) {
-                            log_warning("unmatched LPF 'IOBUF PORT' '%s'\n", cell.c_str());
-                        } else {
+                        if (fnd_cell != cells.end()) {
                             for (size_t i = 3; i < words.size(); i++) {
                                 std::string setting = words.at(i);
                                 size_t eqpos = setting.find('=');
-                                NPNR_ASSERT(eqpos != std::string::npos);
+                                if (eqpos == std::string::npos)
+                                    log_error(
+                                            "expected syntax 'IOBUF PORT <port name> <attr>=<value>...' (on line %d)\n",
+                                            lineno);
                                 std::string key = setting.substr(0, eqpos), value = setting.substr(eqpos + 1);
                                 fnd_cell->second->attrs[id(key)] = value;
                             }

--- a/ecp5/lpf.cc
+++ b/ecp5/lpf.cc
@@ -17,6 +17,7 @@
  *
  */
 
+#include <boost/algorithm/string.hpp>
 #include <sstream>
 #include "log.h"
 
@@ -25,7 +26,7 @@ NEXTPNR_NAMESPACE_BEGIN
 bool Arch::applyLPF(std::string filename, std::istream &in)
 {
     auto isempty = [](const std::string &str) {
-        return std::all_of(str.begin(), str.end(), [](char c) { return isblank(c); });
+        return std::all_of(str.begin(), str.end(), [](char c) { return isblank(c) || c == '\r' || c == '\n'; });
     };
     auto strip_quotes = [](const std::string &str) {
         if (str.at(0) == '"') {
@@ -77,11 +78,12 @@ bool Arch::applyLPF(std::string filename, std::istream &in)
                             std::string target = strip_quotes(words.at(2));
                             float freq = std::stof(words.at(3));
                             std::string unit = words.at(4);
-                            if (unit == "MHz")
+                            boost::algorithm::to_upper(unit);
+                            if (unit == "MHZ")
                                 ;
-                            else if (unit == "kHz")
+                            else if (unit == "KHZ")
                                 freq /= 1.0e3;
-                            else if (unit == "Hz")
+                            else if (unit == "HZ")
                                 freq /= 1.0e6;
                             else
                                 log_error("unsupported frequency unit '%s' (on line %d)\n", unit.c_str(), lineno);

--- a/ecp5/main.cc
+++ b/ecp5/main.cc
@@ -157,7 +157,10 @@ void ECP5CommandHandler::customAfterLoad(Context *ctx)
         std::vector<std::string> files = vm["lpf"].as<std::vector<std::string>>();
         for (const auto &filename : files) {
             std::ifstream in(filename);
-            ctx->applyLPF(filename, in);
+            if (!in)
+                log_error("failed to open LPF file '%s'\n", filename.c_str());
+            if (!ctx->applyLPF(filename, in))
+                log_error("failed to parse LPF file '%s'\n", filename.c_str());
         }
     }
 }

--- a/ecp5/main.cc
+++ b/ecp5/main.cc
@@ -25,6 +25,7 @@
 #include "design_utils.h"
 #include "log.h"
 #include "timing.h"
+#include "util.h"
 
 USING_NEXTPNR_NAMESPACE
 
@@ -68,6 +69,7 @@ po::options_description ECP5CommandHandler::getArchOptions()
     specific.add_options()("textcfg", po::value<std::string>(), "textual configuration in Trellis format to write");
 
     specific.add_options()("lpf", po::value<std::vector<std::string>>(), "LPF pin constraint file(s)");
+    specific.add_options()("lpf-allow-unconstrained", "don't require LPF file(s) to constrain all IO");
 
     return specific;
 }
@@ -161,6 +163,22 @@ void ECP5CommandHandler::customAfterLoad(Context *ctx)
                 log_error("failed to open LPF file '%s'\n", filename.c_str());
             if (!ctx->applyLPF(filename, in))
                 log_error("failed to parse LPF file '%s'\n", filename.c_str());
+        }
+
+        for (auto cell : sorted(ctx->cells)) {
+            CellInfo *ci = cell.second;
+            if (ci->type == ctx->id("$nextpnr_ibuf") || ci->type == ctx->id("$nextpnr_obuf") ||
+                ci->type == ctx->id("$nextpnr_iobuf")) {
+                if (!ci->attrs.count(ctx->id("LOC"))) {
+                    if (vm.count("lpf-allow-unconstrained"))
+                        log_warning("IO '%s' is unconstrained in LPF and will be automatically placed\n",
+                                    cell.first.c_str(ctx));
+                    else
+                        log_error("IO '%s' is unconstrained in LPF (override this error with "
+                                  "--lpf-allow-unconstrained)\n",
+                                  cell.first.c_str(ctx));
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
 - Better errors (with line numbers) and fewer assertion failures in the LPF parser
 - Remove the warning for unmatched constraints; add an error if an LPF file is specified but some IO are unconstrained, with `--lpf-allow-unconstrained` to override (this is identical to the current iCE40 situation)