### PR TITLE
Remove comment about the USRMCLK primitive being untested.

### DIFF
--- a/ecp5/docs/primitives.md
+++ b/ecp5/docs/primitives.md
@@ -43,5 +43,5 @@ nextpnr-ecp5 currently supports the following primitives:
  - **TRELLIS_SLICE**
  - **TSHX2DQA**
  - **TSHX2DQSA**
- - **USRMCLK** (untested)
+ - **USRMCLK**
 


### PR DESCRIPTION
Tested and verified working: the trivial configuration:

    module USRMCLK( USRMCLKI, USRMCLKTS );
        input USRMCLKI, USRMCLKTS;
    endmodule

    module top( input clk );
        reg[ 24:0 ] count = 0;

        always @( posedge clk ) begin
            count <= count + 1'b1;
        end

        USRMCLK mspi( .USRMCLKI( count[ 20 ] ), .USRMCLKTS( count[ 24 ] ) );
    endmodule

produces the expected output (toggling at high frequency, toggling
tri-state at lower frequency) on an LFE5U-85 when fed with an appropriate
clock.  See https://bayimg.com/AAnNKAAGO for an example.  The top
(magenta) trace is the MCLK line.