### PR TITLE
ecp5: Add full part name to bitstream header

### DIFF
--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -158,6 +158,26 @@ std::string Arch::getChipName() const
     }
 }
 
+std::string Arch::getFullChipName() const
+{
+    std::string name = getChipName();
+    name += "-";
+    switch (args.speed) {
+    case ArchArgs::SPEED_6:
+        name += "6";
+        break;
+    case ArchArgs::SPEED_7:
+        name += "7";
+        break;
+    case ArchArgs::SPEED_8:
+    case ArchArgs::SPEED_8_5G:
+        name += "8";
+        break;
+    }
+    name += args.package;
+    return name;
+}
+
 // -----------------------------------------------------------------------
 
 IdString Arch::archArgsToId(ArchArgs args) const

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -491,6 +491,7 @@ struct Arch : BaseCtx
     Arch(ArchArgs args);
 
     std::string getChipName() const;
+    std::string getFullChipName() const;
 
     IdString archId() const { return id("ecp5"); }
     ArchArgs archArgs() const { return args; }

--- a/ecp5/bitstream.cc
+++ b/ecp5/bitstream.cc
@@ -600,6 +600,8 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
         }
     }
 
+    cc.metadata.push_back("Part: " + ctx->getFullChipName());
+
     // Clear out DCU tieoffs in base config if DCU used
     for (auto &cell : ctx->cells) {
         CellInfo *ci = cell.second.get();


### PR DESCRIPTION
Get rids of the warning mentioned in https://www.reddit.com/r/yosys/comments/crf3e2/bitstream_file_generating_warning/ when using a nextpnr/trellis bitstream with Diamond programmer or other Diamond tools.