### PR TITLE
Add bba #embed support

### DIFF
--- a/bba/main.cc
+++ b/bba/main.cc
@@ -445,9 +445,9 @@ int main(int argc, char **argv)
         for (auto &s : preText)
             fprintf(fileOut, "%s\n", s.c_str());
 
-        fprintf(fileOut, "const char %s[%d] =\n", streams[0].name.c_str(), int(data.size()));
+        fprintf(fileOut, "const char %s[%d] =\n", streams[0].name.c_str(), int(data.size()) + 1);
         char *bin_basename_buf = strdup(files.at(2).c_str());
-        fprintf(fileOut, "#embed \"%s\"\n", basename(bin_basename_buf));
+        fprintf(fileOut, "#embed_str \"%s\"\n", basename(bin_basename_buf));
         fprintf(fileOut, ";\n");
 
         for (auto &s : postText)

--- a/bba/main.cc
+++ b/bba/main.cc
@@ -72,6 +72,7 @@ int main(int argc, char **argv)
     bool verbose = false;
     bool bigEndian;
     bool writeC = false;
+    bool writeE = false;
     char buffer[512];
 
     namespace po = boost::program_options;
@@ -82,7 +83,8 @@ int main(int argc, char **argv)
     options.add_options()("debug,d", "debug output");
     options.add_options()("be,b", "big endian");
     options.add_options()("le,l", "little endian");
-    options.add_options()("c,c", "write c strings");
+    options.add_options()("c,c", "write C strings");
+    options.add_options()("e,e", "write #embed C");
     options.add_options()("files", po::value<std::vector<std::string>>(), "file parameters");
     pos.add("files", -1);
 
@@ -115,13 +117,19 @@ int main(int argc, char **argv)
     }
     if (vm.count("c"))
         writeC = true;
+    if (vm.count("e"))
+        writeE = true;
 
+    if (writeC && writeE) {
+        printf("Incompatible modes\n");
+        exit(-1);
+    }
     if (vm.count("files") == 0) {
         printf("File parameters are mandatory\n");
         exit(-1);
     }
     std::vector<std::string> files = vm["files"].as<std::vector<std::string>>();
-    if (files.size() != 2) {
+    if (files.size() != (writeE ? 3 : 2)) {
         printf("Input and output parameters must be set\n");
         exit(-1);
     }
@@ -433,6 +441,22 @@ int main(int argc, char **argv)
 
         for (auto &s : postText)
             fprintf(fileOut, "%s\n", s.c_str());
+    } else if (writeE) {
+        for (auto &s : preText)
+            fprintf(fileOut, "%s\n", s.c_str());
+
+        fprintf(fileOut, "const char %s[%d] =\n", streams[0].name.c_str(), int(data.size()));
+        char *bin_basename_buf = strdup(files.at(2).c_str());
+        fprintf(fileOut, "#embed \"%s\"\n", basename(bin_basename_buf));
+        fprintf(fileOut, ";\n");
+
+        for (auto &s : postText)
+            fprintf(fileOut, "%s\n", s.c_str());
+
+        FILE *fileBin = fopen(files.at(2).c_str(), "wb");
+        assert(fileBin != nullptr);
+        fwrite(data.data(), int(data.size()), 1, fileBin);
+        fclose(fileBin);
     } else {
         fwrite(data.data(), int(data.size()), 1, fileOut);
     }

--- a/ice40/family.cmake
+++ b/ice40/family.cmake
@@ -84,6 +84,7 @@ if (NOT EXTERNAL_CHIPDB)
             set(DEV_TXT_DB ${ICEBOX_ROOT}/chipdb-${dev}.txt)
             set(DEV_CC_BBA_DB ${CMAKE_CURRENT_SOURCE_DIR}/ice40/chipdbs/chipdb-${dev}.bba)
             set(DEV_CC_DB ${CMAKE_CURRENT_BINARY_DIR}/ice40/chipdbs/chipdb-${dev}.cc)
+            set(DEV_BIN_DB ${CMAKE_CURRENT_BINARY_DIR}/ice40/chipdbs/chipdb-${dev}.bin)
             set(DEV_CONSTIDS_INC ${CMAKE_CURRENT_SOURCE_DIR}/ice40/constids.inc)
             set(DEV_GFXH ${CMAKE_CURRENT_SOURCE_DIR}/ice40/gfx.h)
             if(PREGENERATED_BBA_PATH)
@@ -97,11 +98,19 @@ if (NOT EXTERNAL_CHIPDB)
                     COMMAND mv ${DEV_CC_BBA_DB}.new ${DEV_CC_BBA_DB}
                     DEPENDS ${DEV_CONSTIDS_INC} ${DEV_GFXH} ${DEV_TXT_DB} ${DB_PY} ${PREV_DEV_CC_BBA_DB}
                     )
-                add_custom_command(OUTPUT ${DEV_CC_DB}
-                    COMMAND bbasm --c ${BBASM_ENDIAN_FLAG} ${DEV_CC_BBA_DB} ${DEV_CC_DB}.new
-                    COMMAND mv ${DEV_CC_DB}.new ${DEV_CC_DB}
-                    DEPENDS bbasm ${DEV_CC_BBA_DB}
-                    )
+                if(USE_C_EMBED)
+                    add_custom_command(OUTPUT ${DEV_CC_DB}
+                        COMMAND bbasm --e ${BBASM_ENDIAN_FLAG} ${DEV_CC_BBA_DB} ${DEV_CC_DB}.new ${DEV_BIN_DB}
+                        COMMAND mv ${DEV_CC_DB}.new ${DEV_CC_DB}
+                        DEPENDS bbasm ${DEV_CC_BBA_DB}
+                        )
+                else()
+                    add_custom_command(OUTPUT ${DEV_CC_DB}
+                        COMMAND bbasm --c ${BBASM_ENDIAN_FLAG} ${DEV_CC_BBA_DB} ${DEV_CC_DB}.new
+                        COMMAND mv ${DEV_CC_DB}.new ${DEV_CC_DB}
+                        DEPENDS bbasm ${DEV_CC_BBA_DB}
+                        )
+                endif()
             endif()
             if (SERIALIZE_CHIPDB)
                 set(PREV_DEV_CC_BBA_DB ${DEV_CC_BBA_DB})


### PR DESCRIPTION
Disabled by default. Use `cmake -DUSE_C_EMBED=1` to enable. `#embed_str` is part of [P1040](https://thephd.github.io/vendor/future_cxx/papers/d1040.html).