### PR TITLE
README: update windows build instructions for eigen, python

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ of the selected architecture:
 - Eigen3 (`libeigen3-dev` for Ubuntu) is required to build the analytic placer
 - Latest git Yosys is required to synthesise the demo design
 - For building on Windows with MSVC, usage of vcpkg is advised for dependency installation.
-  - For 32 bit builds: `vcpkg install boost-filesystem boost-program-options boost-thread boost-python qt5-base`
-  - For 64 bit builds: `vcpkg install boost-filesystem:x64-windows boost-program-options:x64-windows boost-thread:x64-windows boost-python:x64-windows qt5-base:x64-windows`
+  - For 32 bit builds: `vcpkg install boost-filesystem boost-program-options boost-thread boost-python qt5-base eigen3`
+  - For 64 bit builds: `vcpkg install boost-filesystem:x64-windows boost-program-options:x64-windows boost-thread:x64-windows boost-python:x64-windows qt5-base:x64-windows eigen3:x64-windows`
+  - A copy of Python that matches the version in vcpkg (currently Python 3.6.4).  You can download the [Embeddable Zip File](https://www.python.org/downloads/release/python-364/) and extract it.  You may need to extract `python36.zip` within the embeddable zip file to a new directory called "Lib".
 - For building on macOS, brew utility is needed.
   - Install all needed packages `brew install cmake python boost boost-python3 qt5`
   - Do not forget to add qt5 in path as well `echo 'export PATH="/usr/local/opt/qt/bin:$PATH"' >> ~/.bash_profile`
@@ -59,6 +60,13 @@ Then build and install `nextpnr-ice40` using the following commands:
 cmake -DARCH=ice40 .
 make -j$(nproc)
 sudo make install
+```
+
+On Windows, you may specify paths explicitly:
+
+```
+cmake -DARCH=ice40 -DICEBOX_ROOT=C:/ProgramData/icestorm/share/icebox -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -G "Visual Studio 15 2017 Win64" -DPYTHON_EXECUTABLE=C:/Python364/python.exe -DPYTHON_LIBRARY=C:/vcpkg/packages/python3_x64-windows/lib/python36.lib -DPYTHON_INCLUDE_DIR=C:/vcpkg/packages/python3_x64-windows/include/python3.6
+cmake --build . --config Release
 ```
 
 A simple example that runs on the iCEstick dev board can be found in `ice40/blinky.*`.


### PR DESCRIPTION
The recent addition of "eigen3" to nextpnr necessitates the addition of
"eigen" to the list of vcpkg packages to be installed on Windows.

Add the 32- and 64-bit versions of eigen to the command issued to
install various dependencies.

Also document one possible build command, and note about unpacking
python36.zip.

Signed-off-by: Sean Cross <sean@xobs.io>