### PR TITLE
Fix assertion failure on invalid LOCATE input.

### DIFF
--- a/ecp5/lpf.cc
+++ b/ecp5/lpf.cc
@@ -101,6 +101,8 @@ bool Arch::applyLPF(std::string filename, std::istream &in)
                         if (words.at(3) != "SITE")
                             log_error("expected 'SITE' after 'LOCATE COMP %s' (on line %d)\n", cell.c_str(), lineno);
                         auto fnd_cell = cells.find(id(cell));
+                        if (words.size() > 5)
+                            log_error("unexpected input following LOCATE clause (on line %d)\n", lineno);
                         if (fnd_cell != cells.end()) {
                             fnd_cell->second->attrs[id("LOC")] = strip_quotes(words.at(4));
                         }


### PR DESCRIPTION
Trying to parse this invalid LPF syntax:

    LOCATE COMP "a" SITE "A1"
    IOBUF PORT "a" IO_TYPE=LVCMOS33;

(note missing semicolon on first line) gives an assertion failure in
strip_quotes, because the fifth token is scanned as "A1"IOBUF (without
a trailing quote).

Avoid the problem by detecting extraneous input and issuing a more
specific error.