### PR TITLE
Improve handling of top level IO and add SDF support

### DIFF
--- a/common/command.cc
+++ b/common/command.cc
@@ -150,6 +150,7 @@ po::options_description CommandHandler::getGeneralOptions()
     general.add_options()("timing-allow-fail", "allow timing to fail in design");
     general.add_options()("no-tmdriv", "disable timing-driven placement");
     general.add_options()("sdf", po::value<std::string>(), "SDF delay back-annotation file to write");
+    general.add_options()("sdf-cvc", "enable tweaks for SDF file compatibility with the CVC simulator");
 
     return general;
 }
@@ -343,7 +344,7 @@ int CommandHandler::executeMain(std::unique_ptr<Context> ctx)
         std::ofstream f(filename);
         if (!f)
             log_error("Failed to open SDF file '%s' for writing.\n", filename.c_str());
-        ctx->writeSDF(f);
+        ctx->writeSDF(f, vm.count("sdf-cvc"));
     }
 
 #ifndef NO_PYTHON

--- a/common/command.cc
+++ b/common/command.cc
@@ -149,6 +149,8 @@ po::options_description CommandHandler::getGeneralOptions()
     general.add_options()("freq", po::value<double>(), "set target frequency for design in MHz");
     general.add_options()("timing-allow-fail", "allow timing to fail in design");
     general.add_options()("no-tmdriv", "disable timing-driven placement");
+    general.add_options()("sdf", po::value<std::string>(), "SDF delay back-annotation file to write");
+
     return general;
 }
 
@@ -334,6 +336,14 @@ int CommandHandler::executeMain(std::unique_ptr<Context> ctx)
         std::ofstream f(filename);
         if (!write_json_file(f, filename, ctx.get()))
             log_error("Saving design failed.\n");
+    }
+
+    if (vm.count("sdf")) {
+        std::string filename = vm["sdf"].as<std::string>();
+        std::ofstream f(filename);
+        if (!f)
+            log_error("Failed to open SDF file '%s' for writing.\n", filename.c_str());
+        ctx->writeSDF(f);
     }
 
 #ifndef NO_PYTHON

