### PR TITLE
build: Default the ECP5 and iCE40 roots to the install prefix

### DIFF
--- a/ecp5/family.cmake
+++ b/ecp5/family.cmake
@@ -2,8 +2,8 @@ if (NOT EXTERNAL_CHIPDB)
     set(devices 25k 45k 85k)
 
     if (NOT DEFINED TRELLIS_INSTALL_PREFIX)
-        message(STATUS "TRELLIS_INSTALL_PREFIX not defined using -DTRELLIS_INSTALL_PREFIX=/path-prefix/to/prjtrellis-installation. Default to /usr/local or reset by -DCMAKE_INSTALL_PREFIX when building prjtrellis/libtrellis")
-        set(TRELLIS_INSTALL_PREFIX "/usr/local")
+        message(STATUS "TRELLIS_INSTALL_PREFIX not defined using -DTRELLIS_INSTALL_PREFIX=/path-prefix/to/prjtrellis-installation. Defaulted to ${CMAKE_INSTALL_PREFIX}")
+        set(TRELLIS_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
     endif()
 
     if (NOT DEFINED PYTRELLIS_LIBDIR)

--- a/ice40/family.cmake
+++ b/ice40/family.cmake
@@ -10,7 +10,7 @@ if (NOT EXTERNAL_CHIPDB)
 
     set(DB_PY ${CMAKE_CURRENT_SOURCE_DIR}/ice40/chipdb.py)
 
-    set(ICEBOX_ROOT "/usr/local/share/icebox" CACHE STRING "icebox location root")
+    set(ICEBOX_ROOT ${CMAKE_INSTALL_PREFIX}/share/icebox CACHE STRING "icebox location root")
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ice40/chipdbs/)
     add_library(ice40_chipdb OBJECT ${CMAKE_CURRENT_BINARY_DIR}/ice40/chipdbs/)
     target_compile_definitions(ice40_chipdb PRIVATE NEXTPNR_NAMESPACE=nextpnr_${family})


### PR DESCRIPTION
If the user specifies a custom install prefix, chances are icestrom/trellis
are also in that prefix rather than the hardcoded /usr/local

Fixes #351

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>