### PR TITLE
gui: fixed broken GUI on some DEs like LXDE

### DIFF
--- a/gui/application.cc
+++ b/gui/application.cc
@@ -42,7 +42,6 @@ BOOL WINAPI WinHandler(DWORD dwCtrlType)
 Application::Application(int &argc, char **argv) : QApplication(argc, argv)
 {
     QSurfaceFormat fmt;
-    fmt.setSamples(10);
     fmt.setProfile(QSurfaceFormat::CoreProfile);
     // macOS is very picky about this version matching
     // the version of openGL  used in ImGuiRenderer


### PR DESCRIPTION
not an expert with QT, the fix is based on a SO
post https://stackoverflow.com/questions/53768408/qt3d-qt-glx-qglx-findconfig-failed-to-finding-matching-fbconfig-warning/55235823#55235823

fixes #240
and probably fixes #271

Signed-off-by: Sahaj Sarup <sahajsarup@gmail.com>