--- a/common/design_utils.cc
+++ b/common/design_utils.cc
@@ -88,7 +88,7 @@ void connect_port(const Context *ctx, NetInfo *net, CellInfo *cell, IdString por
         NPNR_ASSERT(net->driver.cell == nullptr);
         net->driver.cell = cell;
         net->driver.port = port_name;
-    } else if (port.type == PORT_IN) {
+    } else if (port.type == PORT_IN || port.type == PORT_INOUT) {
         PortRef user;
         user.cell = cell;
         user.port = port_name;
@@ -144,6 +144,16 @@ void rename_port(Context *ctx, CellInfo *cell, IdString old_name, IdString new_n
     cell->ports.erase(old_name);
     pi.name = new_name;
     cell->ports[new_name] = pi;
+}
+
+void rename_net(Context *ctx, NetInfo *net, IdString new_name)
+{
+    if (net == nullptr)
+        return;
+    NPNR_ASSERT(!ctx->nets.count(new_name));
+    std::swap(ctx->nets[net->name], ctx->nets[new_name]);
+    ctx->nets.erase(net->name);
+    net->name = new_name;
 }
 
 NEXTPNR_NAMESPACE_END

--- a/common/design_utils.h
+++ b/common/design_utils.h
@@ -94,6 +94,9 @@ void connect_ports(Context *ctx, CellInfo *cell1, IdString port1_name, CellInfo 
 // Rename a port if it exists on a cell
 void rename_port(Context *ctx, CellInfo *cell, IdString old_name, IdString new_name);
 
+// Rename a net without invalidating pointers to it
+void rename_net(Context *ctx, NetInfo *net, IdString new_name);
+
 void print_utilisation(const Context *ctx);
 
 NEXTPNR_NAMESPACE_END

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -808,6 +808,11 @@ struct Context : Arch, DeterministicRNG
 
     // --------------------------------------------------------------
 
+    // provided by sdf.cc
+    void writeSDF(std::ostream &out) const;
+
+    // --------------------------------------------------------------
+
     uint32_t checksum() const;
 
     void check() const;

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -809,7 +809,7 @@ struct Context : Arch, DeterministicRNG
     // --------------------------------------------------------------
 
     // provided by sdf.cc
-    void writeSDF(std::ostream &out) const;
+    void writeSDF(std::ostream &out, bool cvc_mode = false) const;
 
     // --------------------------------------------------------------
 

--- a/common/sdf.cc
+++ b/common/sdf.cc
@@ -1,0 +1,200 @@
+/*
+ *  nextpnr -- Next Generation Place and Route
+ *
+ *  Copyright (C) 2019  David Shah <dave@ds0.me>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "nextpnr.h"
+
+NEXTPNR_NAMESPACE_BEGIN
+
+namespace SDF {
+
+struct MinMaxTyp
+{
+    double min, typ, max;
+};
+
+struct RiseFallDelay
+{
+    MinMaxTyp rise, fall;
+};
+
+struct PortAndEdge
+{
+    std::string port;
+    ClockEdge edge;
+};
+
+struct IOPath
+{
+    std::string from, to;
+    RiseFallDelay delay;
+};
+
+struct TimingCheck
+{
+    enum CheckType
+    {
+        SETUPHOLD,
+        PERIOD,
+        WIDTH
+    } type;
+    PortAndEdge from, to;
+    RiseFallDelay delay;
+};
+
+struct Cell
+{
+    std::string celltype, instance;
+    std::vector<IOPath> iopaths;
+    std::vector<TimingCheck> checks;
+};
+
+struct CellPort
+{
+    std::string cell, port;
+};
+
+struct Interconnect
+{
+    CellPort from, to;
+    RiseFallDelay delay;
+};
+
+struct SDFWriter
+{
+    std::vector<Cell> cells;
+    std::vector<Interconnect> conn;
+    std::string sdfversion, design, vendor, program;
+
+    std::string format_name(const std::string &name)
+    {
+        std::string fmt = "\"";
+        for (char c : name) {
+            if (c == '\\' || c == '\"')
+                fmt += "\"";
+            fmt += c;
+        }
+        fmt += "\"";
+        return fmt;
+    }
+
+    std::string timing_check_name(TimingCheck::CheckType type)
+    {
+        switch (type) {
+        case TimingCheck::SETUPHOLD:
+            return "SETUPHOLD";
+        case TimingCheck::PERIOD:
+            return "PERIOD";
+        case TimingCheck::WIDTH:
+            return "WIDTH";
+        default:
+            NPNR_ASSERT_FALSE("unknown timing check type");
+        }
+    }
+
+    void write_delay(std::ostream &out, const RiseFallDelay &delay)
+    {
+        write_delay(out, delay.rise);
+        out << " ";
+        write_delay(out, delay.fall);
+    }
+
+    void write_delay(std::ostream &out, const MinMaxTyp &delay)
+    {
+        out << "(" << delay.min << ":" << delay.typ << ":" << delay.max << ")";
+    }
+
+    void write_port(std::ostream &out, const CellPort &port) { out << format_name(port.cell + "/" + port.port); }
+
+    void write_portedge(std::ostream &out, const PortAndEdge &pe)
+    {
+        out << "(" << (pe.edge == RISING_EDGE ? "posedge" : "negedge") << " " << pe.port << ")";
+    }
+
+    void write(std::ostream &out)
+    {
+        out << "(DELAYFILE" << std::endl;
+        // Headers and  metadata
+        out << "  (SDFVERSION " << format_name(sdfversion) << ")" << std::endl;
+        out << "  (DESIGN " << format_name(design) << ")" << std::endl;
+        out << "  (VENDOR " << format_name(vendor) << ")" << std::endl;
+        out << "  (PROGRAM " << format_name(program) << ")" << std::endl;
+        out << "  (DIVIDER /)" << std::endl;
+        out << "  (TIMESCALE 1ps)" << std::endl;
+        // Write cells
+        for (auto &cell : cells) {
+            out << "  (CELL" << std::endl;
+            out << "    (CELLTYPE " << format_name(cell.celltype) << ")" << std::endl;
+            out << "    (INSTANCE " << format_name(cell.instance) << ")" << std::endl;
+            // IOPATHs (combinational delay and clock-to-q)
+            if (!cell.iopaths.empty()) {
+                out << "    (DELAY" << std::endl;
+                out << "      (ABSOLUTE" << std::endl;
+                for (auto &path : cell.iopaths) {
+                    out << "        (IOPATH " << path.from << " " << path.to << " ";
+                    write_delay(out, path.delay);
+                    out << ")" << std::endl;
+                }
+                out << "      )" << std::endl;
+                out << "    )" << std::endl;
+            }
+            // Timing Checks (setup/hold, period, width)
+            if (!cell.checks.empty()) {
+                out << "    (TIMINGCHECK" << std::endl;
+                for (auto &check : cell.checks) {
+                    out << "      (" << timing_check_name(check.type) << " ";
+                    write_portedge(out, check.from);
+                    out << " ";
+                    if (check.type == TimingCheck::SETUPHOLD) {
+                        write_portedge(out, check.to);
+                        out << " ";
+                    }
+                    if (check.type == TimingCheck::SETUPHOLD)
+                        write_delay(out, check.delay);
+                    else
+                        write_delay(out, check.delay.rise);
+                    out << ")" << std::endl;
+                }
+                out << "    )" << std::endl;
+            }
+            out << "    )" << std::endl;
+        }
+        // Write interconnect delays, with the main design begin a "cell"
+        out << "  (CELL" << std::endl;
+        out << "    (CELLTYPE " << format_name(design) << ")" << std::endl;
+        out << "    (DELAY" << std::endl;
+        out << "      (ABSOLUTE" << std::endl;
+        for (auto &ic : conn) {
+            out << "        (INTERCONNECT ";
+            write_port(out, ic.from);
+            out << " ";
+            write_port(out, ic.to);
+            out << " ";
+            write_delay(out, ic.delay);
+            out << std::endl;
+        }
+        out << "      )" << std::endl;
+        out << "    )" << std::endl;
+        out << "  )" << std::endl;
+        out << ")" << std::endl;
+    }
+};
+
+} // namespace SDF
+
+NEXTPNR_NAMESPACE_END

--- a/common/sdf.cc
+++ b/common/sdf.cc
@@ -18,6 +18,7 @@
  */
 
 #include "nextpnr.h"
+#include "util.h"
 
 NEXTPNR_NAMESPACE_BEGIN
 
@@ -93,6 +94,17 @@ struct SDFWriter
         return fmt;
     }
 
+    std::string escape_name(const std::string &name)
+    {
+        std::string esc;
+        for (char c : name) {
+            if (c == '$' || c == '\\' || c == '[' || c == ']' || c == ':')
+                esc += '\\';
+            esc += c;
+        }
+        return esc;
+    }
+
     std::string timing_check_name(TimingCheck::CheckType type)
     {
         switch (type) {
@@ -119,11 +131,11 @@ struct SDFWriter
         out << "(" << delay.min << ":" << delay.typ << ":" << delay.max << ")";
     }
 
-    void write_port(std::ostream &out, const CellPort &port) { out << format_name(port.cell + "/" + port.port); }
+    void write_port(std::ostream &out, const CellPort &port) { out << escape_name(port.cell + "/" + port.port); }
 
     void write_portedge(std::ostream &out, const PortAndEdge &pe)
     {
-        out << "(" << (pe.edge == RISING_EDGE ? "posedge" : "negedge") << " " << pe.port << ")";
+        out << "(" << (pe.edge == RISING_EDGE ? "posedge" : "negedge") << " " << escape_name(pe.port) << ")";
     }
 
     void write(std::ostream &out)
@@ -136,17 +148,35 @@ struct SDFWriter
         out << "  (PROGRAM " << format_name(program) << ")" << std::endl;
         out << "  (DIVIDER /)" << std::endl;
         out << "  (TIMESCALE 1ps)" << std::endl;
+        // Write interconnect delays, with the main design begin a "cell"
+        out << "  (CELL" << std::endl;
+        out << "    (CELLTYPE " << format_name(design) << ")" << std::endl;
+        out << "    (INSTANCE )" << std::endl;
+        out << "    (DELAY" << std::endl;
+        out << "      (ABSOLUTE" << std::endl;
+        for (auto &ic : conn) {
+            out << "        (INTERCONNECT ";
+            write_port(out, ic.from);
+            out << " ";
+            write_port(out, ic.to);
+            out << " ";
+            write_delay(out, ic.delay);
+            out << ")" << std::endl;
+        }
+        out << "      )" << std::endl;
+        out << "    )" << std::endl;
+        out << "  )" << std::endl;
         // Write cells
         for (auto &cell : cells) {
             out << "  (CELL" << std::endl;
             out << "    (CELLTYPE " << format_name(cell.celltype) << ")" << std::endl;
-            out << "    (INSTANCE " << format_name(cell.instance) << ")" << std::endl;
+            out << "    (INSTANCE " << escape_name(cell.instance) << ")" << std::endl;
             // IOPATHs (combinational delay and clock-to-q)
             if (!cell.iopaths.empty()) {
                 out << "    (DELAY" << std::endl;
                 out << "      (ABSOLUTE" << std::endl;
                 for (auto &path : cell.iopaths) {
-                    out << "        (IOPATH " << path.from << " " << path.to << " ";
+                    out << "        (IOPATH " << escape_name(path.from) << " " << escape_name(path.to) << " ";
                     write_delay(out, path.delay);
                     out << ")" << std::endl;
                 }
@@ -174,27 +204,116 @@ struct SDFWriter
             }
             out << "    )" << std::endl;
         }
-        // Write interconnect delays, with the main design begin a "cell"
-        out << "  (CELL" << std::endl;
-        out << "    (CELLTYPE " << format_name(design) << ")" << std::endl;
-        out << "    (DELAY" << std::endl;
-        out << "      (ABSOLUTE" << std::endl;
-        for (auto &ic : conn) {
-            out << "        (INTERCONNECT ";
-            write_port(out, ic.from);
-            out << " ";
-            write_port(out, ic.to);
-            out << " ";
-            write_delay(out, ic.delay);
-            out << std::endl;
-        }
-        out << "      )" << std::endl;
-        out << "    )" << std::endl;
-        out << "  )" << std::endl;
         out << ")" << std::endl;
     }
 };
 
 } // namespace SDF
