### PR TITLE
Switching from std to boost fix crash

### DIFF
--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -26,13 +26,13 @@
 #include <stdexcept>
 #include <stdint.h>
 #include <string>
-#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include <boost/functional/hash.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/thread.hpp>
 
 #ifndef NEXTPNR_H
 #define NEXTPNR_H
@@ -533,7 +533,7 @@ struct BaseCtx
 {
     // Lock to perform mutating actions on the Context.
     std::mutex mutex;
-    std::thread::id mutex_owner;
+    boost::thread::id mutex_owner;
 
     // Lock to be taken by UI when wanting to access context - the yield()
     // method will lock/unlock it when its' released the main mutex to make
@@ -583,12 +583,12 @@ struct BaseCtx
     void lock(void)
     {
         mutex.lock();
-        mutex_owner = std::this_thread::get_id();
+        mutex_owner = boost::this_thread::get_id();
     }
 
     void unlock(void)
     {
-        NPNR_ASSERT(std::this_thread::get_id() == mutex_owner);
+        NPNR_ASSERT(boost::this_thread::get_id() == mutex_owner);
         mutex.unlock();
     }
 

--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -37,12 +37,12 @@
 #include <Eigen/Core>
 #include <Eigen/IterativeLinearSolvers>
 #include <boost/optional.hpp>
+#include <boost/thread.hpp>
 #include <chrono>
 #include <deque>
 #include <fstream>
 #include <numeric>
 #include <queue>
-#include <thread>
 #include <tuple>
 #include <unordered_map>
 #include "log.h"
@@ -154,7 +154,7 @@ class HeAPPlacer
         for (int i = 0; i < 4; i++) {
             setup_solve_cells();
             auto solve_startt = std::chrono::high_resolution_clock::now();
-            std::thread xaxis([&]() { build_solve_direction(false, -1); });
+            boost::thread xaxis([&]() { build_solve_direction(false, -1); });
             build_solve_direction(true, -1);
             xaxis.join();
             auto solve_endt = std::chrono::high_resolution_clock::now();
@@ -208,7 +208,7 @@ class HeAPPlacer
                     build_solve_direction(false, (iter == 0) ? -1 : iter);
                     build_solve_direction(true, (iter == 0) ? -1 : iter);
                 } else {
-                    std::thread xaxis([&]() { build_solve_direction(false, (iter == 0) ? -1 : iter); });
+                    boost::thread xaxis([&]() { build_solve_direction(false, (iter == 0) ? -1 : iter); });
                     build_solve_direction(true, (iter == 0) ? -1 : iter);
                     xaxis.join();
                 }


### PR DESCRIPTION
In statically linked builds it crash inside std::thread implementation. Switching to boost helps resolving this issue.

#0  0x0000000000000000 in ?? ()
#1  0x000000000042fb8a in __gthread_self () at /usr/include/x86_64-linux-gnu/c++/7/bits/gthr-default.h:686
#2  std::this_thread::get_id () at /usr/include/c++/7/thread:343
#3  nextpnr_ice40::BaseCtx::lock (this=0xe659c00) at nextpnr/common/nextpnr.h:586
