### PR TITLE
ice40: Add set_frequency pcf command; and document pcf format

### DIFF
--- a/docs/ice40.md
+++ b/docs/ice40.md
@@ -1,0 +1,17 @@
+# iCE40 Architecture Documentation
+
+## PCF format reference
+
+PCF files contain physical constraints and are specified using the `--pcf` argument. Each (non blank) line contains a command; lines beginning with `#` are comments.
+
+Two commands are supported: `set_io` and `set_frequency`.
+
+    set_io [-nowarn] [-pullup yes|no] [-pullup_resistor 3P3K|6P8K|10K|100K] port pin
+
+Constrains named port `port` to package pin `pin`. `-nowarn` disables the warning if `port` does not exist. `-pullup yes` can be used to enable the built in pullup for all iCE40 devices. `-pullup_resistor` sets the pullup strength, and is available on iCE40 UltraPlus only.
+
+    set_frequency net frequency
+
+Adds a clock constraint to a named net (any alias for the net can be used). `frequency` is in MHz.
+
+_Note that this is a non-standard extension, not supported by the vendor toolchain. It allows specifying clock constraints without needing the Python API._

--- a/ice40/pcf.cc
+++ b/ice40/pcf.cc
@@ -100,6 +100,10 @@ bool apply_pcf(Context *ctx, std::string filename, std::istream &in)
                     for (const auto &attr : extra_attrs)
                         fnd_cell->second->attrs[attr.first] = attr.second;
                 }
+            } else if (cmd == "set_frequency") {
+                if (words.size() < 3)
+                    log_error("expected PCF syntax 'set_frequency net frequency' (on line %d)\n", lineno);
+                ctx->addClock(ctx->id(words.at(1)), std::stof(words.at(2)));
             } else {
                 log_error("unsupported PCF command '%s' (on line %d)\n", cmd.c_str(), lineno);
             }


### PR DESCRIPTION
Right now the lack of any other timing constraint format limits builds not linked with Python. This should make useful static/distributable builds much smaller and simpler than at present.

Strictly speaking, the vendor-compatible way would be to use sdc files. But this is a bigger project as it applies to multiple architectures and would need more research into a reasonable subset to support (and any IP issues that might affect it). It might even be best to approach that from the Yosys side; as eventually synthesis-time constraints will be needed too (this could then be passed to nextpnr in an attribute).