+
+void Context::writeSDF(std::ostream &out) const
+{
+    using namespace SDF;
+    SDFWriter wr;
+    wr.design = str_or_default(attrs, id("module"), "top");
+    wr.sdfversion = "3.0";
+    wr.vendor = "nextpnr";
+    wr.program = "nextpnr";
+
+    const double delay_scale = 1000;
+    // Convert from DelayInfo to SDF-friendly RiseFallDelay
+    auto convert_delay = [&](const DelayInfo &dly) {
+        RiseFallDelay rf;
+        rf.rise.min = getDelayNS(dly.minRaiseDelay()) * delay_scale;
+        rf.rise.typ = getDelayNS((dly.minRaiseDelay() + dly.maxRaiseDelay()) / 2) * delay_scale; // fixme: typ delays?
+        rf.rise.max = getDelayNS(dly.maxRaiseDelay()) * delay_scale;
+        rf.fall.min = getDelayNS(dly.minFallDelay()) * delay_scale;
+        rf.fall.typ = getDelayNS((dly.minFallDelay() + dly.maxFallDelay()) / 2) * delay_scale; // fixme: typ delays?
+        rf.fall.max = getDelayNS(dly.maxFallDelay()) * delay_scale;
+        return rf;
+    };
+
+    auto convert_setuphold = [&](const DelayInfo &setup, const DelayInfo &hold) {
+        RiseFallDelay rf;
+        rf.rise.min = getDelayNS(setup.minDelay()) * delay_scale;
+        rf.rise.typ = getDelayNS((setup.minDelay() + setup.maxDelay()) / 2) * delay_scale; // fixme: typ delays?
+        rf.rise.max = getDelayNS(setup.maxDelay()) * delay_scale;
+        rf.fall.min = getDelayNS(hold.minDelay()) * delay_scale;
+        rf.fall.typ = getDelayNS((hold.minDelay() + hold.maxDelay()) / 2) * delay_scale; // fixme: typ delays?
+        rf.fall.max = getDelayNS(hold.maxDelay()) * delay_scale;
+        return rf;
+    };
+
+    for (auto cell : sorted(cells)) {
+        Cell sc;
+        const CellInfo *ci = cell.second;
+        sc.instance = ci->name.str(this);
+        sc.celltype = ci->type.str(this);
+        for (auto port : ci->ports) {
+            int clockCount = 0;
+            TimingPortClass cls = getPortTimingClass(ci, port.first, clockCount);
+            if (cls == TMG_IGNORE)
+                continue;
+            if (port.second.type != PORT_IN) {
+                // Add combinational paths to this output (or inout)
+                for (auto other : ci->ports) {
+                    if (other.second.type == PORT_OUT)
+                        continue;
+                    DelayInfo dly;
+                    if (!getCellDelay(ci, other.first, port.first, dly))
+                        continue;
+                    IOPath iop;
+                    iop.from = other.first.str(this);
+                    iop.to = port.first.str(this);
+                    iop.delay = convert_delay(dly);
+                    sc.iopaths.push_back(iop);
+                }
+                // Add clock-to-output delays, also as IOPaths
+                if (cls == TMG_REGISTER_OUTPUT)
+                    for (int i = 0; i < clockCount; i++) {
+                        auto clkInfo = getPortClockingInfo(ci, port.first, i);
+                        IOPath cqp;
+                        cqp.from = clkInfo.clock_port.str(this);
+                        cqp.to = port.first.str(this);
+                        cqp.delay = convert_delay(clkInfo.clockToQ);
+                        sc.iopaths.push_back(cqp);
+                    }
+            }
+            if (port.second.type != PORT_OUT && cls == TMG_REGISTER_INPUT) {
+                // Add setup/hold checks
+                for (int i = 0; i < clockCount; i++) {
+                    auto clkInfo = getPortClockingInfo(ci, port.first, i);
+                    TimingCheck chk;
+                    chk.from.edge = RISING_EDGE; // Add setup/hold checks equally for rising and falling edges
+                    chk.from.port = port.first.str(this);
+                    chk.to.edge = clkInfo.edge;
+                    chk.to.port = clkInfo.clock_port.str(this);
+                    chk.type = TimingCheck::SETUPHOLD;
+                    chk.delay = convert_setuphold(clkInfo.setup, clkInfo.hold);
+                    sc.checks.push_back(chk);
+                    chk.from.edge = FALLING_EDGE;
+                    sc.checks.push_back(chk);
+                }
+            }
+        }
+        wr.cells.push_back(sc);
+    }
+
+    for (auto net : sorted(nets)) {
+        NetInfo *ni = net.second;
+        if (ni->driver.cell == nullptr)
+            continue;
+        for (auto &usr : ni->users) {
+            Interconnect ic;
+            ic.from.cell = ni->driver.cell->name.str(this);
+            ic.from.port = ni->driver.port.str(this);
+            ic.to.cell = usr.cell->name.str(this);
+            ic.to.port = usr.port.str(this);
+            // FIXME: min/max routing delay - or at least constructing DelayInfo here
+            ic.delay = convert_delay(getDelayFromNS(getDelayNS(getNetinfoRouteDelay(ni, usr))));
+            wr.conn.push_back(ic);
+        }
+    }
+    wr.write(out);
+}
 
 NEXTPNR_NAMESPACE_END

