### PR TITLE
placer1: Improve incremental bounding box updates

### DIFF
--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -291,6 +291,24 @@ class SAPlacer
                 }
             }
 
+            if (ctx->debug) {
+                // Verify correctness of incremental wirelen updates
+                for (size_t i = 0; i < net_bounds.size(); i++) {
+                    auto net = net_by_udata[i];
+                    if (ignore_net(net))
+                        continue;
+                    auto &incr = net_bounds.at(i), gold = get_net_bounds(net);
+                    NPNR_ASSERT(incr.x0 == gold.x0);
+                    NPNR_ASSERT(incr.x1 == gold.x1);
+                    NPNR_ASSERT(incr.y0 == gold.y0);
+                    NPNR_ASSERT(incr.y1 == gold.y1);
+                    NPNR_ASSERT(incr.nx0 == gold.nx0);
+                    NPNR_ASSERT(incr.nx1 == gold.nx1);
+                    NPNR_ASSERT(incr.ny0 == gold.ny0);
+                    NPNR_ASSERT(incr.ny1 == gold.ny1);
+                }
+            }
+
             if (curr_wirelen_cost < min_wirelen) {
                 min_wirelen = curr_wirelen_cost;
                 improved = true;

--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -835,7 +835,8 @@ class SAPlacer
     struct MoveChangeData
     {
 
-        enum BoundChangeType {
+        enum BoundChangeType
+        {
             NO_CHANGE,
             CELL_MOVED_INWARDS,
             CELL_MOVED_OUTWARDS,
@@ -854,7 +855,8 @@ class SAPlacer
         wirelen_t wirelen_delta = 0;
         double timing_delta = 0;
 
-        void init(SAPlacer *p) {
+        void init(SAPlacer *p)
+        {
             already_bounds_changed_x.resize(p->ctx->nets.size());
             already_bounds_changed_y.resize(p->ctx->nets.size());
             already_changed_arcs.resize(p->ctx->nets.size());
@@ -921,7 +923,7 @@ class SAPlacer
                         mc.already_bounds_changed_x[pn->udata] = MoveChangeData::CELL_MOVED_OUTWARDS;
                         mc.bounds_changed_nets_x.push_back(pn->udata);
                     }
-                } else if (old_loc.x == curr_bounds.x0  && curr_loc.x > curr_bounds.x0) {
+                } else if (old_loc.x == curr_bounds.x0 && curr_loc.x > curr_bounds.x0) {
                     if (mc.already_bounds_changed_x[pn->udata] == MoveChangeData::NO_CHANGE)
                         mc.bounds_changed_nets_x.push_back(pn->udata);
                     if (curr_bounds.nx0 == 1) {
@@ -951,7 +953,7 @@ class SAPlacer
                         mc.already_bounds_changed_x[pn->udata] = MoveChangeData::CELL_MOVED_OUTWARDS;
                         mc.bounds_changed_nets_x.push_back(pn->udata);
                     }
-                } else if (old_loc.x == curr_bounds.x1  && curr_loc.x < curr_bounds.x1) {
+                } else if (old_loc.x == curr_bounds.x1 && curr_loc.x < curr_bounds.x1) {
                     if (mc.already_bounds_changed_x[pn->udata] == MoveChangeData::NO_CHANGE)
                         mc.bounds_changed_nets_x.push_back(pn->udata);
                     if (curr_bounds.nx1 == 1) {
@@ -1006,7 +1008,7 @@ class SAPlacer
                         mc.already_bounds_changed_y[pn->udata] = MoveChangeData::CELL_MOVED_OUTWARDS;
                         mc.bounds_changed_nets_y.push_back(pn->udata);
                     }
-                } else if (old_loc.y == curr_bounds.y1  && curr_loc.y < curr_bounds.y1) {
+                } else if (old_loc.y == curr_bounds.y1 && curr_loc.y < curr_bounds.y1) {
                     if (mc.already_bounds_changed_y[pn->udata] == MoveChangeData::NO_CHANGE)
                         mc.bounds_changed_nets_y.push_back(pn->udata);
                     if (curr_bounds.ny1 == 1) {
@@ -1048,7 +1050,8 @@ class SAPlacer
                 md.new_net_bounds[bc] = get_net_bounds(net_by_udata[bc]);
         }
         for (const auto &bc : md.bounds_changed_nets_y) {
-            if (md.already_bounds_changed_x[bc] != MoveChangeData::FULL_RECOMPUTE && md.already_bounds_changed_y[bc] == MoveChangeData::FULL_RECOMPUTE)
+            if (md.already_bounds_changed_x[bc] != MoveChangeData::FULL_RECOMPUTE &&
+                md.already_bounds_changed_y[bc] == MoveChangeData::FULL_RECOMPUTE)
                 md.new_net_bounds[bc] = get_net_bounds(net_by_udata[bc]);
         }
 


### PR DESCRIPTION
This further improves incremental bounding box updates by keeping track of the number of cells on each edge of the bounding box, so a full recompute is needed only when the last cell at an edge moves inwards (moves outwards never need a full recompute).

Although there is no significant runtime improvement on small designs, on a large design it gives about a 3x runtime improvement.