### PR TITLE
Add missing header to main.cc

### DIFF
--- a/bba/main.cc
+++ b/bba/main.cc
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <string>
 #include <vector>
+#include <libgen.h>
 
 enum TokenType : int8_t
 {


### PR DESCRIPTION
This fixes building with clang on OS X.

Fixes #366.