### PR TITLE
common: avoid std::ofstream copy

### DIFF
--- a/common/command.cc
+++ b/common/command.cc
@@ -87,8 +87,8 @@ bool CommandHandler::executeBeforeContext()
 
     if (vm.count("log")) {
         std::string logfilename = vm["log"].as<std::string>();
-        logfile = std::ofstream(logfilename);
-        if (!logfile)
+        logfile.open(logfilename);
+        if (!logfile.is_open())
             log_error("Failed to open log file '%s' for writing.\n", logfilename.c_str());
         log_streams.push_back(std::make_pair(&logfile, LogLevel::LOG_MSG));
     }


### PR DESCRIPTION
Using a copy constructor to set the logfile is the only thing that
stops compilation with the libstdc++ shipping with gcc 4.8 (maybe 4.7)