### PR TITLE
Upstreaming router2

### DIFF
--- a/common/command.cc
+++ b/common/command.cc
@@ -132,6 +132,12 @@ po::options_description CommandHandler::getGeneralOptions()
                         "; default: " + Arch::defaultPlacer)
                     .c_str());
 
+    general.add_options()(
+            "router", po::value<std::string>(),
+            std::string("router algorithm to use; available: " + boost::algorithm::join(Arch::availableRouters, ", ") +
+                        "; default: " + Arch::defaultPlacer)
+                    .c_str());
+
     general.add_options()("slack_redist_iter", po::value<int>(), "number of iterations between slack redistribution");
     general.add_options()("cstrweight", po::value<float>(), "placer weighting for relative constraint satisfaction");
     general.add_options()("starttemp", po::value<float>(), "placer SA start temperature");
@@ -214,6 +220,15 @@ void CommandHandler::setupContext(Context *ctx)
         ctx->settings[ctx->id("placer")] = placer;
     }
 
+    if (vm.count("router")) {
+        std::string router = vm["router"].as<std::string>();
+        if (std::find(Arch::availableRouters.begin(), Arch::availableRouters.end(), router) ==
+            Arch::availableRouters.end())
+            log_error("Router algorithm '%s' is not supported (available options: %s)\n", router.c_str(),
+                      boost::algorithm::join(Arch::availableRouters, ", ").c_str());
+        ctx->settings[ctx->id("router")] = router;
+    }
+
     if (vm.count("cstrweight")) {
         ctx->settings[ctx->id("placer1/constraintWeight")] = std::to_string(vm["cstrweight"].as<float>());
     }
@@ -244,6 +259,8 @@ void CommandHandler::setupContext(Context *ctx)
         ctx->settings[ctx->id("auto_freq")] = false;
     if (ctx->settings.find(ctx->id("placer")) == ctx->settings.end())
         ctx->settings[ctx->id("placer")] = Arch::defaultPlacer;
+    if (ctx->settings.find(ctx->id("router")) == ctx->settings.end())
+        ctx->settings[ctx->id("router")] = Arch::defaultRouter;
 
     ctx->settings[ctx->id("arch.name")] = std::string(ctx->archId().c_str(ctx));
     ctx->settings[ctx->id("arch.type")] = std::string(ctx->archArgsToId(ctx->archArgs()).c_str(ctx));

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -199,6 +199,28 @@ struct Loc
     bool operator!=(const Loc &other) const { return (x != other.x) || (y != other.y) || (z != other.z); }
 };
 
+struct ArcBounds
+{
+    int x0 = -1, y0 = -1, x1 = -1, y1 = -1;
+
+    ArcBounds() {}
+    ArcBounds(int x0, int y0, int x1, int y1) : x0(x0), y0(y0), x1(x1), y1(y1){};
+
+    int distance(Loc loc) const
+    {
+        int dist = 0;
+        if (loc.x < x0)
+            dist += x0 - loc.x;
+        if (loc.x > x1)
+            dist += loc.x - x1;
+        if (loc.y < y0)
+            dist += y0 - loc.y;
+        if (loc.y > y1)
+            dist += loc.y - y1;
+        return dist;
+    };
+};
+
 struct TimingConstrObjectId
 {
     int32_t index = -1;

--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -609,9 +609,10 @@ class SAPlacer
         std::vector<std::pair<CellInfo *, BelId>> dest_bels;
         double delta = 0;
         moveChange.reset(this);
+#if 0
         if (ctx->debug)
             log_info("finding cells for chain swap %s\n", cell->name.c_str(ctx));
-
+#endif
         Loc baseLoc = ctx->getBelLocation(cell->bel);
         discover_chain(baseLoc, cell, cell_rel);
         Loc newBaseLoc = ctx->getBelLocation(newBase);
@@ -634,8 +635,10 @@ class SAPlacer
                 return false;
             dest_bels.emplace_back(std::make_pair(cr.first, targetBel));
         }
+#if 0
         if (ctx->debug)
             log_info("trying chain swap %s\n", cell->name.c_str(ctx));
