### PR TITLE
option to disable anti aliasing in gui

### DIFF
--- a/common/command.cc
+++ b/common/command.cc
@@ -107,6 +107,7 @@ po::options_description CommandHandler::getGeneralOptions()
     general.add_options()("force,f", "keep running after errors");
 #ifndef NO_GUI
     general.add_options()("gui", "start gui");
+    general.add_options()("gui-no-aa", "disable anti aliasing");
 #endif
 #ifndef NO_PYTHON
     general.add_options()("run", po::value<std::vector<std::string>>(),
@@ -235,7 +236,7 @@ int CommandHandler::executeMain(std::unique_ptr<Context> ctx)
 
 #ifndef NO_GUI
     if (vm.count("gui")) {
-        Application a(argc, argv);
+        Application a(argc, argv, (vm.count("gui-no-aa") > 0));
         MainWindow w(std::move(ctx), chipArgs);
         try {
             if (vm.count("json")) {

--- a/gui/application.cc
+++ b/gui/application.cc
@@ -39,10 +39,11 @@ BOOL WINAPI WinHandler(DWORD dwCtrlType)
 }
 #endif
 
-Application::Application(int &argc, char **argv) : QApplication(argc, argv)
+Application::Application(int &argc, char **argv, bool noantialiasing) : QApplication(argc, argv)
 {
     QSurfaceFormat fmt;
-    fmt.setSamples(10);
+    if (!noantialiasing)
+        fmt.setSamples(10);
     fmt.setProfile(QSurfaceFormat::CoreProfile);
     // macOS is very picky about this version matching
     // the version of openGL  used in ImGuiRenderer

--- a/gui/application.h
+++ b/gui/application.h
@@ -29,7 +29,7 @@ NEXTPNR_NAMESPACE_BEGIN
 class Application : public QApplication
 {
   public:
-    Application(int &argc, char **argv);
+    Application(int &argc, char **argv, bool noantialiasing);
     bool notify(QObject *receiver, QEvent *event);
 };
 


### PR DESCRIPTION
Added option --gui-no-aa to disable anti-aliasing in GUI mode
 
Way to fix problems like https://github.com/YosysHQ/nextpnr/pull/278 when hardware does not support that level of anti aliasing.

