### PR TITLE
ecp5: Use an attribute to store is_global

### DIFF
--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -531,6 +531,7 @@ bool Arch::place()
 bool Arch::route()
 {
     route_ecp5_globals(getCtx());
+    assignArchInfo();
     assign_budget(getCtx(), true);
 
     bool result = router1(getCtx(), Router1Cfg(getCtx()));
@@ -994,7 +995,7 @@ void Arch::archInfoToAttributes()
     for (auto &net : getCtx()->nets) {
         auto ni = net.second.get();
         ni->attrs[id("IS_GLOBAL")] = ni->is_global ? "1" : "0";
-    }    
+    }
 }
 
 void Arch::attributesToArchInfo()

--- a/ecp5/globals.cc
+++ b/ecp5/globals.cc
@@ -382,7 +382,7 @@ class Ecp5GlobalRouter
         glbnet->name = ctx->id("$glbnet$" + net->name.str(ctx));
         glbnet->driver.cell = dcc.get();
         glbnet->driver.port = id_CLKO;
-        glbnet->is_global = true;
+        glbnet->attrs[ctx->id("ECP5_IS_GLOBAL")] = "1";
         dcc->ports[id_CLKO].net = glbnet.get();
 
         std::vector<PortRef> keep_users;

--- a/ecp5/pack.cc
+++ b/ecp5/pack.cc
@@ -1508,7 +1508,8 @@ class Ecp5Packer
 
                 std::unique_ptr<NetInfo> promoted_ecknet(new NetInfo);
                 promoted_ecknet->name = eckname;
-                promoted_ecknet->is_global = true; // Prevents router etc touching this special net
+                promoted_ecknet->attrs[ctx->id("ECP5_IS_GLOBAL")] =
+                        "1"; // Prevents router etc touching this special net
                 eclk.buf = promoted_ecknet.get();
                 NPNR_ASSERT(!ctx->nets.count(eckname));
                 ctx->nets[eckname] = std::move(promoted_ecknet);
@@ -1654,7 +1655,7 @@ class Ecp5Packer
                                       port.c_str(ctx), ci->name.c_str(ctx), usr.port.c_str(ctx),
                                       usr.cell->name.c_str(ctx));
                     }
-                    pn->is_global = true;
+                    pn->attrs[ctx->id("ECP5_IS_GLOBAL")] = "1";
                 }
 
                 for (auto zport :
@@ -2469,6 +2470,9 @@ void Arch::assignArchInfo()
                 ci->ports[id_FXA].net->driver.port == id_OFX0)
                 ci->sliceInfo.has_l6mux = true;
         }
+    }
+    for (auto net : sorted(nets)) {
+        net.second->is_global = bool_or_default(net.second->attrs, id("ECP5_IS_GLOBAL"));
     }
 }
 


### PR DESCRIPTION
This way load and save between place/pack and routing works correctly.