### PR TITLE
ice40: Fix output register timing analysis for registered output enable

### DIFF
--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -1037,7 +1037,7 @@ TimingPortClass Arch::getPortTimingClass(const CellInfo *cell, IdString port, in
             }
         }
         if (port == id_OUTPUT_ENABLE) {
-            if ((cell->ioInfo.pintype & 0x18) == 0x18) {
+            if ((cell->ioInfo.pintype & 0x30) == 0x30) {
                 return TMG_REGISTER_INPUT;
             } else {
                 return TMG_ENDPOINT;


### PR DESCRIPTION
Wrong bits were being tested. [5:4] is what's controlling the output
enable path.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>