### PR TITLE
Major rewrite & speedup of timing analysis

### DIFF
--- a/common/command.cc
+++ b/common/command.cc
@@ -161,6 +161,7 @@ po::options_description CommandHandler::getGeneralOptions()
     general.add_options()("placed-svg", po::value<std::string>(), "write render of placement to SVG file");
     general.add_options()("routed-svg", po::value<std::string>(), "write render of routing to SVG file");
 
+    general.add_options()("threads", po::value<int>(), "max thread count");
     return general;
 }
 
@@ -246,6 +247,10 @@ void CommandHandler::setupContext(Context *ctx)
         auto freq = vm["freq"].as<double>();
         if (freq > 0)
             ctx->settings[ctx->id("target_freq")] = std::to_string(freq * 1e6);
+    }
+
+    if (vm.count("threads")) {
+        ctx->settings[ctx->id("threads")] = vm["threads"].as<int>();
     }
 
     if (vm.count("no-tmdriv"))

--- a/common/command.cc
+++ b/common/command.cc
@@ -161,7 +161,6 @@ po::options_description CommandHandler::getGeneralOptions()
     general.add_options()("placed-svg", po::value<std::string>(), "write render of placement to SVG file");
     general.add_options()("routed-svg", po::value<std::string>(), "write render of routing to SVG file");
 
-    general.add_options()("threads", po::value<int>(), "max thread count");
     return general;
 }
 

--- a/common/nextpnr.cc
+++ b/common/nextpnr.cc
@@ -117,8 +117,8 @@ TimingConstrObjectId BaseCtx::timingCellObject(CellInfo *cell)
 
 TimingConstrObjectId BaseCtx::timingPortObject(CellInfo *cell, IdString port)
 {
-    if (cell->ports.at(port).tmg_id != TimingConstrObjectId()) {
-        return cell->ports.at(port).tmg_id;
+    if (cell->ports.at(port).tmg_constr_id != TimingConstrObjectId()) {
+        return cell->ports.at(port).tmg_constr_id;
     } else {
         TimingConstraintObject obj;
         TimingConstrObjectId id;
@@ -128,7 +128,7 @@ TimingConstrObjectId BaseCtx::timingPortObject(CellInfo *cell, IdString port)
         obj.entity = cell->name;
         obj.port = port;
         constraintObjects.push_back(obj);
-        cell->ports.at(port).tmg_id = id;
+        cell->ports.at(port).tmg_constr_id = id;
         return id;
     }
 }

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -885,7 +885,6 @@ struct BaseCtx
     void archInfoToAttributes();
     void attributesToArchInfo();
 
-
     void addFalsePath(const std::unordered_set<TimingConstrObjectId> &from,
                       const std::unordered_set<TimingConstrObjectId> &to);
     void setMinDelay(const std::unordered_set<TimingConstrObjectId> &from,
@@ -1069,7 +1068,7 @@ struct TimingData
     // Topological ordering of ports
     std::vector<port_uid_t> topological_order;
 
-    std::vector<NetInfo*> all_nets; 
+    std::vector<NetInfo *> all_nets;
 };
 
 struct Context : Arch, DeterministicRNG

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -907,16 +907,19 @@ struct TimingPortTimes
     MinMaxDelay required;
     MinMaxDelay arrival;
     MinMaxDelay slack;
-    delay_t budget;
-    int max_path_length;
-    float criticality;
+    delay_t budget = std::numeric_limits<delay_t>::max();
+    int max_path_length = 0;
+    float criticality = 0;
+
+    // Critical path predecessor for setup and hold
+    port_uid_t bwd_setup = -1, bwd_hold = -1;
 
     enum
     {
         FLAGS_NONE = 0,
         FLAGS_FALSE_STARTPOINT = 1,
         FLAGS_FALSE_ENDPOINT = 2,
-    } flags;
+    } flags = FLAGS_NONE;
 };
 
 struct TimingCellArc
@@ -957,10 +960,19 @@ struct TimingPortData
     delay_t net_delay = 0;
 };
 
