### PR TITLE
design_utils: Set port.net to null when disconnecting

### DIFF
--- a/common/design_utils.cc
+++ b/common/design_utils.cc
@@ -111,6 +111,7 @@ void disconnect_port(const Context *ctx, CellInfo *cell, IdString port_name)
                               port.net->users.end());
         if (port.net->driver.cell == cell && port.net->driver.port == port_name)
             port.net->driver.cell = nullptr;
+        port.net = nullptr;
     }
 }
 


### PR DESCRIPTION
Without this the python bindings can't actually connect anything else
to a disconnected port since the assert in connect_ports will think
it's still connected

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>