### PR TITLE
Fix paths to prjtrellies project

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ task:
     memory: 20
     dockerfile: .cirrus/Dockerfile.ubuntu16.04
 
-  build_script: mkdir build && cd build && cmake .. -DARCH=all -DTRELLIS_ROOT=/usr/local/src/prjtrellis -DBUILD_TESTS=on && make -j $(nproc)
+  build_script: mkdir build && cd build && cmake .. -DARCH=all -DBUILD_TESTS=on && make -j $(nproc)
   submodule_script: git submodule sync --recursive && git submodule update --init --recursive
   test_generic_script: cd build && ./nextpnr-generic-test
   test_ice40_script: cd build && ./nextpnr-ice40-test

--- a/.cirrus/Dockerfile.ubuntu16.04
+++ b/.cirrus/Dockerfile.ubuntu16.04
@@ -47,7 +47,7 @@ RUN set -e -x ;\
     cd /usr/local/src ;\
     git clone --recursive https://github.com/SymbiFlow/prjtrellis.git ;\
     cd prjtrellis ;\
-    git reset --hard 46e95314be7f8850db80ad1ef6b3359b091fad93 ;\
+    git reset --hard 668ce3492cbe1566c61760f06bdf676f6fb265c3 ;\
     cd libtrellis ;\
     cmake -DCMAKE_INSTALL_PREFIX=/usr . ;\
     make -j $(nproc) ;\

--- a/.cirrus/Dockerfile.ubuntu16.04
+++ b/.cirrus/Dockerfile.ubuntu16.04
@@ -49,6 +49,6 @@ RUN set -e -x ;\
     cd prjtrellis ;\
     git reset --hard 668ce3492cbe1566c61760f06bdf676f6fb265c3 ;\
     cd libtrellis ;\