+struct TimingDomainData
+{
+    TimingDomainTag tag;
+    // <start/end port, clock port>
+    std::vector<std::pair<port_uid_t, port_uid_t>> startpoints, endpoints;
+    port_uid_t crit_setup_ep = -1, crit_hold_ep = -1;
+};
+
 struct TimingData
 {
-    std::vector<TimingDomainTag> domainTags;
+    std::vector<TimingDomainData> domains;
     std::unordered_map<TimingDomainTag, int> domainTagIds;
+
     std::vector<PortRef *> ports_by_uid;
     std::vector<PortInfo *> portInfos_by_uid;
     // port uid -> data

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -1068,6 +1068,8 @@ struct TimingData
     std::vector<TimingPortData> ports;
     // Topological ordering of ports
     std::vector<port_uid_t> topological_order;
+
+    std::vector<NetInfo*> all_nets; 
 };
 
 struct Context : Arch, DeterministicRNG

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -902,6 +902,13 @@ NEXTPNR_NAMESPACE_END
 
 NEXTPNR_NAMESPACE_BEGIN
 
+struct ArrivReqTime
+{
+    MinMaxDelay value;
+    port_uid_t bwd_min = -1, bwd_max = -1;
+    int path_length = 0;
+};
+
 struct TimingPortTimes
 {
     MinMaxDelay required;
@@ -944,8 +951,8 @@ struct TimingPortData
     // Arrival, required, etc times
     // Stored once per clock domain
     // domainTag index -> TimingPortTimes
-    std::unordered_map<int, MinMaxDelay> arrival;
-    std::unordered_map<int, MinMaxDelay> required;
+    std::unordered_map<int, ArrivReqTime> arrival;
+    std::unordered_map<int, ArrivReqTime> required;
 
     // Max criticality, minimum slack and minimum budget over all domains
     // this port is involved in

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -944,7 +944,8 @@ struct TimingPortData
     // Arrival, required, etc times
     // Stored once per clock domain
     // domainTag index -> TimingPortTimes
-    std::unordered_map<int, TimingPortTimes> times;
+    std::unordered_map<int, MinMaxDelay> arrival;
+    std::unordered_map<int, MinMaxDelay> required;
 
     // Max criticality, minimum slack and minimum budget over all domains
     // this port is involved in

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -970,7 +970,8 @@ struct TimingDomainData
 
 struct TimingDomainPair
 {
-    TimingDomainTag start, end;
+    int start_domain, end_domain;
+    std::vector<port_uid_t> ports;
 
     MinMaxDelay period;
     MinMaxDelay crit_delay;

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -578,7 +578,7 @@ struct TimingConstraintObject
 
 struct MinMaxDelay
 {
-    delay_t min, max;
+    delay_t min = std::numeric_limits<delay_t>::max(), max = std::numeric_limits<delay_t>::min();
 };
 
 struct TimingConstraint
@@ -952,6 +952,9 @@ struct TimingPortData
     // when connectivity hasn't changed (e.g. inbetween placement
     // steps)
     std::vector<TimingCellArc> cell_arcs;
+
+    // Input ports only - net delay from driver to this port
+    delay_t net_delay = 0;
 };
 
 struct TimingData

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -578,7 +578,7 @@ struct TimingConstraintObject
 
 struct MinMaxDelay
 {
-    delay_t min = std::numeric_limits<delay_t>::max(), max = std::numeric_limits<delay_t>::min();
+    delay_t min = std::numeric_limits<delay_t>::max(), max = std::numeric_limits<delay_t>::lowest();
 };
 
 struct TimingConstraint
@@ -939,6 +939,8 @@ struct TimingCellArc
 
 struct TimingPortData
 {
+    CellInfo *cell;
+
     // Arrival, required, etc times
     // Stored once per clock domain
     // domainTag index -> TimingPortTimes
@@ -965,6 +967,16 @@ struct TimingDomainData
     TimingDomainTag tag;
     // <start/end port, clock port>
     std::vector<std::pair<port_uid_t, port_uid_t>> startpoints, endpoints;
+};
+
+struct TimingDomainPair
+{
+    TimingDomainTag start, end;
+
+    MinMaxDelay period;
+    MinMaxDelay crit_delay;
+    delay_t worst_slack;
+
     port_uid_t crit_setup_ep = -1, crit_hold_ep = -1;
 };
 

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -67,6 +67,8 @@
 #define NPNR_PACKED_STRUCT(...) __VA_ARGS__
 #endif
 
+typedef struct _object PyObject;
+
 NEXTPNR_NAMESPACE_BEGIN
 
 class assertion_failure : public std::runtime_error
@@ -803,6 +805,7 @@ struct BaseCtx
     TimingConstrObjectId timingNetObject(NetInfo *net);
     TimingConstrObjectId timingCellObject(CellInfo *cell);
     TimingConstrObjectId timingPortObject(CellInfo *cell, IdString port);
+    std::unordered_set<TimingConstrObjectId> parsePythonTimingObject(PyObject *obj);
 
     NetInfo *getNetByAlias(IdString alias) const
     {
@@ -833,6 +836,16 @@ struct BaseCtx
 
     void archInfoToAttributes();
     void attributesToArchInfo();
+
+
+    void addFalsePath(const std::unordered_set<TimingConstrObjectId> &from,
+                      const std::unordered_set<TimingConstrObjectId> &to);
+    void setMinDelay(const std::unordered_set<TimingConstrObjectId> &from,
+                     const std::unordered_set<TimingConstrObjectId> &to, delay_t delay);
+    void setMaxDelay(const std::unordered_set<TimingConstrObjectId> &from,
+                     const std::unordered_set<TimingConstrObjectId> &to, delay_t delay);
+    void addMulticyclePath(const std::unordered_set<TimingConstrObjectId> &from,
+                           const std::unordered_set<TimingConstrObjectId> &to);
 };
 
 NEXTPNR_NAMESPACE_END

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -982,6 +982,12 @@ template <typename Tk, typename Tv> struct FastSingleItemMap
                 func(item.first, item.second);
         }
     }