+#endif
         // <cell, oldBel>
         for (const auto &db : dest_bels) {
             BelId oldBel = swap_cell_bels(db.first, db.second);
@@ -661,8 +664,10 @@ class SAPlacer
         // SA acceptance criterea
         if (delta < 0 || (temp > 1e-9 && (ctx->rng() / float(0x3fffffff)) <= std::exp(-delta / temp))) {
             n_accept++;
+#if 0
             if (ctx->debug)
                 log_info("accepted chain swap %s\n", cell->name.c_str(ctx));
+#endif
         } else {
             goto swap_fail;
         }

--- a/common/router1.cc
+++ b/common/router1.cc
@@ -813,7 +813,7 @@ bool router1(Context *ctx, const Router1Cfg &cfg)
                  std::chrono::duration<float>(rend - rstart).count());
         log_info("Routing complete.\n");
         ctx->yield();
-        log_info("Route time %.02fs\n", std::chrono::duration<float>(rend - rstart).count());
+        log_info("Router1 time %.02fs\n", std::chrono::duration<float>(rend - rstart).count());
 
 #ifndef NDEBUG
         router.check();

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -1,0 +1,202 @@
+/*
+ *  nextpnr -- Next Generation Place and Route
+ *
+ *  Copyright (C) 2019  David Shah <dave@ds0.me>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include <algorithm>
+#include <deque>
+#include <queue>
+#include "log.h"
+#include "nextpnr.h"
+#include "util.h"
+
+NEXTPNR_NAMESPACE_BEGIN
+
+namespace {
+struct Router2
+{
+    struct arc_key
+    {
+        NetInfo *net_info;
+        int user_idx;
+
+        bool operator==(const arc_key &other) const
+        {
+            return (net_info == other.net_info) && (user_idx == other.user_idx);
+        }
+        bool operator<(const arc_key &other) const
+        {
+            return net_info == other.net_info ? user_idx < other.user_idx : net_info->name < other.net_info->name;
+        }
+
+        struct Hash
+        {
+            std::size_t operator()(const arc_key &arg) const noexcept
+            {
+                std::size_t seed = std::hash<NetInfo *>()(arg.net_info);
+                seed ^= std::hash<int>()(arg.user_idx) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+                return seed;
+            }
+        };
+    };
+
+    struct arc_entry
+    {
+        arc_key arc;
+        delay_t pri;
+        int randtag = 0;
+
+        struct Less
+        {
+            bool operator()(const arc_entry &lhs, const arc_entry &rhs) const noexcept
+            {
+                if (lhs.pri != rhs.pri)
+                    return lhs.pri < rhs.pri;
+                return lhs.randtag < rhs.randtag;
+            }
+        };
+    };
+
+    struct BoundingBox
+    {
+        int x0, x1, y0, y1;
+    };
+
+    struct PerArcData
+    {
+        std::vector<std::pair<WireId, PipId>> wires;
+        BoundingBox bb;
+    };
+
+    // As we allow overlap at first; the nextpnr bind functions can't be used
+    // as the primary relation between arcs and wires/pips
+    struct PerNetData
+    {
+        std::vector<PerArcData> arcs;
+        BoundingBox bb;
+    };
+
+    struct PerWireData
+    {
+        // net --> driving pip
+        std::unordered_map<int, PipId> bound_nets;
+        // Which net is bound in the Arch API
+        int arch_bound_net = -1;
+        // Historical congestion cost
+        float hist_cong_cost = 0;
+    };
+
+    struct WireScore
+    {
+        float cost;
+        float togo_cost;
+        delay_t delay;
+        float total() const { return cost + togo_cost; }
+    };
+
+    Context *ctx;
+
+    // Use 'udata' for fast net lookups and indexing
+    std::vector<NetInfo *> nets_by_udata;
+
+    struct QueuedWire
+    {
+
+        explicit QueuedWire(WireId wire = WireId(), PipId pip = PipId(), WireScore score = WireScore{}, int randtag = 0)
+                : wire(wire), pip(pip), score(score), randtag(randtag){};
+
+        WireId wire;
+        PipId pip;
+
+        WireScore score;
+        int randtag = 0;
+
+        struct Greater
+        {
+            bool operator()(const QueuedWire &lhs, const QueuedWire &rhs) const noexcept
+            {
+                float lhs_score = lhs.score.cost + lhs.score.togo_cost,
+                      rhs_score = rhs.score.cost + rhs.score.togo_cost;
+                return lhs_score == rhs_score ? lhs.randtag > rhs.randtag : lhs_score > rhs_score;
+            }
+        };
+    };
+
+    double curr_cong_weight, hist_cong_weight, estimate_weight;
+    // Soft-route a net (don't touch Arch data structures which might not be thread safe)
+    // If is_mt is true, then strict bounding box rules are applied and log_* won't be called
+    struct ThreadContext
+    {
+        std::priority_queue<QueuedWire, std::vector<QueuedWire>, QueuedWire::Greater> queue;
+        std::unordered_map<WireId, QueuedWire> visited;
+    };
+
+    enum ArcRouteResult
+    {
+        ARC_SUCCESS,
+        ARC_RETRY_WITHOUT_BB,
+        ARC_FATAL,
+    };
+
+// Avoid log_error in MT
+#define ARC_ERR(...)                                                                                                   \
+    do {                                                                                                               \
+        if (is_mt)                                                                                                     \
+            return ARC_FATAL;                                                                                          \
+        else                                                                                                           \
+            log_error(__VA_ARGS__);                                                                                    \
+    } while (0)
+#define ARC_DBG(...)                                                                                                   \
+    do {                                                                                                               \
+        if (!is_mt && ctx->debug)                                                                                      \
+            log(__VA_ARGS__);                                                                                          \
+    } while (0)
+
+    ArcRouteResult route_arc(ThreadContext &t, NetInfo *net, size_t i, bool is_mt, bool is_bb = true)
+    {
+        auto &usr = net->users.at(i);
+        ARC_DBG("Routing arc %d of net '%s'", int(i), ctx->nameOf(net));
+        WireId src_wire = ctx->getNetinfoSourceWire(net), dst_wire = ctx->getNetinfoSinkWire(net, usr);
+
+        if (src_wire == WireId())
+            log_error("No wire found for port %s on source cell %s.\n", ctx->nameOf(net->driver.port),
+                      ctx->nameOf(net->driver.cell));
+        if (dst_wire == WireId())
+            log_error("No wire found for port %s on destination cell %s.\n", ctx->nameOf(usr.port),
+                      ctx->nameOf(usr.cell));
+    }
+#undef ARC_ERR
+#undef ARC_DBG
+    bool route_net(ThreadContext &t, NetInfo *net, bool is_mt)
+    {
+
+        // Define to make sure we don't print in a multithreaded context
+
+        if (!t.queue.empty()) {
+            std::priority_queue<QueuedWire, std::vector<QueuedWire>, QueuedWire::Greater> new_queue;
+            t.queue.swap(new_queue);
+        }
+        t.visited.clear();
+        for (size_t i = 0; i < net->users.size(); i++) {
+        }
+    }
+
+    void bind_and_check_legality(NetInfo *net) {}
+};
+} // namespace
+
+NEXTPNR_NAMESPACE_END

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -572,7 +572,17 @@ struct Router2
         auto &ad = nd.arcs.at(usr_idx);
         auto &usr = net->users.at(usr_idx);
         WireId src = ctx->getNetinfoSourceWire(net);
+        // Skip routes with no source
+        if (src == WireId())
+            return true;
         WireId dst = ctx->getNetinfoSinkWire(net, usr);
+        // Skip routes where the destination is already bound
+        if (dst == WireId() || ctx->getBoundWireNet(dst) == net)
+            return true;
+        // Skip routes where there is no routing (special cases)
+        if (ad.wires.empty())
+            return true;
+
         WireId cursor = dst;
 
         std::vector<PipId> to_bind;

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -141,6 +141,8 @@ struct Router2
                 nets.at(i).src_wire = src_wire;
                 if (ni->driver.cell == nullptr)
                     src_wire = dst_wire;
+                if (ni->driver.cell == nullptr && dst_wire == WireId())
+                    continue;
                 if (src_wire == WireId())
                     log_error("No wire found for port %s on source cell %s.\n", ctx->nameOf(ni->driver.port),
                               ctx->nameOf(ni->driver.cell));

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -356,8 +356,11 @@ struct Router2
         std::unordered_set<WireId> rsv;
         WireId cursor = sink;
         bool done = false;
+        log("resevering wires for arc %d of net %s\n", int(i), ctx->nameOf(net));
         while (!done) {
             auto &wd = wires.at(cursor);
+            if (ctx->debug)
+                log("      %s\n", ctx->nameOfWire(cursor));
             wd.reserved_net = net->udata;
             if (cursor == src)
                 break;
@@ -648,7 +651,9 @@ struct Router2
                     auto res2 = route_arc(t, net, i, is_mt, false);
                     // If this also fails, no choice but to give up
                     if (res2 != ARC_SUCCESS)
-                        log_error("Failed to route arc %d of net '%s'.\n", int(i), ctx->nameOf(net));
+                        log_error("Failed to route arc %d of net '%s', from %s to %s.\n", int(i), ctx->nameOf(net),
+                                  ctx->nameOfWire(ctx->getNetinfoSourceWire(net)),
+                                  ctx->nameOfWire(ctx->getNetinfoSinkWire(net, net->users.at(i))));
                 }
             }
         }

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -399,6 +399,7 @@ struct Router2
                         cursor2 = ctx->getPipSrcWire(p);
                         t.backwards_pip[cursor2] = p;
                     }
+                    break;
                 }
                 cpip = cwd.bound_nets.at(net->udata).second;
             }
@@ -494,7 +495,7 @@ struct Router2
                 next_score.cost = curr.score.cost + score_wire_for_arc(net, i, next, dh);
                 next_score.delay =
                         curr.score.delay + ctx->getPipDelay(dh).maxDelay() + ctx->getWireDelay(next).maxDelay();
-                next_score.togo_cost = 1.5 * get_togo_cost(net, i, next, dst_wire);
+                next_score.togo_cost = 1.75 * get_togo_cost(net, i, next, dst_wire);
                 if (!t.visited.count(next) || (t.visited.at(next).score.total() > next_score.total())) {
 #if 0
                     ROUTE_LOG_DBG("exploring wire %s cost %f togo %f\n", ctx->nameOfWire(next), next_score.cost,

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -300,7 +300,9 @@ struct Router2
         if (wd.bound_nets.count(net->udata))
             source_uses = wd.bound_nets.at(net->udata).first;
         // FIXME: timing/wirelength balance?
-        return ctx->getDelayNS(ctx->estimateDelay(wire, sink)) / (1 + source_uses);
+        float ipin_cost = ctx->getDelayNS(ctx->getWireDelay(sink).maxDelay() + ctx->getDelayEpsilon());
+        return std::max(0.0f, ctx->getDelayNS(ctx->estimateDelay(wire, sink)) - ipin_cost) / (1 + source_uses) +
+               ipin_cost;
     }
 
     bool check_arc_routing(NetInfo *net, size_t usr)

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -434,7 +434,7 @@ struct Router2
         // This could also be used to speed up forwards routing by a hybrid
         // bidirectional approach
         int backwards_iter = 0;
-        int backwards_limit = 10;
+        int backwards_limit = ctx->getBelGlobalBuf(net->driver.cell->bel) ? 20000 : 15;
         t.backwards_pip.clear();
         t.backwards_queue.push(dst_wire);
         while (!t.backwards_queue.empty() && backwards_iter < backwards_limit) {

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -304,7 +304,7 @@ struct Router2
             source_uses = wd.bound_nets.at(net->udata).first;
         if (pip != PipId()) {
             Loc pl = ctx->getPipLocation(pip);
-            bias_cost = 0.5f * (base_cost / int(net->users.size())) *
+            bias_cost = 0.25f * (base_cost / int(net->users.size())) *
                         ((std::abs(pl.x - nd.cx) + std::abs(pl.y - nd.cy)) / float(nd.hpwl));
         }
         return base_cost * hist_cost * present_cost / (1 + source_uses) + bias_cost;

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -196,7 +196,7 @@ struct Router2
         };
     };
 
-    int bb_margin_x = 2, bb_margin_y = 2; // number of units outside the bounding box we may go
+    int bb_margin_x = 4, bb_margin_y = 4; // number of units outside the bounding box we may go
     bool hit_test_pip(ArcBounds &bb, Loc l)
     {
         return l.x >= (bb.x0 - bb_margin_x) && l.x <= (bb.x1 + bb_margin_x) && l.y >= (bb.y0 - bb_margin_y) &&
@@ -671,8 +671,10 @@ struct Router2
 #endif
             // Ripup wires and pips used by the net in nextpnr's structures
             net_wires.clear();
-            for (auto &w : net->wires)
-                net_wires.push_back(w.first);
+            for (auto &w : net->wires) {
+                if (w.second.strength <= STRENGTH_STRONG)
+                    net_wires.push_back(w.first);
+            }
             for (auto w : net_wires)
                 ctx->unbindWire(w);
             // Bind the arcs using the routes we have discovered

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -521,6 +521,9 @@ struct Router2
         int toexplore = 25000 * std::max(1, (ad.bb.x1 - ad.bb.x0) + (ad.bb.y1 - ad.bb.y0));
         int iter = 0;
         int explored = 1;
+        bool debug_arc = /*usr.cell->type.str(ctx).find("RAMB") != std::string::npos && (usr.port ==
+                            ctx->id("ADDRATIEHIGH0") || usr.port == ctx->id("ADDRARDADDRL0"))*/
+                false;
         while (!t.queue.empty() && (!is_bb || iter < toexplore)) {
             auto curr = t.queue.top();
             t.queue.pop();
@@ -546,8 +549,9 @@ struct Router2
 #endif
                 // Evaluate score of next wire
                 WireId next = ctx->getPipDstWire(dh);
-#if 0
-                ROUTE_LOG_DBG("   src wire %s\n", ctx->nameOfWire(next));
+#if 1
+                if (debug_arc)
+                    ROUTE_LOG_DBG("   src wire %s\n", ctx->nameOfWire(next));
 #endif
                 auto &nwd = wires.at(next);
                 if (nwd.unavailable)

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -791,10 +791,11 @@ struct Router2
                 bin = 3;
             tcs.at(bin).route_nets.push_back(ni);
         }
