### PR TITLE
Resolve difference in interpretation of TRELLIS_ROOT

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ task:
     memory: 20
     dockerfile: .cirrus/Dockerfile.ubuntu16.04
 
-  build_script: mkdir build && cd build && cmake .. -DARCH=all -DTRELLIS_ROOT=/usr/local/src/prjtrellis -DBUILD_TESTS=on && make -j $(nproc)
+  build_script: mkdir build && cd build && cmake .. -DARCH=all -DTRELLIS_ROOT=/usr/local -DBUILD_TESTS=on && make -j $(nproc)
   submodule_script: git submodule sync --recursive && git submodule update --init --recursive
   test_generic_script: cd build && ./nextpnr-generic-test
   test_ice40_script: cd build && ./nextpnr-ice40-test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ task:
     memory: 20
     dockerfile: .cirrus/Dockerfile.ubuntu16.04
 
-  build_script: mkdir build && cd build && cmake .. -DARCH=all -DTRELLIS_ROOT=/usr/local -DBUILD_TESTS=on && make -j $(nproc)
+  build_script: mkdir build && cd build && cmake .. -DARCH=all -DTRELLIS_ROOT=/usr -DBUILD_TESTS=on && make -j $(nproc)
   submodule_script: git submodule sync --recursive && git submodule update --init --recursive
   test_generic_script: cd build && ./nextpnr-generic-test
   test_ice40_script: cd build && ./nextpnr-ice40-test

--- a/ecp5/family.cmake
+++ b/ecp5/family.cmake
@@ -6,7 +6,7 @@ if (NOT EXTERNAL_CHIPDB)
         set(TRELLIS_ROOT "/usr/local/share/trellis")
     endif()
 
-    file(GLOB found_pytrellis ${TRELLIS_ROOT}/libtrellis/pytrellis.*
+    file(GLOB found_pytrellis ${TRELLIS_ROOT}/trellis/pytrellis.*
                               /usr/lib/pytrellis.*
                               /usr/lib64/pytrellis.*
                               /usr/lib/trellis/pytrellis.*

--- a/ecp5/family.cmake
+++ b/ecp5/family.cmake
@@ -2,11 +2,11 @@ if (NOT EXTERNAL_CHIPDB)
     set(devices 25k 45k 85k)
 
     if (NOT DEFINED TRELLIS_ROOT)
-        message(STATUS "TRELLIS_ROOT not defined using -DTRELLIS_ROOT=/path/to/prjtrellis. Default to /usr/local/share/trellis")
-        set(TRELLIS_ROOT "/usr/local/share/trellis")
+        message(STATUS "TRELLIS_ROOT not defined using -DTRELLIS_ROOT=/path/to/prjtrellis. Default to /usr/local")
+        set(TRELLIS_ROOT "/usr/local")
     endif()
 
-    file(GLOB found_pytrellis ${TRELLIS_ROOT}/trellis/pytrellis.*
+    file(GLOB found_pytrellis ${TRELLIS_ROOT}/lib/trellis/pytrellis.*
                               /usr/lib/pytrellis.*
                               /usr/lib64/pytrellis.*
                               /usr/lib/trellis/pytrellis.*
@@ -27,9 +27,9 @@ if (NOT EXTERNAL_CHIPDB)
     target_include_directories(ecp5_chipdb PRIVATE ${family}/)
 
     if (CMAKE_HOST_WIN32)
-    set(ENV_CMD ${CMAKE_COMMAND} -E env "PYTHONPATH=\"${PYTRELLIS_LIBDIR}\;${TRELLIS_ROOT}/util/common\;${TRELLIS_ROOT}/timing/util\"")
+    set(ENV_CMD ${CMAKE_COMMAND} -E env "PYTHONPATH=\"${PYTRELLIS_LIBDIR}\;${TRELLIS_ROOT}/share/util/common\;${TRELLIS_ROOT}/share/timing/util\"")
     else()
-    set(ENV_CMD ${CMAKE_COMMAND} -E env "PYTHONPATH=${PYTRELLIS_LIBDIR}\:${TRELLIS_ROOT}/util/common:${TRELLIS_ROOT}/timing/util")
+    set(ENV_CMD ${CMAKE_COMMAND} -E env "PYTHONPATH=${PYTRELLIS_LIBDIR}\:${TRELLIS_ROOT}/share/util/common:${TRELLIS_ROOT}/share/timing/util")
     endif()
 
     if (MSVC)

--- a/ecp5/family.cmake
+++ b/ecp5/family.cmake
@@ -27,9 +27,9 @@ if (NOT EXTERNAL_CHIPDB)
     target_include_directories(ecp5_chipdb PRIVATE ${family}/)
 
     if (CMAKE_HOST_WIN32)
-    set(ENV_CMD ${CMAKE_COMMAND} -E env "PYTHONPATH=\"${PYTRELLIS_LIBDIR}\;${TRELLIS_ROOT}/share/util/common\;${TRELLIS_ROOT}/share/timing/util\"")
+    set(ENV_CMD ${CMAKE_COMMAND} -E env "PYTHONPATH=\"${PYTRELLIS_LIBDIR}\;${TRELLIS_ROOT}/share/trellis/util/common\;${TRELLIS_ROOT}/share/trellis/timing/util\"")
     else()
-    set(ENV_CMD ${CMAKE_COMMAND} -E env "PYTHONPATH=${PYTRELLIS_LIBDIR}\:${TRELLIS_ROOT}/share/util/common:${TRELLIS_ROOT}/share/timing/util")
+    set(ENV_CMD ${CMAKE_COMMAND} -E env "PYTHONPATH=${PYTRELLIS_LIBDIR}\:${TRELLIS_ROOT}/share/trellis/util/common:${TRELLIS_ROOT}/share/trellis/timing/util")
     endif()
 
     if (MSVC)


### PR DESCRIPTION
nextpnr appears to be out of date vs. prjtrellis's use of TRELLIS_ROOT. prjtrellis places libtrellis and pytrellis in a lib directory, and all other data in share/trellis. This patch adapts nextpnr accordingly.

I feel TRELLIS_ROOT might be better named TRELLIS_PREFIX, but that's up to @daveshah1, I imagine. And that would no longer match the ICEBOX_ROOT nomenclature.

Thanks to all the Yosys and SymbiFlow contributors for these wonderful tools!