--- a/common/sdf.cc
+++ b/common/sdf.cc
@@ -253,9 +253,13 @@ void Context::writeSDF(std::ostream &out) const
             TimingPortClass cls = getPortTimingClass(ci, port.first, clockCount);
             if (cls == TMG_IGNORE)
                 continue;
+            if (port.second.net == nullptr)
+                continue; // Ignore disconnected ports
             if (port.second.type != PORT_IN) {
                 // Add combinational paths to this output (or inout)
                 for (auto other : ci->ports) {
+                    if (other.second.net == nullptr)
+                        continue;
                     if (other.second.type == PORT_OUT)
                         continue;
                     DelayInfo dly;

--- a/ecp5/cells.cc
+++ b/ecp5/cells.cc
@@ -419,9 +419,9 @@ void nxio_to_tr(Context *ctx, CellInfo *nxio, CellInfo *trio, std::vector<std::u
     NetInfo *donet = trio->ports.at(ctx->id("I")).net, *dinet = trio->ports.at(ctx->id("O")).net;
 
     // Rename I/O nets to avoid conflicts
-    if (donet != nullptr)
+    if (donet != nullptr && donet->name == nxio->name)
         rename_net(ctx, donet, ctx->id(donet->name.str(ctx) + "$TRELLIS_IO_OUT"));
-    if (dinet != nullptr)
+    if (dinet != nullptr && dinet->name == nxio->name)
         rename_net(ctx, dinet, ctx->id(dinet->name.str(ctx) + "$TRELLIS_IO_IN"));
 
     // Create a new top port net for accurate IO timing analysis and simulation netlists

--- a/ecp5/pack.cc
+++ b/ecp5/pack.cc
@@ -362,8 +362,7 @@ class Ecp5Packer
                     for (auto &port : ci->ports)
                         disconnect_port(ctx, ci, port.first);
                 } else if (trio != nullptr) {
-                    // Trivial case, TRELLIS_IO used. Just destroy the net and the
-                    // iobuf
+                    // Trivial case, TRELLIS_IO used. Just remove the IOBUF
                     log_info("%s feeds TRELLIS_IO %s, removing %s %s.\n", ci->name.c_str(ctx), trio->name.c_str(ctx),
                              ci->type.c_str(ctx), ci->name.c_str(ctx));
 
@@ -383,14 +382,6 @@ class Ecp5Packer
                                 // Move clock constraint from IO pad to input buffer output
                                 std::swap(net->clkconstr, onet->clkconstr);
                             }
-                        }
-                        ctx->nets.erase(net->name);
-                        trio->ports.at(ctx->id("B")).net = nullptr;
-                    }
-                    if (ci->type == ctx->id("$nextpnr_iobuf")) {
-                        NetInfo *net2 = ci->ports.at(ctx->id("I")).net;
-                        if (net2 != nullptr) {
-                            ctx->nets.erase(net2->name);
                         }
                     }
                 } else if (drives_top_port(ionet, tp)) {
@@ -414,7 +405,8 @@ class Ecp5Packer
                     new_cells.push_back(std::move(tr_cell));
                     trio = new_cells.back().get();
                 }
-
+                for (auto port : ci->ports)
+                    disconnect_port(ctx, ci, port.first);
                 packed_cells.insert(ci->name);
                 if (trio != nullptr) {
                     for (const auto &attr : ci->attrs)

--- a/ice40/cells.cc
+++ b/ice40/cells.cc
@@ -69,7 +69,7 @@ std::unique_ptr<CellInfo> create_ice_cell(Context *ctx, IdString type, std::stri
         new_cell->params[ctx->id("PIN_TYPE")] = Property(0, 6);
         new_cell->params[ctx->id("PULLUP")] = Property::State::S0;
         new_cell->params[ctx->id("NEG_TRIGGER")] = Property::State::S0;
-        new_cell->params[ctx->id("IOSTANDARD")] = Property("SB_LVCMOS");
+        new_cell->params[ctx->id("IO_STANDARD")] = Property("SB_LVCMOS");
 
         add_port(ctx, new_cell.get(), "PACKAGE_PIN", PORT_INOUT);
 


### PR DESCRIPTION
SDF timing simulation requires some changes to the Yosys cell library that are still being worked on. Furthermore a closed source simulator (e.g. xsim) seems to be required; iverilog's SDF support seems to be too limited, in particular not supporting interconnect delays.