+        log_info("%d/%d nets not multi-threadable\n", int(tcs.at(N).route_nets.size()), int(route_queue.size()));
         // Multithreaded part of routing
         std::vector<std::thread> threads;
         for (int i = 0; i < N; i++) {
-            threads.emplace_back([&]() { router_thread(tcs.at(i)); });
+            threads.emplace_back([this, &tcs, i]() { router_thread(tcs.at(i)); });
         }
         for (int i = 0; i < N; i++)
             threads.at(i).join();

--- a/common/router2.h
+++ b/common/router2.h
@@ -1,0 +1,26 @@
+/*
+ *  nextpnr -- Next Generation Place and Route
+ *
+ *  Copyright (C) 2019  David Shah <dave@ds0.me>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "nextpnr.h"
+
+NEXTPNR_NAMESPACE_BEGIN
+
+void router2_test(Context *ctx);
+
+NEXTPNR_NAMESPACE_END

--- a/common/router2.h
+++ b/common/router2.h
@@ -21,6 +21,6 @@
 
 NEXTPNR_NAMESPACE_BEGIN
 
-void router2_test(Context *ctx);
+void router2(Context *ctx);
 
 NEXTPNR_NAMESPACE_END

--- a/common/router2.h
+++ b/common/router2.h
@@ -21,6 +21,36 @@
 
 NEXTPNR_NAMESPACE_BEGIN
 
-void router2(Context *ctx);
+struct Router2Cfg
+{
+    Router2Cfg(Context *ctx);
+
+    // Maximum iterations for backwards routing attempt
+    int backwards_max_iter;
+    // Maximum iterations for backwards routing attempt for global nets
+    int global_backwards_max_iter;
+    // Padding added to bounding boxes to account for imperfect routing,
+    // congestion, etc
+    int bb_margin_x, bb_margin_y;
+    // Cost factor added to input pin wires; effectively reduces the
+    // benefit of sharing interconnect
+    float ipin_cost_adder;
+    // Cost factor for "bias" towards center location of net
+    float bias_cost_factor;
+    // Starting current and historical congestion cost factor
+    float init_curr_cong_weight, hist_cong_weight;
+    // Current congestion cost multiplier
+    float curr_cong_mult;
+
+    // Weight given to delay estimate in A*. Higher values
+    // mean faster and more directed routing, at the risk
+    // of choosing a less congestion/delay-optimal route
+    float estimate_weight;
+
+    // Print additional performance profiling information
+    bool perf_profile = false;
+};
+
+void router2(Context *ctx, const Router2Cfg &cfg);
 
 NEXTPNR_NAMESPACE_END

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -237,6 +237,13 @@ Get a list of all wires on the device.
 
 Get a list of all bel pins attached to a given wire.
 
+### ArcBounds getRouteBoundingBox(WireId src, WireId dst) const
+
+Get the bounding box required to route an arc, assuming an uncongested
+chip. There may be significant performance impacts if routing regularly
+exceeds these bounds by more than a small margin; so an over-estimate
+of the bounds is almost always better than an under-estimate.
+
 Pip Methods
 -----------
 

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -508,3 +508,13 @@ Name of the default placement algorithm for the architecture, if
 
 Name of available placer algorithms for the architecture, used
 to provide help for and validate `--placer`.
+
+### static const std::string defaultRouter
+
+Name of the default router algorithm for the architecture, if
+`--router` isn't specified on the command line.
+
+### static const std::vector\<std::string\> availableRouters
+
+Name of available router algorithms for the architecture, used
+to provide help for and validate `--router`.

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -610,7 +610,7 @@ bool Arch::route()
     route_ecp5_globals(getCtx());
     assignArchInfo();
     assign_budget(getCtx(), true);
-    router2_test(getCtx());
+    router2(getCtx());
     bool result = router1(getCtx(), Router1Cfg(getCtx()));
 #if 0
     std::vector<std::pair<WireId, int>> fanout_vector;

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -633,7 +633,7 @@ bool Arch::route()
         result = router1(getCtx(), Router1Cfg(getCtx()));
     } else if (router == "router2") {
         router2(getCtx(), Router2Cfg(getCtx()));
-        result = router1(getCtx(), Router1Cfg(getCtx()));
+        result = true;
     } else {
         log_error("ECP5 architecture does not support router '%s'\n", router.c_str());
     }

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -625,7 +625,7 @@ bool Arch::route()
     route_ecp5_globals(getCtx());
     assignArchInfo();
     assign_budget(getCtx(), true);
-    router2(getCtx());
+    router2(getCtx(), Router2Cfg(getCtx()));
     bool result = router1(getCtx(), Router1Cfg(getCtx()));
 #if 0
     std::vector<std::pair<WireId, int>> fanout_vector;

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -621,12 +621,23 @@ bool Arch::place()
 
 bool Arch::route()
 {
+    std::string router = str_or_default(settings, id("router"), defaultRouter);
+
     setupWireLocations();
     route_ecp5_globals(getCtx());
     assignArchInfo();
     assign_budget(getCtx(), true);
-    router2(getCtx(), Router2Cfg(getCtx()));
-    bool result = router1(getCtx(), Router1Cfg(getCtx()));
+
+    bool result;
+    if (router == "router1") {
+        result = router1(getCtx(), Router1Cfg(getCtx()));
+    } else if (router == "router2") {
+        router2(getCtx(), Router2Cfg(getCtx()));
+        result = router1(getCtx(), Router1Cfg(getCtx()));
+    } else {
+        log_error("ECP5 architecture does not support router '%s'\n", router.c_str());
+    }
+
 #if 0
     std::vector<std::pair<WireId, int>> fanout_vector;
     std::copy(wire_fanout.begin(), wire_fanout.end(), std::back_inserter(fanout_vector));
@@ -1172,6 +1183,9 @@ const std::vector<std::string> Arch::availablePlacers = {"sa",
                                                          "heap"
 #endif
 };
+
+const std::string Arch::defaultRouter = "router1";
+const std::vector<std::string> Arch::availableRouters = {"router1", "router2"};
 
 // -----------------------------------------------------------------------
 

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -948,6 +948,7 @@ struct Arch : BaseCtx
     // -------------------------------------------------
 
     delay_t estimateDelay(WireId src, WireId dst) const;
+    ArcBounds getRouteBoundingBox(WireId src, WireId dst) const;
     delay_t predictDelay(const NetInfo *net_info, const PortRef &sink) const;
     delay_t getDelayEpsilon() const { return 20; }
     delay_t getRipupDelayPenalty() const;

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -1066,6 +1066,8 @@ struct Arch : BaseCtx
 
     static const std::string defaultPlacer;
     static const std::vector<std::string> availablePlacers;
+    static const std::string defaultRouter;
+    static const std::vector<std::string> availableRouters;
 };
 
 NEXTPNR_NAMESPACE_END

--- a/ecp5/arch_place.cc
+++ b/ecp5/arch_place.cc
@@ -203,17 +203,26 @@ void Arch::setupWireLocations()
         CellInfo *ci = cell.second;
         if (ci->bel == BelId())
             continue;
-        if (ci->type == id_MULT18X18D || ci->type == id_DCUA) {
+        if (ci->type == id_MULT18X18D || ci->type == id_DCUA || ci->type == id_DDRDLL || ci->type == id_DQSBUFM ||
+            ci->type == id_EHXPLLL) {
             for (auto &port : ci->ports) {
-                if (port.second.type != PORT_IN || port.second.net == nullptr)
+                if (port.second.net == nullptr)
                     continue;
                 WireId pw = getBelPinWire(ci->bel, port.first);
                 if (pw == WireId())
                     continue;
-                for (auto uh : getPipsUphill(pw)) {
-                    WireId pip_src = getPipSrcWire(uh);
-                    wire_loc_overrides[pw] = std::make_pair(pip_src.location.x, pip_src.location.y);
-                    break;
+                if (port.second.type == PORT_OUT) {
+                    for (auto dh : getPipsDownhill(pw)) {
+                        WireId pip_dst = getPipDstWire(dh);
+                        wire_loc_overrides[pw] = std::make_pair(pip_dst.location.x, pip_dst.location.y);
+                        break;
+                    }
+                } else {
+                    for (auto uh : getPipsUphill(pw)) {
+                        WireId pip_src = getPipSrcWire(uh);
+                        wire_loc_overrides[pw] = std::make_pair(pip_src.location.x, pip_src.location.y);
+                        break;
+                    }
                 }
             }
         }

--- a/generic/arch.cc
+++ b/generic/arch.cc
@@ -515,6 +515,30 @@ delay_t Arch::predictDelay(const NetInfo *net_info, const PortRef &sink) const
 
 bool Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const { return false; }
 
+ArcBounds Arch::getRouteBoundingBox(WireId src, WireId dst) const
+{
+    ArcBounds bb;
+
+    int src_x = wires.at(src).x;
+    int src_y = wires.at(src).y;
+    int dst_x = wires.at(dst).x;
+    int dst_y = wires.at(dst).y;
+
+    bb.x0 = src_x;
+    bb.y0 = src_y;
+    bb.x1 = src_x;
+    bb.y1 = src_y;
+
+    auto extend = [&](int x, int y) {
+        bb.x0 = std::min(bb.x0, x);
+        bb.x1 = std::max(bb.x1, x);
+        bb.y0 = std::min(bb.y0, y);
+        bb.y1 = std::max(bb.y1, y);
+    };
+    extend(dst_x, dst_y);
+    return bb;
+}
+
 // ---------------------------------------------------------------
 
 bool Arch::place()

--- a/generic/arch.cc
+++ b/generic/arch.cc
@@ -560,7 +560,7 @@ bool Arch::route()
         result = router1(getCtx(), Router1Cfg(getCtx()));
     } else if (router == "router2") {
         router2(getCtx(), Router2Cfg(getCtx()));
-        result = router1(getCtx(), Router1Cfg(getCtx()));
+        result = true;
     } else {
         log_error("iCE40 architecture does not support router '%s'\n", router.c_str());
     }

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -288,6 +288,8 @@ struct Arch : BaseCtx
 
     static const std::string defaultPlacer;
     static const std::vector<std::string> availablePlacers;
+    static const std::string defaultRouter;
+    static const std::vector<std::string> availableRouters;
 
     // ---------------------------------------------------------------
     // Internal usage

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -267,6 +267,8 @@ struct Arch : BaseCtx
     uint32_t getDelayChecksum(delay_t v) const { return 0; }
     bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const;
 
+    ArcBounds getRouteBoundingBox(WireId src, WireId dst) const;
+
     bool pack();
     bool place();
     bool route();

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -1255,6 +1255,30 @@ void Arch::assignCellInfo(CellInfo *cell)
     }
 }
 
+ArcBounds Arch::getRouteBoundingBox(WireId src, WireId dst) const
+{
+    ArcBounds bb;
+
+    int src_x = chip_info->wire_data[src.index].x;
+    int src_y = chip_info->wire_data[src.index].y;
+    int dst_x = chip_info->wire_data[dst.index].x;
+    int dst_y = chip_info->wire_data[dst.index].y;
+
+    bb.x0 = src_x;
+    bb.y0 = src_y;
+    bb.x1 = src_x;
+    bb.y1 = src_y;
+
+    auto extend = [&](int x, int y) {
+        bb.x0 = std::min(bb.x0, x);
+        bb.x1 = std::max(bb.x1, x);
+        bb.y0 = std::min(bb.y0, y);
+        bb.y1 = std::max(bb.y1, y);
+    };
+    extend(dst_x, dst_y);
+    return bb;
+}
+
 #ifdef WITH_HEAP
 const std::string Arch::defaultPlacer = "heap";
 #else

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -703,7 +703,7 @@ bool Arch::route()
         result = router1(getCtx(), Router1Cfg(getCtx()));
     } else if (router == "router2") {
         router2(getCtx(), Router2Cfg(getCtx()));
-        result = router1(getCtx(), Router1Cfg(getCtx()));
+        result = true;
     } else {
         log_error("iCE40 architecture does not support router '%s'\n", router.c_str());
     }

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -28,6 +28,7 @@
 #include "placer1.h"
 #include "placer_heap.h"
 #include "router1.h"
+#include "router2.h"
 #include "timing_opt.h"
 #include "util.h"
 NEXTPNR_NAMESPACE_BEGIN
@@ -696,10 +697,19 @@ bool Arch::place()
 
 bool Arch::route()
 {
-    bool retVal = router1(getCtx(), Router1Cfg(getCtx()));
+    std::string router = str_or_default(settings, id("router"), defaultRouter);
+    bool result;
+    if (router == "router1") {
+        result = router1(getCtx(), Router1Cfg(getCtx()));
+    } else if (router == "router2") {
+        router2(getCtx(), Router2Cfg(getCtx()));
+        result = router1(getCtx(), Router1Cfg(getCtx()));
+    } else {
+        log_error("iCE40 architecture does not support router '%s'\n", router.c_str());
+    }
     getCtx()->settings[getCtx()->id("route")] = 1;
     archInfoToAttributes();
-    return retVal;
+    return result;
 }
 
 // -----------------------------------------------------------------------
@@ -1256,5 +1266,8 @@ const std::vector<std::string> Arch::availablePlacers = {"sa",
                                                          "heap"
 #endif
 };
+
+const std::string Arch::defaultRouter = "router1";
+const std::vector<std::string> Arch::availableRouters = {"router1", "router2"};
 
 NEXTPNR_NAMESPACE_END

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -826,6 +826,8 @@ struct Arch : BaseCtx
     uint32_t getDelayChecksum(delay_t v) const { return v; }
     bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const;
 
+    ArcBounds getRouteBoundingBox(WireId src, WireId dst) const;
+
     // -------------------------------------------------
 
     bool pack();

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -900,6 +900,8 @@ struct Arch : BaseCtx
 
     static const std::string defaultPlacer;
     static const std::vector<std::string> availablePlacers;
+    static const std::string defaultRouter;
+    static const std::vector<std::string> availableRouters;
 };
 
 void ice40DelayFuzzerMain(Context *ctx);


### PR DESCRIPTION
router2 is a negotiated congestion based router, based on CRoute (DOI 10.1109/FCCM.2019.00017). Its primary intention is in preparation Xilinx flows where congestion is a serious problem, it has limited benefit for existing arches. It also currently carries a timing cost compared to router1 but this is more due to having fewer timing heuristics at present. As a result router1 remains the default for all current arches, and will do for the near future.

This is only the first phase of development, I have future plans for SAT to deal with difficult congestion conflicts, a special pass for high-fanout nets and timing-driven ripup in the future. It also currently relies on router1 to check the route is valid, I hope to remove this eventually.

