### PR TITLE
timing_opt: Add locks to optimise()

### DIFF
--- a/common/timing_opt.cc
+++ b/common/timing_opt.cc
@@ -84,6 +84,7 @@ class TimingOptimiser
     bool optimise()
     {
         log_info("Running timing-driven placement optimisation...\n");
+        ctx->lock();
         if (ctx->verbose)
             timing_analysis(ctx, false, true, false, false);
         for (int i = 0; i < 30; i++) {
@@ -96,6 +97,7 @@ class TimingOptimiser
             if (ctx->verbose)
                 timing_analysis(ctx, false, true, false, false);
         }
+        ctx->unlock();
         return true;
     }
 


### PR DESCRIPTION
Just add lock/unlock calls on the context; this fixes (at least for me) a GUI crash when using --opt-timing. I didn't add a yield() call in the loop, but I could add one if wanted.