+
+    ~FastSingleItemMap()
+    {
+        if (item_count > 1)
+            delete multi_items;
+    }
 };
 
 struct TimingCellArc

--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -385,7 +385,6 @@ class SAPlacer
                 assign_budget(ctx, true /* quiet */);
             }
 
- 
             // Invoke timing analysis to obtain criticalities
             if (!cfg.budgetBased && cfg.timing_driven)
                 update_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY), &pool);

--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -246,11 +246,10 @@ class SAPlacer
             log_info("Running simulated annealing placer for refinement.\n");
         }
         auto saplace_start = std::chrono::high_resolution_clock::now();
-        boost::asio::thread_pool pool(int_or_default(ctx->settings, ctx->id("threads"), 4));
 
         // Invoke timing analysis to obtain criticalities
         if (!cfg.budgetBased)
-            init_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY), &pool);
+            init_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY));
 
         // Calculate costs after initial placement
         setup_costs();
@@ -387,7 +386,7 @@ class SAPlacer
 
             // Invoke timing analysis to obtain criticalities
             if (!cfg.budgetBased && cfg.timing_driven)
-                update_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY), &pool);
+                update_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY));
             // Need to rebuild costs after criticalities change
             setup_costs();
             // Reset incremental bounds

--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -246,7 +246,7 @@ class SAPlacer
             log_info("Running simulated annealing placer for refinement.\n");
         }
         auto saplace_start = std::chrono::high_resolution_clock::now();
-        boost::asio::thread_pool pool(ctx->threads);
+        boost::asio::thread_pool pool(int_or_default(ctx->settings, ctx->id("threads"), 4));
 
         // Invoke timing analysis to obtain criticalities
         if (!cfg.budgetBased)

--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -246,10 +246,11 @@ class SAPlacer
             log_info("Running simulated annealing placer for refinement.\n");
         }
         auto saplace_start = std::chrono::high_resolution_clock::now();
+        boost::asio::thread_pool pool(ctx->threads);
 
         // Invoke timing analysis to obtain criticalities
         if (!cfg.budgetBased)
-            init_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY));
+            init_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY), &pool);
 
         // Calculate costs after initial placement
         setup_costs();
@@ -384,9 +385,10 @@ class SAPlacer
                 assign_budget(ctx, true /* quiet */);
             }
 
+ 
             // Invoke timing analysis to obtain criticalities
             if (!cfg.budgetBased && cfg.timing_driven)
-                update_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY));
+                update_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY), &pool);
             // Need to rebuild costs after criticalities change
             setup_costs();
             // Reset incremental bounds

--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -247,11 +247,12 @@ class HeAPPlacer
                          std::chrono::duration<double>(run_stopt - run_startt).count());
             }
 