-    cmake -DCMAKE_INSTALL_PREFIX=/usr . ;\
+    cmake . ;\
     make -j $(nproc) ;\
     make install

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ For ECP5 support, you must download [Project Trellis](https://github.com/SymbiFl
 then follow its instructions to download the latest database and build _libtrellis_.
 
 ```
-cmake -DARCH=ecp5 -DTRELLIS_ROOT=/path/to/prjtrellis .
+cmake -DARCH=ecp5 -DTRELLIS_INSTALL_PREFIX=/path/to/prjtrellis .
 make -j$(nproc)
 sudo make install
 ```

--- a/ecp5/family.cmake
+++ b/ecp5/family.cmake
@@ -1,14 +1,14 @@
 if (NOT EXTERNAL_CHIPDB)
     set(devices 25k 45k 85k)
 
-    if (NOT DEFINED TRELLIS_ROOT)
-        message(STATUS "TRELLIS_ROOT not defined using -DTRELLIS_ROOT=/path/to/prjtrellis. Default to /usr/local")
-        set(TRELLIS_ROOT "/usr/local")
+    if (NOT DEFINED TRELLIS_INSTALL_PREFIX)
+        message(STATUS "TRELLIS_INSTALL_PREFIX not defined using -DTRELLIS_INSTALL_PREFIX=/path-prefix/to/prjtrellis-installation. Default to /usr/local or reset by -DCMAKE_INSTALL_PREFIX when building prjtrellis/libtrellis")
+        set(TRELLIS_INSTALL_PREFIX "/usr/local")
     endif()
 
     if (NOT DEFINED PYTRELLIS_LIBDIR)
         find_library(PYTRELLIS pytrellis.so
-            PATHS ${TRELLIS_ROOT}/lib/trellis
+            PATHS ${TRELLIS_INSTALL_PREFIX}/lib/trellis
             PATH_SUFFIXES trellis
             DOC "Location of pytrellis library")
 
@@ -27,9 +27,9 @@ if (NOT EXTERNAL_CHIPDB)
     target_include_directories(ecp5_chipdb PRIVATE ${family}/)
 
     if (CMAKE_HOST_WIN32)
-        set(ENV_CMD ${CMAKE_COMMAND} -E env "PYTHONPATH=\"${PYTRELLIS_LIBDIR}\;${TRELLIS_ROOT}/share/trellis/util/common\;${TRELLIS_ROOT}/share/trellis/timing/util\"")
+        set(ENV_CMD ${CMAKE_COMMAND} -E env "PYTHONPATH=\"${PYTRELLIS_LIBDIR}\;${TRELLIS_INSTALL_PREFIX}/share/trellis/util/common\;${TRELLIS_INSTALL_PREFIX}/share/trellis/timing/util\"")
     else()
-        set(ENV_CMD ${CMAKE_COMMAND} -E env "PYTHONPATH=${PYTRELLIS_LIBDIR}\:${TRELLIS_ROOT}/share/trellis/util/common:${TRELLIS_ROOT}/share/trellis/timing/util")
+        set(ENV_CMD ${CMAKE_COMMAND} -E env "PYTHONPATH=${PYTRELLIS_LIBDIR}\:${TRELLIS_INSTALL_PREFIX}/share/trellis/util/common:${TRELLIS_INSTALL_PREFIX}/share/trellis/timing/util")
     endif()
 
     if (MSVC)

--- a/ecp5/family.cmake
+++ b/ecp5/family.cmake
@@ -2,13 +2,13 @@ if (NOT EXTERNAL_CHIPDB)
     set(devices 25k 45k 85k)
 
     if (NOT DEFINED TRELLIS_ROOT)
-        message(STATUS "TRELLIS_ROOT not defined using -DTRELLIS_ROOT=/path/to/prjtrellis. Default to /usr/local/share/trellis")
-        set(TRELLIS_ROOT "/usr/local/share/trellis")
+        message(STATUS "TRELLIS_ROOT not defined using -DTRELLIS_ROOT=/path/to/prjtrellis. Default to /usr/local")
+        set(TRELLIS_ROOT "/usr/local")
     endif()
 
     if (NOT DEFINED PYTRELLIS_LIBDIR)
         find_library(PYTRELLIS pytrellis.so
-            PATHS ${TRELLIS_ROOT}/libtrellis
+            PATHS ${TRELLIS_ROOT}/lib/trellis
             PATH_SUFFIXES trellis
             DOC "Location of pytrellis library")
 
@@ -27,9 +27,9 @@ if (NOT EXTERNAL_CHIPDB)
     target_include_directories(ecp5_chipdb PRIVATE ${family}/)
 
     if (CMAKE_HOST_WIN32)
-        set(ENV_CMD ${CMAKE_COMMAND} -E env "PYTHONPATH=\"${PYTRELLIS_LIBDIR}\;${TRELLIS_ROOT}/util/common\;${TRELLIS_ROOT}/timing/util\"")
+        set(ENV_CMD ${CMAKE_COMMAND} -E env "PYTHONPATH=\"${PYTRELLIS_LIBDIR}\;${TRELLIS_ROOT}/share/trellis/util/common\;${TRELLIS_ROOT}/share/trellis/timing/util\"")
     else()
-        set(ENV_CMD ${CMAKE_COMMAND} -E env "PYTHONPATH=${PYTRELLIS_LIBDIR}\:${TRELLIS_ROOT}/util/common:${TRELLIS_ROOT}/timing/util")
+        set(ENV_CMD ${CMAKE_COMMAND} -E env "PYTHONPATH=${PYTRELLIS_LIBDIR}\:${TRELLIS_ROOT}/share/trellis/util/common:${TRELLIS_ROOT}/share/trellis/timing/util")
     endif()
 
     if (MSVC)


### PR DESCRIPTION
Rebased, updated and squashed commits by @jboone on jboone/nextpnr@246fff9
(also mentioned in #272)

Necessary, if prjtrellis or rather libtrellis is install to a custom install path (e.g. `/opt/prjtrellis/`),
then `cmake -DARCH=ecp5 -DTRELLIS_ROOT=/opt/prjtrellis` did not found pytrellis library etc.
