### PR TITLE
gui: Fix warning: catching polymorphic type by value

### DIFF
--- a/gui/application.cc
+++ b/gui/application.cc
@@ -53,7 +53,7 @@ bool Application::notify(QObject *receiver, QEvent *event)
     bool retVal = true;
     try {
         retVal = QApplication::notify(receiver, event);
-    } catch (assertion_failure ex) {
+    } catch (const assertion_failure &ex) {
         QString msg;
         QTextStream out(&msg);
         out << ex.filename.c_str() << " at " << ex.line << "\n";


### PR DESCRIPTION
gui/application.cc: In member function ‘virtual bool nextpnr_ice40::Application::notify(QObject*, QEvent*)’:
gui/application.cc:56:32: warning: catching polymorphic type ‘class nextpnr_ice40::assertion_failure’ by value [-Wcatch-value=]