### PR TITLE
Dedicated output for LUT in GENERIC_SLICE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ CMakeCache.txt
 .*.swp
 a.out
 *.json
+*.dot
+*.il
+/generic/examples/blinky.png
 build/
 *.asc
 *.bin

--- a/generic/cells.cc
+++ b/generic/cells.cc
@@ -44,13 +44,13 @@ std::unique_ptr<CellInfo> create_generic_cell(Context *ctx, IdString type, std::
     if (type == ctx->id("GENERIC_SLICE")) {
         new_cell->params[ctx->id("K")] = std::to_string(ctx->args.K);
         new_cell->params[ctx->id("INIT")] = 0;
-        new_cell->params[ctx->id("FF_USED")] = 0;
 
         for (int i = 0; i < ctx->args.K; i++)
             add_port(ctx, new_cell.get(), "I[" + std::to_string(i) + "]", PORT_IN);
 
         add_port(ctx, new_cell.get(), "CLK", PORT_IN);
 
+        add_port(ctx, new_cell.get(), "F", PORT_OUT);
         add_port(ctx, new_cell.get(), "Q", PORT_OUT);
     } else if (type == ctx->id("GENERIC_IOB")) {
         new_cell->params[ctx->id("INPUT_USED")] = 0;
@@ -80,18 +80,16 @@ void lut_to_lc(const Context *ctx, CellInfo *lut, CellInfo *lc, bool no_dff)
     }
 
     if (no_dff) {
-        replace_port(lut, ctx->id("Q"), lc, ctx->id("Q"));
-        lc->params[ctx->id("FF_USED")] = 0;
+        replace_port(lut, ctx->id("Q"), lc, ctx->id("F"));
     }
 }
 
 void dff_to_lc(const Context *ctx, CellInfo *dff, CellInfo *lc, bool pass_thru_lut)
 {
-    lc->params[ctx->id("FF_USED")] = 1;
     replace_port(dff, ctx->id("CLK"), lc, ctx->id("CLK"));
 
     if (pass_thru_lut) {
-        lc->params[ctx->id("INIT")] = 2;
+        lc->params[ctx->id("INIT")] = 0xAAAA;
         replace_port(dff, ctx->id("D"), lc, ctx->id("I[0]"));
     }
 

--- a/generic/cells.cc
+++ b/generic/cells.cc
@@ -42,8 +42,9 @@ std::unique_ptr<CellInfo> create_generic_cell(Context *ctx, IdString type, std::
     }
     new_cell->type = type;
     if (type == ctx->id("GENERIC_SLICE")) {
-        new_cell->params[ctx->id("K")] = std::to_string(ctx->args.K);
+        new_cell->params[ctx->id("K")] = ctx->args.K;
         new_cell->params[ctx->id("INIT")] = 0;
+        new_cell->params[ctx->id("FF_USED")] = 0;
 
         for (int i = 0; i < ctx->args.K; i++)
             add_port(ctx, new_cell.get(), "I[" + std::to_string(i) + "]", PORT_IN);
@@ -80,16 +81,25 @@ void lut_to_lc(const Context *ctx, CellInfo *lut, CellInfo *lc, bool no_dff)
     }
 
     if (no_dff) {
+        lc->params[ctx->id("FF_USED")] = 0;
         replace_port(lut, ctx->id("Q"), lc, ctx->id("F"));
     }
 }
 
 void dff_to_lc(const Context *ctx, CellInfo *dff, CellInfo *lc, bool pass_thru_lut)
 {
+    lc->params[ctx->id("FF_USED")] = 1;
     replace_port(dff, ctx->id("CLK"), lc, ctx->id("CLK"));
 
     if (pass_thru_lut) {
-        lc->params[ctx->id("INIT")] = 0xAAAA;
+        // Fill LUT with alternating 10
+        const int init_size = 1 << lc->params[ctx->id("K")].as_int64();
+        std::string init;
+        init.reserve(init_size);
+        for(int i = 0; i < init_size; i+=2)
+            init.append("10");
+        lc->params[ctx->id("INIT")] = Property::from_string(init);
+
         replace_port(dff, ctx->id("D"), lc, ctx->id("I[0]"));
     }
 

--- a/generic/examples/bitstream.py
+++ b/generic/examples/bitstream.py
@@ -6,7 +6,6 @@ from simple_config import K
 param_map = {
 	("GENERIC_SLICE", "K"): ParameterConfig(write=False),
 	("GENERIC_SLICE", "INIT"): ParameterConfig(write=True, numeric=True, width=2**K),
-	("GENERIC_SLICE", "FF_USED"): ParameterConfig(write=True, numeric=True, width=1),
 
 	("GENERIC_IOB", "INPUT_USED"): ParameterConfig(write=True, numeric=True, width=1),
 	("GENERIC_IOB", "OUTPUT_USED"): ParameterConfig(write=True, numeric=True, width=1),

--- a/generic/examples/bitstream.py
+++ b/generic/examples/bitstream.py
@@ -6,6 +6,7 @@ from simple_config import K
 param_map = {
 	("GENERIC_SLICE", "K"): ParameterConfig(write=False),
 	("GENERIC_SLICE", "INIT"): ParameterConfig(write=True, numeric=True, width=2**K),
+	("GENERIC_SLICE", "FF_USED"): ParameterConfig(write=True, numeric=True, width=1),
 
 	("GENERIC_IOB", "INPUT_USED"): ParameterConfig(write=True, numeric=True, width=1),
 	("GENERIC_IOB", "OUTPUT_USED"): ParameterConfig(write=True, numeric=True, width=1),

--- a/generic/examples/simple.py
+++ b/generic/examples/simple.py
@@ -9,6 +9,7 @@ for x in range(X):
 		for z in range(N):
 			ctx.addWire(name="X%dY%dZ%d_CLK" % (x, y, z), type="BEL_CLK", x=x, y=y)
 			ctx.addWire(name="X%dY%dZ%d_Q" % (x, y, z), type="BEL_Q", x=x, y=y)
+			ctx.addWire(name="X%dY%dZ%d_F" % (x, y, z), type="BEL_F", x=x, y=y)
 			for i in range(K):
 				ctx.addWire(name="X%dY%dZ%d_I%d" % (x, y, z, i), type="BEL_I", x=x, y=y)
 		# Local wires
@@ -29,6 +30,7 @@ for x in range(X):
 				ctx.addBelInput(bel="X%dY%d_SLICE%d" % (x, y, z), name="CLK", wire="X%dY%dZ%d_CLK" % (x, y, z))
 				for k in range(K):
 					ctx.addBelInput(bel="X%dY%d_SLICE%d" % (x, y, z), name="I[%d]" % k, wire="X%dY%dZ%d_I%d" % (x, y, z, k))
+				ctx.addBelOutput(bel="X%dY%d_SLICE%d" % (x, y, z), name="F", wire="X%dY%dZ%d_F" % (x, y, z))
 				ctx.addBelOutput(bel="X%dY%d_SLICE%d" % (x, y, z), name="Q", wire="X%dY%dZ%d_Q" % (x, y, z))
 
 for x in range(X):
@@ -48,6 +50,9 @@ for x in range(X):
 		# Pips from bel outputs to locals
 		def create_output_pips(dst, offset, skip):
 			for i in range(offset % skip, N, skip):
+				src = "X%dY%dZ%d_F" % (x, y, i)
+				ctx.addPip(name="X%dY%d.%s.%s" % (x, y, src, dst), type="BEL_OUTPUT",
+					srcWire=src, dstWire=dst, delay=ctx.getDelayFromNS(0.05), loc=Loc(x, y, 0))
 				src = "X%dY%dZ%d_Q" % (x, y, i)
 				ctx.addPip(name="X%dY%d.%s.%s" % (x, y, src, dst), type="BEL_OUTPUT",
 					srcWire=src, dstWire=dst, delay=ctx.getDelayFromNS(0.05), loc=Loc(x, y, 0))

--- a/generic/examples/simple.sh
+++ b/generic/examples/simple.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -ex
 yosys -p "tcl ../synth/synth_generic.tcl 4 blinky.json" blinky.v
-${NEXTPNR:-../../nextpnr-generic} --pre-pack simple.py --pre-place simple_timing.py --json blinky.json --post-route bitstream.py
+${NEXTPNR:-../../nextpnr-generic} --pre-pack simple.py --pre-place simple_timing.py --json blinky.json --post-route bitstream.py --write pnrblinky.json
+yosys -p "read_verilog -lib ../synth/prims.v; read_json pnrblinky.json; dump -o blinky.il; show -format png -prefix blinky"

--- a/generic/examples/simple_timing.py
+++ b/generic/examples/simple_timing.py
@@ -1,15 +1,13 @@
 for cname, cell in ctx.cells:
-	if cell.type != "GENERIC_SLICE":
-		continue
-	if cname in ("$PACKER_GND", "$PACKER_VCC"):
-		continue
-	K = int(cell.params["K"])
-	if int(cell.params["FF_USED"], 2) == 1:
-		ctx.addCellTimingClock(cell=cname, port="CLK")
-		for i in range(K):
-			ctx.addCellTimingSetupHold(cell=cname, port="I[%d]" % i, clock="CLK",
-				setup=ctx.getDelayFromNS(0.2), hold=ctx.getDelayFromNS(0))
-		ctx.addCellTimingClockToOut(cell=cname, port="Q", clock="CLK", clktoq=ctx.getDelayFromNS(0.2))
-	else:
-		for i in range(K):
-			ctx.addCellTimingDelay(cell=cname, fromPort="I[%d]" % i, toPort="Q", delay=ctx.getDelayFromNS(0.2))
+    if cell.type != "GENERIC_SLICE":
+        continue
+    if cname in ("$PACKER_GND", "$PACKER_VCC"):
+        continue
+    K = int(cell.params["K"])
+    ctx.addCellTimingClock(cell=cname, port="CLK")
+    for i in range(K):
+        ctx.addCellTimingSetupHold(cell=cname, port="I[%d]" % i, clock="CLK",
+            setup=ctx.getDelayFromNS(0.2), hold=ctx.getDelayFromNS(0))
+    ctx.addCellTimingClockToOut(cell=cname, port="Q", clock="CLK", clktoq=ctx.getDelayFromNS(0.2))
+    for i in range(K):
+        ctx.addCellTimingDelay(cell=cname, fromPort="I[%d]" % i, toPort="F", delay=ctx.getDelayFromNS(0.2))

--- a/generic/synth/prims.v
+++ b/generic/synth/prims.v
@@ -21,21 +21,19 @@ endmodule
 module GENERIC_SLICE #(
 	parameter K = 4,
 	parameter [2**K-1:0] INIT = 0,
-	parameter FF_USED = 1'b0
 ) (
 	input CLK,
 	input [K-1:0] I,
+  output F,
 	output Q
 );
+  wire f_wire;
 	
-	wire lut_q;
-	LUT #(.K(K), .INIT(INIT)) lut_i(.I(I), .Q(lut_q));
+	LUT #(.K(K), .INIT(INIT)) lut_i(.I(I), .Q(f_wire));
 
-	generate if (FF_USED)
-		DFF dff_i(.CLK(CLK), .D(lut_q), .Q(Q));
-	else
-		assign Q = lut_q; 
-	endgenerate
+  DFF dff_i(.CLK(CLK), .D(f_wire), .Q(Q));
+
+  assign F = f_wire;
 endmodule
 
 module GENERIC_IOB #(

--- a/generic/synth/prims.v
+++ b/generic/synth/prims.v
@@ -21,19 +21,20 @@ endmodule
 module GENERIC_SLICE #(
 	parameter K = 4,
 	parameter [2**K-1:0] INIT = 0,
+  parameter FF_USED = 1'b0
 ) (
 	input CLK,
 	input [K-1:0] I,
   output F,
 	output Q
 );
-  wire f_wire;
+	wire f_wire;
 	
 	LUT #(.K(K), .INIT(INIT)) lut_i(.I(I), .Q(f_wire));
 
-  DFF dff_i(.CLK(CLK), .D(f_wire), .Q(Q));
+	DFF dff_i(.CLK(CLK), .D(f_wire), .Q(Q));
 
-  assign F = f_wire;
+	assign F = f_wire;
 endmodule
 
 module GENERIC_IOB #(

--- a/generic/synth/prims.v
+++ b/generic/synth/prims.v
@@ -21,11 +21,11 @@ endmodule
 module GENERIC_SLICE #(
 	parameter K = 4,
 	parameter [2**K-1:0] INIT = 0,
-  parameter FF_USED = 1'b0
+	parameter FF_USED = 1'b0
 ) (
 	input CLK,
 	input [K-1:0] I,
-  output F,
+	output F,
 	output Q
 );
 	wire f_wire;


### PR DESCRIPTION
Currently the GENERIC_SLICE has one Q output that is either used by the DFF output or by the LUT output. However, it appears that most FPGA architectures have a seperate output for the LUT that bypasses the DFF.

This PR adds an F output to GENERIC_SLICE that is the direct output of the LUT, and removes the FF_USED parameter.