### PR TITLE
gui: Fix undefined behavior in TreeModel.

### DIFF
--- a/gui/treemodel.cc
+++ b/gui/treemodel.cc
@@ -135,7 +135,7 @@ void IdStringList::updateElements(Context *ctx, std::vector<IdString> elements)
         }
 
         // Same string.
-        return true;
+        return false;
     });
 }
 


### PR DESCRIPTION
std::sort() requires the comparison function to return false for even
comparison. Returning true results in undefined behavior and a potential
segfault.