### PR TITLE
Fix missing \n in log statement

### DIFF
--- a/common/timing.cc
+++ b/common/timing.cc
@@ -752,7 +752,7 @@ void timing_analysis(Context *ctx, bool print_histogram, bool print_fmax, bool p
         }
 
         if (clock_reports.empty()) {
-            log_warning("No clocks found in design");
+            log_warning("No clocks found in design\n");
         }
 
         std::sort(xclock_paths.begin(), xclock_paths.end(), [ctx](const ClockPair &a, const ClockPair &b) {


### PR DESCRIPTION
It was annoying me so I fixed it. I also looked at every other log statement and that was the only one missing that I noticed.