### PR TITLE
Warning fixes

### DIFF
--- a/3rdparty/QtPropertyBrowser/src/qteditorfactory.cpp
+++ b/3rdparty/QtPropertyBrowser/src/qteditorfactory.cpp
@@ -2207,9 +2207,9 @@ void QtColorEditWidget::buttonClicked()
 {
     bool ok = false;
     QRgb oldRgba = m_color.rgba();
-    QRgb newRgba = QColorDialog::getRgba(oldRgba, &ok, this);
-    if (ok && newRgba != oldRgba) {
-        setValue(QColor::fromRgba(newRgba));
+    QColor newRgba = QColorDialog::getColor(oldRgba, this).rgba();
+    if (newRgba.isValid() && newRgba.rgba() != oldRgba) {
+        setValue(newRgba);
         emit valueChanged(m_color);
     }
 }

--- a/3rdparty/QtPropertyBrowser/src/qttreepropertybrowser.cpp
+++ b/3rdparty/QtPropertyBrowser/src/qttreepropertybrowser.cpp
@@ -609,7 +609,7 @@ void QtTreePropertyBrowserPrivate::propertyInserted(QtBrowserItem *index, QtBrow
     m_indexToItem[index] = newItem;
 
     newItem->setFlags(newItem->flags() | Qt::ItemIsEditable);
-    m_treeWidget->setItemExpanded(newItem, true);
+    newItem->setExpanded(true);
 
     updateItem(newItem);
 }

--- a/3rdparty/QtPropertyBrowser/src/qttreepropertybrowser.cpp
+++ b/3rdparty/QtPropertyBrowser/src/qttreepropertybrowser.cpp
@@ -132,9 +132,9 @@ public:
 protected:
     void mouseMoveEvent(QMouseEvent *event) override;
     void leaveEvent(QEvent *event) override;
-    void keyPressEvent(QKeyEvent *event);
-    void mousePressEvent(QMouseEvent *event);
-    void drawRow(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    void keyPressEvent(QKeyEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void drawRow(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
 Q_SIGNALS:
     void hoverPropertyChanged(QtBrowserItem *item);
@@ -383,7 +383,7 @@ void QtPropertyEditorDelegate::paint(QPainter *painter, const QStyleOptionViewIt
         opt.palette.setColor(QPalette::Text, opt.palette.color(QPalette::BrightText));
     } else {
         c = m_editorPrivate->calculatedBackgroundColor(m_editorPrivate->indexToBrowserItem(index));
-        if (c.isValid() && (opt.features & QStyleOptionViewItemV2::Alternate))
+        if (c.isValid() && (opt.features & QStyleOptionViewItem::Alternate))
             c = c.lighter(112);
     }
     if (c.isValid())

--- a/3rdparty/QtPropertyBrowser/src/qtvariantproperty.cpp
+++ b/3rdparty/QtPropertyBrowser/src/qtvariantproperty.cpp
@@ -576,7 +576,7 @@ void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, con
 void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, const QKeySequence &val)
 {
     QVariant v;
-    qVariantSetValue(v, val);
+    v.setValue(val);
     valueChanged(property, v);
 }
 
@@ -663,7 +663,7 @@ void QtVariantPropertyManagerPrivate::slotEnumIconsChanged(QtProperty *property,
 {
     if (QtVariantProperty *varProp = m_internalToProperty.value(property, 0)) {
         QVariant v;
-        qVariantSetValue(v, enumIcons);
+        v.setValue(enumIcons);
         emit q_ptr->attributeChanged(varProp, m_enumIconsAttribute, v);
     }
 }
@@ -1567,7 +1567,7 @@ QVariant QtVariantPropertyManager::attributeValue(const QtProperty *property, co
             return enumManager->enumNames(internProp);
         if (attribute == d_ptr->m_enumIconsAttribute) {
             QVariant v;
-            qVariantSetValue(v, enumManager->enumIcons(internProp));
+            v.setValue(enumManager->enumIcons(internProp));
             return v;
         }
         return QVariant();

--- a/3rdparty/imgui/imgui_internal.h
+++ b/3rdparty/imgui/imgui_internal.h
@@ -27,6 +27,9 @@
 #pragma clang diagnostic ignored "-Wunused-function"        // for stb_textedit.h
 #pragma clang diagnostic ignored "-Wmissing-prototypes"     // for stb_textedit.h
 #pragma clang diagnostic ignored "-Wold-style-cast"
+#elif defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
 
 //-----------------------------------------------------------------------------

--- a/ecp5/gfx.cc
+++ b/ecp5/gfx.cc
@@ -32,14 +32,10 @@ const float slice_pitch = 0.0374 + 0.0068;
 const float io_cell_v_x1 = 0.76;
 const float io_cell_v_x2 = 0.95;
 const float io_cell_v_y1 = 0.05;
-const float io_cell_v_y2 = 0.15;
-const float io_cell_v_pitch = 0.125;
 const float io_cell_gap = 0.10;
 const float io_cell_h_x1 = 0.05;
-const float io_cell_h_x2 = 0.14;
 const float io_cell_h_y1 = 0.05;
 const float io_cell_h_y2 = 0.24;
-const float io_cell_h_pitch = 0.125;
 
 const float wire_distance = 0.0017f;
 const float wire_distance_small = 0.00085f;

--- a/frontend/json_frontend.cc
+++ b/frontend/json_frontend.cc
@@ -46,7 +46,7 @@ struct JsonFrontendImpl
             Func(mod.first, mod.second);
     }
 
-    template <typename TFunc> void foreach_port(const ModuleDataType &mod, TFunc Func) const
+    template <typename TFunc> void foreach_port(ModuleDataType &mod, TFunc Func) const
     {
         const auto &ports = mod["ports"];
         if (ports.is_null())
@@ -55,7 +55,7 @@ struct JsonFrontendImpl
             Func(port.first, port.second);
     }
 
-    template <typename TFunc> void foreach_cell(const ModuleDataType &mod, TFunc Func) const
+    template <typename TFunc> void foreach_cell(ModuleDataType &mod, TFunc Func) const
     {
         const auto &cells = mod["cells"];
         if (cells.is_null())
@@ -64,7 +64,7 @@ struct JsonFrontendImpl
             Func(cell.first, cell.second);
     }
 
-    template <typename TFunc> void foreach_netname(const ModuleDataType &mod, TFunc Func) const
+    template <typename TFunc> void foreach_netname(ModuleDataType &mod, TFunc Func) const
     {
         const auto &netnames = mod["netnames"];
         if (netnames.is_null())
@@ -85,7 +85,7 @@ struct JsonFrontendImpl
             NPNR_ASSERT_FALSE("invalid json port direction");
     }
 
-    PortType get_port_dir(const ModulePortDataType &port) const
+    PortType get_port_dir(ModulePortDataType &port) const
     {
         return lookup_portdir(port["direction"].string_value());
     }
@@ -102,9 +102,9 @@ struct JsonFrontendImpl
         return upto.is_null() ? false : bool(upto.int_value());
     }
 
-    const BitVectorDataType &get_port_bits(const ModulePortDataType &port) const { return port["bits"].array_items(); }
+    BitVectorDataType &get_port_bits(ModulePortDataType &port) const { return port["bits"].array_items(); }
 
-    const std::string &get_cell_type(const CellDataType &cell) const { return cell["type"].string_value(); }
+    const std::string &get_cell_type(CellDataType &cell) const { return cell["type"].string_value(); }
 
     Property parse_property(const Json &val) const
     {
@@ -144,36 +144,36 @@ struct JsonFrontendImpl
         }
     }
 
-    template <typename TFunc> void foreach_port_dir(const CellDataType &cell, TFunc Func) const
+    template <typename TFunc> void foreach_port_dir(CellDataType &cell, TFunc Func) const
     {
         for (const auto &pdir : cell["port_directions"].object_items())
             Func(pdir.first, lookup_portdir(pdir.second.string_value()));
     }
 
-    template <typename TFunc> void foreach_port_conn(const CellDataType &cell, TFunc Func) const
+    template <typename TFunc> void foreach_port_conn(CellDataType &cell, TFunc Func) const
     {
         for (const auto &pconn : cell["connections"].object_items())
             Func(pconn.first, pconn.second.array_items());
     }
 
-    const BitVectorDataType &get_net_bits(const NetnameDataType &net) const { return net["bits"].array_items(); }
+    BitVectorDataType &get_net_bits(NetnameDataType &net) const { return net["bits"].array_items(); }
 
-    int get_vector_length(const BitVectorDataType &bits) const { return int(bits.size()); }
+    int get_vector_length(BitVectorDataType &bits) const { return int(bits.size()); }
 
-    bool is_vector_bit_constant(const BitVectorDataType &bits, int i) const
+    bool is_vector_bit_constant(BitVectorDataType &bits, int i) const
     {
         NPNR_ASSERT(i < int(bits.size()));
         return bits[i].is_string();
     }
 
-    char get_vector_bit_constval(const BitVectorDataType &bits, int i) const
+    char get_vector_bit_constval(BitVectorDataType &bits, int i) const
     {
         auto s = bits.at(i).string_value();
         NPNR_ASSERT(s.size() == 1);
         return s.at(0);
     }
 
-    int get_vector_bit_signal(const BitVectorDataType &bits, int i) const
+    int get_vector_bit_signal(BitVectorDataType &bits, int i) const
     {
         NPNR_ASSERT(bits.at(i).is_number());
         return bits.at(i).int_value();

--- a/generic/pack.cc
+++ b/generic/pack.cc
@@ -112,17 +112,6 @@ static void pack_nonlut_ffs(Context *ctx)
     }
 }
 
-static bool net_is_constant(const Context *ctx, NetInfo *net, bool &value)
-{
-    if (net == nullptr)
-        return false;
-    if (net->name == ctx->id("$PACKER_GND_NET") || net->name == ctx->id("$PACKER_VCC_NET")) {
-        value = (net->name == ctx->id("$PACKER_VCC_NET"));
-        return true;
-    } else {
-        return false;
-    }
-}
 
 // Merge a net into a constant net
 static void set_net_constant(const Context *ctx, NetInfo *orig, NetInfo *constnet, bool constval)

--- a/gui/treemodel.cc
+++ b/gui/treemodel.cc
@@ -93,7 +93,7 @@ void IdStringList::updateElements(Context *ctx, std::vector<IdString> elements)
     }
 
     // Sort new children
-    qSort(children_.begin(), children_.end(), [&](const Item *a, const Item *b) {
+    std::sort(children_.begin(), children_.end(), [&](const Item *a, const Item *b) {
         auto parts_a = alphaNumSplit(a->name());
         auto parts_b = alphaNumSplit(b->name());
 


### PR DESCRIPTION
Various fixes of warnings in nextpnr code.

@daveshah1 one with json_frontend.cc is due to typedef already being const others are quite straight forward

warning: 'const' qualifier on reference type 'nextpnr_generic::JsonFrontendImpl::ModuleDataType' (aka 'const json11::Json &') has no effect [-Wignored-qualifiers]