-
             if (cfg.timing_driven) {
+                boost::asio::thread_pool pool(4);
                 if (iter == 0)
-                    init_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY));
-                update_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY));
+                    init_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY), &pool);
+                else
+                    update_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY), &pool);
             }
 
             if (legal_hpwl < best_hpwl) {

--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -200,7 +200,7 @@ class HeAPPlacer
         heap_runs.push_back(all_celltypes);
         // The main HeAP placer loop
         log_info("Running main analytical placer.\n");
-        boost::asio::thread_pool pool(ctx->threads);
+        boost::asio::thread_pool pool(int_or_default(ctx->settings, ctx->id("threads"), 4));
 
         while (stalled < 5 && (solved_hpwl <= legal_hpwl * 0.8)) {
             // Alternate between particular Bel types and all bels

--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -250,8 +250,8 @@ class HeAPPlacer
 
             if (cfg.timing_driven) {
                 if (iter == 0)
-                    init_timing(ctx, &td);
-                update_timing(ctx, &td);
+                    init_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY));
+                update_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY));
             }
 
             if (legal_hpwl < best_hpwl) {

--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -200,6 +200,8 @@ class HeAPPlacer
         heap_runs.push_back(all_celltypes);
         // The main HeAP placer loop
         log_info("Running main analytical placer.\n");
+        boost::asio::thread_pool pool(4);
+
         while (stalled < 5 && (solved_hpwl <= legal_hpwl * 0.8)) {
             // Alternate between particular Bel types and all bels
             for (auto &run : heap_runs) {

--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -200,7 +200,7 @@ class HeAPPlacer
         heap_runs.push_back(all_celltypes);
         // The main HeAP placer loop
         log_info("Running main analytical placer.\n");
-        boost::asio::thread_pool pool(4);
+        boost::asio::thread_pool pool(ctx->threads);
 
         while (stalled < 5 && (solved_hpwl <= legal_hpwl * 0.8)) {
             // Alternate between particular Bel types and all bels

--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -200,7 +200,6 @@ class HeAPPlacer
         heap_runs.push_back(all_celltypes);
         // The main HeAP placer loop
         log_info("Running main analytical placer.\n");
-        boost::asio::thread_pool pool(int_or_default(ctx->settings, ctx->id("threads"), 4));
 
         while (stalled < 5 && (solved_hpwl <= legal_hpwl * 0.8)) {
             // Alternate between particular Bel types and all bels
@@ -250,11 +249,10 @@ class HeAPPlacer
             }
 
             if (cfg.timing_driven) {
-                boost::asio::thread_pool pool(4);
                 if (iter == 0)
-                    init_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY), &pool);
+                    init_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY));
                 else
-                    update_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY), &pool);
+                    update_timing(ctx, &td, TimingAnalyserFlags(TMG_IGNORE_CLOCK_ROUTING | TMG_SETUP_ONLY));
             }
 
             if (legal_hpwl < best_hpwl) {

--- a/common/pybindings.cc
+++ b/common/pybindings.cc
@@ -26,8 +26,8 @@
 #include "log.h"
 #include "nextpnr.h"
 
-#include <boost/filesystem.hpp>
 #include <Python.h>
+#include <boost/filesystem.hpp>
 #include <fstream>
 #include <memory>
 #include <signal.h>
@@ -71,7 +71,8 @@ void translate_assertfail(const assertion_failure &e)
     PyErr_SetString(PyExc_AssertionError, e.what());
 }
 
