### PR TITLE
Change version to git describe and make set-able from outside

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,13 +121,17 @@ else()
     add_definitions("-DNO_GUI")
 endif()
 
-# Get the latest abbreviated commit hash of the working branch
-execute_process(
-  COMMAND git log -1 --format=%h
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE GIT_COMMIT_HASH
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+if (NOT DEFINED CURRENT_GIT_VERSION)
+    # Get the latest abbreviated commit hash of the working branch
+    # if not already defined outside (e.g. by package manager when building
+    # outside of git repository)
+    execute_process(
+      COMMAND git describe --tags --always
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      OUTPUT_VARIABLE CURRENT_GIT_VERSION
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+endif()
 
 if (BUILD_TESTS)
     add_subdirectory(3rdparty/googletest/googletest ${CMAKE_CURRENT_BINARY_DIR}/generated/3rdparty/googletest EXCLUDE_FROM_ALL)
@@ -137,8 +141,6 @@ endif()
 if (BUILD_GUI)
     add_subdirectory(3rdparty/QtPropertyBrowser ${CMAKE_CURRENT_BINARY_DIR}/generated/3rdparty/QtPropertyBrowser EXCLUDE_FROM_ALL)
 endif()
-
-add_definitions("-DGIT_COMMIT_HASH=${GIT_COMMIT_HASH}")
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/common/version.h.in ${CMAKE_CURRENT_BINARY_DIR}/generated/version.h

--- a/common/command.cc
+++ b/common/command.cc
@@ -69,14 +69,14 @@ bool CommandHandler::executeBeforeContext()
 {
     if (vm.count("help") || argc == 1) {
         std::cerr << boost::filesystem::basename(argv[0])
-                  << " -- Next Generation Place and Route (git sha1 " GIT_COMMIT_HASH_STR ")\n";
+                  << " -- Next Generation Place and Route (Version " GIT_DESCRIBE_STR ")\n";
         std::cerr << options << "\n";
         return argc != 1;
     }
 
     if (vm.count("version")) {
         std::cerr << boost::filesystem::basename(argv[0])
-                  << " -- Next Generation Place and Route (git sha1 " GIT_COMMIT_HASH_STR ")\n";
+                  << " -- Next Generation Place and Route (Version " GIT_DESCRIBE_STR ")\n";
         return true;
     }
     validate();

--- a/common/version.h.in
+++ b/common/version.h.in
@@ -1,6 +1,6 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define GIT_COMMIT_HASH_STR "@GIT_COMMIT_HASH@"
+#define GIT_DESCRIBE_STR "@CURRENT_GIT_VERSION@"
 
 #endif

--- a/json/jsonwrite.cc
+++ b/json/jsonwrite.cc
@@ -214,7 +214,7 @@ void write_context(std::ostream &f, Context *ctx)
 {
     f << stringf("{\n");
     f << stringf("  \"creator\": %s,\n",
-                 get_string("Next Generation Place and Route (git sha1 " GIT_COMMIT_HASH_STR ")").c_str());
+                 get_string("Next Generation Place and Route (Version " GIT_DESCRIBE_STR ")").c_str());
     f << stringf("  \"modules\": {\n");
     write_module(f, ctx);
     f << stringf("\n  }");


### PR DESCRIPTION
Change version to use git describe instead of git log as this will also work
if tags are present and make the version string set-able from outside as a
parameter to cmake, so that package managers can set this if building outside
of a git working tree.