### PR TITLE
json: Add support for net aliases

### DIFF
--- a/common/nextpnr.cc
+++ b/common/nextpnr.cc
@@ -474,10 +474,10 @@ void BaseCtx::addClock(IdString net, float freq)
     cc->period = getCtx()->getDelayFromNS(1000 / freq);
     cc->high = getCtx()->getDelayFromNS(500 / freq);
     cc->low = getCtx()->getDelayFromNS(500 / freq);
-    if (!nets.count(net)) {
+    if (!net_aliases.count(net)) {
         log_warning("net '%s' does not exist in design, ignoring clock constraint\n", net.c_str(this));
     } else {
-        nets.at(net)->clkconstr = std::move(cc);
+        getNetByAlias(net)->clkconstr = std::move(cc);
         log_info("constraining clock net '%s' to %.02f MHz\n", net.c_str(this), freq);
     }
 }

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -609,6 +609,9 @@ struct BaseCtx
     std::unordered_map<IdString, std::unique_ptr<NetInfo>> nets;
     std::unordered_map<IdString, std::unique_ptr<CellInfo>> cells;
 
+    // Aliases for nets, which may have more than one name due to assignments and hierarchy
+    std::unordered_map<IdString, IdString> net_aliases;
+
     // Top-level ports
     std::unordered_map<IdString, PortInfo> ports;
 
@@ -737,6 +740,8 @@ struct BaseCtx
     TimingConstrObjectId timingNetObject(NetInfo *net);
     TimingConstrObjectId timingCellObject(CellInfo *cell);
     TimingConstrObjectId timingPortObject(CellInfo *cell, IdString port);
+
+    NetInfo *getNetByAlias(IdString alias) const { return nets.at(net_aliases.at(alias)).get(); }
 
     void addConstraint(std::unique_ptr<TimingConstraint> constr);
     void removeConstraint(IdString constrName);

--- a/ecp5/arch_pybindings.cc
+++ b/ecp5/arch_pybindings.cc
@@ -125,12 +125,17 @@ void arch_wrap_python()
 
     typedef std::unordered_map<IdString, std::unique_ptr<CellInfo>> CellMap;
     typedef std::unordered_map<IdString, std::unique_ptr<NetInfo>> NetMap;
+    typedef std::unordered_map<IdString, IdString> AliasMap;
 
     readonly_wrapper<Context, decltype(&Context::cells), &Context::cells, wrap_context<CellMap &>>::def_wrap(ctx_cls,
                                                                                                              "cells");
     readonly_wrapper<Context, decltype(&Context::nets), &Context::nets, wrap_context<NetMap &>>::def_wrap(ctx_cls,
                                                                                                           "nets");
+    readonly_wrapper<Context, decltype(&Context::net_aliases), &Context::net_aliases,
+                     wrap_context<AliasMap &>>::def_wrap(ctx_cls, "net_aliases");
 
+    fn_wrapper_1a<Context, decltype(&Context::getNetByAlias), &Context::getNetByAlias, deref_and_wrap<NetInfo>,
+                  conv_from_str<IdString>>::def_wrap(ctx_cls, "getNetByAlias");
     fn_wrapper_2a_v<Context, decltype(&Context::addClock), &Context::addClock, conv_from_str<IdString>,
                     pass_through<float>>::def_wrap(ctx_cls, "addClock");
     fn_wrapper_5a_v<Context, decltype(&Context::createRectangularRegion), &Context::createRectangularRegion,

--- a/ice40/arch_pybindings.cc
+++ b/ice40/arch_pybindings.cc
@@ -136,12 +136,17 @@ void arch_wrap_python()
 
     typedef std::unordered_map<IdString, std::unique_ptr<CellInfo>> CellMap;
     typedef std::unordered_map<IdString, std::unique_ptr<NetInfo>> NetMap;
+    typedef std::unordered_map<IdString, IdString> AliasMap;
 
     readonly_wrapper<Context, decltype(&Context::cells), &Context::cells, wrap_context<CellMap &>>::def_wrap(ctx_cls,
                                                                                                              "cells");
     readonly_wrapper<Context, decltype(&Context::nets), &Context::nets, wrap_context<NetMap &>>::def_wrap(ctx_cls,
                                                                                                           "nets");
+    readonly_wrapper<Context, decltype(&Context::net_aliases), &Context::net_aliases,
+                     wrap_context<AliasMap &>>::def_wrap(ctx_cls, "net_aliases");
 
+    fn_wrapper_1a<Context, decltype(&Context::getNetByAlias), &Context::getNetByAlias, deref_and_wrap<NetInfo>,
+                  conv_from_str<IdString>>::def_wrap(ctx_cls, "getNetByAlias");
     fn_wrapper_2a_v<Context, decltype(&Context::addClock), &Context::addClock, conv_from_str<IdString>,
                     pass_through<float>>::def_wrap(ctx_cls, "addClock");
     fn_wrapper_5a_v<Context, decltype(&Context::createRectangularRegion), &Context::createRectangularRegion,


### PR DESCRIPTION
This makes specifying clock constraints on interior nets much easier.

Not the cleanest implementation, but somewhat limited by the current state of the JSON parser, more significant improvements to which are on my TODO list.