-std::unordered_set<TimingConstrObjectId> BaseCtx::parsePythonTimingObject(PyObject *obj) {
+std::unordered_set<TimingConstrObjectId> BaseCtx::parsePythonTimingObject(PyObject *obj)
+{
     using namespace PythonConversion;
     std::unordered_set<TimingConstrObjectId> result;
     auto convert_item = [&](PyObject *obj_ptr) -> TimingConstrObjectId {

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -337,13 +337,12 @@ struct TimingAnalyser
         }
     };
 
-    template <typename Tf>
-    void parallel_split(int N, Tf func)
+    template <typename Tf> void parallel_split(int N, Tf func)
     {
         if (pool) {
             WorkDispatcher wd;
             for (int i = 0; i < ctx->threads; i++) {
-                wd.dispatch([this, i, N, func]() { func( (N*i) / ctx->threads, (N*(i + 1)) / ctx->threads ); }, pool);
+                wd.dispatch([this, i, N, func]() { func((N * i) / ctx->threads, (N * (i + 1)) / ctx->threads); }, pool);
             }
             wd.join();
         } else {
@@ -519,7 +518,8 @@ struct TimingAnalyser
         }
     }
 
-    void reset_times_worker(int start, int end) {
+    void reset_times_worker(int start, int end)
+    {
         for (int i = start; i < end; i++) {
             auto &p = td->ports[i];
             p.arrival.for_each([](int, ArrivReqTime &t) {
@@ -683,7 +683,8 @@ struct TimingAnalyser
         }
     }
 
-    void slack_worker(int start, int end) {
+    void slack_worker(int start, int end)
+    {
         for (int i = start; i < end; i++) {
             port_uid_t p_uid = td->topological_order.at(i);
             auto &p = td->ports.at(p_uid);
@@ -830,7 +831,6 @@ void init_timing(Context *ctx, TimingData *td, TimingAnalyserFlags flags, boost:
     ta.assign_criticality();
     auto endtt = std::chrono::high_resolution_clock::now();
     log_info("** init_timing time: %.04fs\n", std::chrono::duration<double>(endtt - startt).count());
-
 }
 
 void update_timing(Context *ctx, TimingData *td, TimingAnalyserFlags flags, boost::asio::thread_pool *pool)

--- a/common/timing.h
+++ b/common/timing.h
@@ -22,8 +22,6 @@
 
 #include "nextpnr.h"
 
-#include <boost/asio.hpp>
-
 NEXTPNR_NAMESPACE_BEGIN
 
 // Evenly redistribute the total path slack amongst all sinks on each path
@@ -55,10 +53,8 @@ enum TimingAnalyserFlags
     TMG_IGNORE_CLOCK_ROUTING = 2,
 };
 
-void init_timing(Context *ctx, TimingData *td, TimingAnalyserFlags flags = TMG_FLAGS_NONE,
-                 boost::asio::thread_pool *pool = nullptr);
-void update_timing(Context *ctx, TimingData *td, TimingAnalyserFlags flags = TMG_FLAGS_NONE,
-                   boost::asio::thread_pool *pool = nullptr);
+void init_timing(Context *ctx, TimingData *td, TimingAnalyserFlags flags = TMG_FLAGS_NONE);
+void update_timing(Context *ctx, TimingData *td, TimingAnalyserFlags flags = TMG_FLAGS_NONE);
 
 NEXTPNR_NAMESPACE_END
 

--- a/common/timing.h
+++ b/common/timing.h
@@ -48,8 +48,17 @@ typedef std::unordered_map<IdString, NetCriticalityInfo> NetCriticalityMap;
 void get_criticalities(Context *ctx, NetCriticalityMap *net_crit);
 
 // New STA
-void init_timing(Context *ctx, TimingData *td, boost::asio::thread_pool *pool = nullptr);
-void update_timing(Context *ctx, TimingData *td, boost::asio::thread_pool *pool = nullptr);
+enum TimingAnalyserFlags
+{
+    TMG_FLAGS_NONE = 0,
+    TMG_SETUP_ONLY = 1,
+    TMG_IGNORE_CLOCK_ROUTING = 2,
+};
+
+void init_timing(Context *ctx, TimingData *td, TimingAnalyserFlags flags = TMG_FLAGS_NONE,
+                 boost::asio::thread_pool *pool = nullptr);
+void update_timing(Context *ctx, TimingData *td, TimingAnalyserFlags flags = TMG_FLAGS_NONE,
+                   boost::asio::thread_pool *pool = nullptr);
 
 NEXTPNR_NAMESPACE_END
 

--- a/common/timing.h
+++ b/common/timing.h
@@ -22,6 +22,8 @@
 
 #include "nextpnr.h"
 
+#include <boost/asio.hpp>
+
 NEXTPNR_NAMESPACE_BEGIN
 
 // Evenly redistribute the total path slack amongst all sinks on each path
@@ -44,6 +46,10 @@ struct NetCriticalityInfo
 
 typedef std::unordered_map<IdString, NetCriticalityInfo> NetCriticalityMap;
 void get_criticalities(Context *ctx, NetCriticalityMap *net_crit);
+
+// New STA
+void init_timing(Context *ctx, TimingData *td, boost::asio::thread_pool *pool = nullptr);
+void update_timing(Context *ctx, TimingData *td, boost::asio::thread_pool *pool = nullptr);
 
 NEXTPNR_NAMESPACE_END
 


### PR DESCRIPTION
This forms the final part of my university final year project. It aims to avoid rebuilding all the timing data structures ever time STA is invoked, allowing faster updates during placement and routing and multithreaded timing analysis (calculating arrival/required times in their own thread and clock domains individually). The aim is to replace the existing timing analysis as much as possible, it's not quite there yet.

Remaining TODOs:
 - [ ] fix conflicts
 - [ ] add critical path printing (including more advanced timing reports like _N_ most critical start/endpoints)
 - [ ] add cross clock max delay constraints
 - [ ] replace all users of the old timing analysis (subject to discussion)

Also included in this PR are some improvements to the Python constraints API, although they don't have any function yet.

