### PR TITLE
[DOC] Fixing typo: cmake test suite triggered by 'make test'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Notes for developers
 Testing
 -------
 
-- To build test binaries as well, use `-DBUILD_TESTS=ON` and after `make` run `make tests` to run them, or you can run separate binaries.
+- To build test binaries as well, use `-DBUILD_TESTS=ON` and after `make` run `make test` to run them, or you can run separate binaries.
 - To use code sanitizers use the `cmake` options:
   - `-DSANITIZE_ADDRESS=ON`
   - `-DSANITIZE_MEMORY=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++`


### PR DESCRIPTION
Brand new to FPGA ! iverilog, yosys and nextpnr without problems.
Pushing what I believe to be a typo.

Franck

Running on debian/testing:

```
>> cmake -DARCH=generic -DCMAKE_INSTALL_PREFIX=/scratch/fghp/FPGA/nextpnr/local -DBUILD_TESTS=ON ..; make
>> make tests
make: *** No rule to make target 'tests'.  Stop.
>> make test
Running tests...
Test project /scratch/fghp/FPGA/nextpnr/build
    Start 1: generic-test
1/1 Test #1: generic-test .....................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.01 sec

```