### PR TITLE
Add deprecation warning for default packages

### DIFF
--- a/ecp5/main.cc
+++ b/ecp5/main.cc
@@ -220,8 +220,11 @@ std::unique_ptr<Context> ECP5CommandHandler::createContext(std::unordered_map<st
     if (chipArgs.type == ArchArgs::NONE)
         chipArgs.type = ArchArgs::LFE5U_45F;
 
-    if (chipArgs.package.empty())
+    if (chipArgs.package.empty()) {
         chipArgs.package = "CABGA381";
+        log_warning("Use of default value for --package is deprecated. Please add '--package %s' to arguments.\n",
+                    chipArgs.package.c_str());
+    }
 
     if (chipArgs.type == ArchArgs::LFE5UM5G_25F || chipArgs.type == ArchArgs::LFE5UM5G_45F ||
         chipArgs.type == ArchArgs::LFE5UM5G_85F) {

--- a/ice40/examples/blinky/blinky.sh
+++ b/ice40/examples/blinky/blinky.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 yosys blinky.ys
-../../../nextpnr-ice40 --json blinky.json --pcf blinky.pcf --asc blinky.asc
+../../../nextpnr-ice40 --hx1k --package tq144 --json blinky.json --pcf blinky.pcf --asc blinky.asc
 icepack blinky.asc blinky.bin
 icebox_vlog blinky.asc > blinky_chip.v
 iverilog -o blinky_tb blinky_chip.v blinky_tb.v

--- a/ice40/examples/floorplan/floorplan.sh
+++ b/ice40/examples/floorplan/floorplan.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -ex
 yosys -p "synth_ice40 -top top -json floorplan.json" floorplan.v
-../../../nextpnr-ice40 --up5k --json floorplan.json --pcf icebreaker.pcf --asc floorplan.asc --ignore-loops --pre-place floorplan.py
+../../../nextpnr-ice40 --package sg48  --up5k --json floorplan.json --pcf icebreaker.pcf --asc floorplan.asc --ignore-loops --pre-place floorplan.py
 icepack floorplan.asc floorplan.bin
 iceprog floorplan.bin

--- a/ice40/main.cc
+++ b/ice40/main.cc
@@ -157,7 +157,6 @@ std::unique_ptr<Context> Ice40CommandHandler::createContext(std::unordered_map<s
 
     if (vm.count("package"))
         chipArgs.package = vm["package"].as<std::string>();
-
     if (values.find("arch.name") != values.end()) {
         std::string arch_name = values["arch.name"].as_string();
         if (arch_name != "ice40")
@@ -207,6 +206,9 @@ std::unique_ptr<Context> Ice40CommandHandler::createContext(std::unordered_map<s
         log_error("This version of nextpnr-ice40 is built with HX1K-support only.\n");
     }
 #endif
+
+    log_warning("Use of default value for --package is deprecated. Please add '--package %s' to arguments.\n",
+                chipArgs.package.c_str());
 
     auto ctx = std::unique_ptr<Context>(new Context(chipArgs));
     for (auto &val : values)


### PR DESCRIPTION
This is the first part of a solution to #304, so that we can remove default package value altogether in a month or two, and certainly before the first stable release of nextpnr (whenever that is)