### PR TITLE
Restrict clock promotion to global on ECP5

### DIFF
--- a/ecp5/globals.cc
+++ b/ecp5/globals.cc
@@ -435,8 +435,8 @@ class Ecp5GlobalRouter
         log_info("Promoting globals...\n");
         auto clocks = get_clocks();
         for (auto clock : clocks) {
-            bool is_global = bool_or_default(clock->attrs, ctx->id("ECP5_IS_GLOBAL"), true);
-            if (!is_global)
+            bool is_noglobal = bool_or_default(clock->attrs, ctx->id("noglobal"), false);
+            if (is_noglobal)
                 continue;
             log_info("    promoting clock net %s to global network\n", clock->name.c_str(ctx));
             if (is_ooc) // Don't actually do anything in OOC mode, global routing will be done in the full design

--- a/ecp5/globals.cc
+++ b/ecp5/globals.cc
@@ -435,6 +435,9 @@ class Ecp5GlobalRouter
         log_info("Promoting globals...\n");
         auto clocks = get_clocks();
         for (auto clock : clocks) {
+            bool is_global = bool_or_default(clock->attrs, ctx->id("ECP5_IS_GLOBAL"), true);
+            if (!is_global)
+                continue;
             log_info("    promoting clock net %s to global network\n", clock->name.c_str(ctx));
             if (is_ooc) // Don't actually do anything in OOC mode, global routing will be done in the full design
                 clock->is_global = true;


### PR DESCRIPTION
This PR allows optional disabling of the promotion to global of a clock using the `(* ECP5_IS_GLOBAL=0 *)` attribute.

This allows ring oscillators to be used as clock sources. When creating a ring oscillator with Yosys+NextPNR or Diamond and adding it to the sensitivity list, the ring oscillator stops oscillating. This was described in DurandA/verilog-buildingblocks#1.

To the best of my knowledge, this is not possible in Diamond as I couldn't find such a feature in the chapter _Specifying Constraints and Attributes_ from _Lattice Synthesis Engine for Diamond User Guide_. In this regards (and considering that the use-cases are limited), I don't necessarily expect this PR to be accepted.