### PR TITLE
cmakelists: quote the last argument to REGEX REPLACE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,18 +136,18 @@ if (BUILD_PYTHON)
     # Original source: https://github.com/BVLC/caffe/blob/master/cmake/Dependencies.cmake#L148
     set(version ${PYTHONLIBS_VERSION_STRING})
 
-    STRING(REGEX REPLACE "[^0-9]" "" boost_py_version ${version})
+    STRING(REGEX REPLACE "[^0-9]" "" boost_py_version "${version}")
     find_package(Boost QUIET COMPONENTS "python-py${boost_py_version}" ${boost_libs})
     set(Boost_PYTHON_FOUND ${Boost_PYTHON-PY${boost_py_version}_FOUND})
 
     while (NOT "${version}" STREQUAL "" AND NOT Boost_PYTHON_FOUND)
-        STRING(REGEX REPLACE "([0-9.]+).[0-9]+" "\\1" version ${version})
+        STRING(REGEX REPLACE "([0-9.]+).[0-9]+" "\\1" version "${version}")
 
-        STRING(REGEX REPLACE "[^0-9]" "" boost_py_version ${version})
+        STRING(REGEX REPLACE "[^0-9]" "" boost_py_version "${version}")
         find_package(Boost QUIET COMPONENTS "python-py${boost_py_version}" ${boost_libs})
         set(Boost_PYTHON_FOUND ${Boost_PYTHON-PY${boost_py_version}_FOUND})
 
-        STRING(REGEX MATCHALL "([0-9.]+).[0-9]+" has_more_version ${version})
+        STRING(REGEX MATCHALL "([0-9.]+).[0-9]+" has_more_version "${version}")
         if ("${has_more_version}" STREQUAL "")
             break()
         endif ()
@@ -175,7 +175,7 @@ if (BUILD_PYTHON)
     endif ()
 
     if (NOT Boost_PYTHON_FOUND)
-        STRING(REGEX REPLACE "([0-9]+\\.[0-9]+).*" "\\1" gentoo_version ${PYTHONLIBS_VERSION_STRING})
+        STRING(REGEX REPLACE "([0-9]+\\.[0-9]+).*" "\\1" gentoo_version "${PYTHONLIBS_VERSION_STRING}")
         find_package(Boost QUIET COMPONENTS python-${gentoo_version} ${boost_libs})
         if ("${Boost_LIBRARIES}" MATCHES ".*(python|PYTHON).*" )
             set(Boost_PYTHON_FOUND TRUE)


### PR DESCRIPTION
With newer versions of cmake, an unquoted 6th argument gives the
following error:

    STRING sub-command REGEX, mode REPLACE needs at least 6 arguments
    total to command.

Quoting this fixes the issue.

Signed-off-by: Sean Cross <sean@xobs.io>