### PR TITLE
ice40: cmake: fix build with pregenerated bba path

### DIFF
--- a/ice40/family.cmake
+++ b/ice40/family.cmake
@@ -40,14 +40,6 @@ if (NOT EXTERNAL_CHIPDB)
             set(DEV_CC_DB ${CMAKE_CURRENT_BINARY_DIR}/ice40/chipdbs/chipdb-${dev}.bin)
             set(DEV_CONSTIDS_INC ${CMAKE_CURRENT_SOURCE_DIR}/ice40/constids.inc)
             set(DEV_GFXH ${CMAKE_CURRENT_SOURCE_DIR}/ice40/gfx.h)
-            add_custom_command(OUTPUT ${DEV_CC_BBA_DB}
-                COMMAND ${PYTHON_EXECUTABLE} ${DB_PY} -p ${DEV_CONSTIDS_INC} -g ${DEV_GFXH} ${OPT_FAST} ${OPT_SLOW} ${DEV_TXT_DB} > ${DEV_CC_BBA_DB}
-                DEPENDS ${DEV_CONSTIDS_INC} ${DEV_GFXH} ${DEV_TXT_DB} ${DB_PY} ${PREV_DEV_CC_BBA_DB}
-                )
-            add_custom_command(OUTPUT ${DEV_CC_DB}
-                COMMAND bbasm ${BBASM_ENDIAN_FLAG} ${DEV_CC_BBA_DB} ${DEV_CC_DB}
-                DEPENDS bbasm ${DEV_CC_BBA_DB}
-                )
 
             if(PREGENERATED_BBA_PATH)
                 add_custom_command(OUTPUT ${DEV_CC_DB}


### PR DESCRIPTION
When building using non-pregenerated bba files, the rule to create bbasm
files gets called twice: once unconditionally, and once as part of the
conditional that determines we're not using a pregenerated bba path.

If we _are_ using a pregenerated bba path, then this rule gets called
anyway, resulting in a build error.

Remove the duplicate, unconditional creation of the bba file generation,
to fix the build when using pregenerated files, and to speed up the
build when not using pregenerated files.