### PR TITLE
python: Miscellaneous fixes

### DIFF
--- a/3rdparty/python-console/modified/pyinterpreter.cc
+++ b/3rdparty/python-console/modified/pyinterpreter.cc
@@ -82,7 +82,13 @@ const std::list<std::string> &pyinterpreter_suggest(const std::string &hint)
     PyEval_AcquireThread(m_threadState);
     m_suggestions.clear();
     int i = 0;
-    std::string command = string_format("sys.completer.complete('%s', %d)\n", hint.c_str(), i);
+    std::string escaped;
+    for (char c : hint) {
+        if (c == '\'' || c == '\\')
+            escaped += '\\';
+        escaped += c;
+    }
+    std::string command = string_format("sys.completer.complete('%s', %d)\n", escaped.c_str(), i);
     std::string res;
     do {
         PyObject *py_result;
@@ -94,7 +100,7 @@ const std::list<std::string> &pyinterpreter_suggest(const std::string &hint)
         res = redirector_take_output(m_threadState);
 
         ++i;
-        command = string_format("sys.completer.complete('%s', %d)\n", hint.c_str(), i);
+        command = string_format("sys.completer.complete('%s', %d)\n", escaped.c_str(), i);
         if (res.size()) {
             // throw away the newline
             res = res.substr(1, res.size() - 3);

--- a/3rdparty/python-console/modified/pyinterpreter.cc
+++ b/3rdparty/python-console/modified/pyinterpreter.cc
@@ -94,7 +94,11 @@ const std::list<std::string> &pyinterpreter_suggest(const std::string &hint)
         PyObject *py_result;
         PyObject *dum;
         py_result = Py_CompileString(command.c_str(), "<stdin>", Py_single_input);
+        if (py_result == nullptr)
+            break;
         dum = PyEval_EvalCode(py_result, glb, loc);
+        if (dum == nullptr)
+            break;
         Py_XDECREF(dum);
         Py_XDECREF(py_result);
         res = redirector_take_output(m_threadState);

--- a/common/pycontainers.h
+++ b/common/pycontainers.h
@@ -285,7 +285,9 @@ template <typename T1, typename T2, typename value_conv> struct map_pair_wrapper
     {
         if ((i >= 2) || (i < 0))
             KeyError();
-        return (i == 1) ? object(value_conv()(x.ctx, x.base.second)) : object(x.base.first);
+        return (i == 1) ? object(value_conv()(x.ctx, x.base.second))
+                        : object(PythonConversion::string_converter<decltype(x.base.first)>().to_str(x.ctx,
+                                                                                                     x.base.first));
     }
 
     static int len(wrapped_pair &x) { return 2; }

--- a/common/pycontainers.h
+++ b/common/pycontainers.h
@@ -410,7 +410,8 @@ template <typename T1, typename T2> struct map_pair_wrapper_uptr
         if ((i >= 2) || (i < 0))
             KeyError();
         return (i == 1) ? object(PythonConversion::ContextualWrapper<V &>(x.ctx, *x.base.second.get()))
-                        : object(x.base.first);
+                        : object(PythonConversion::string_converter<decltype(x.base.first)>().to_str(x.ctx,
+                                                                                                     x.base.first));
     }
 
     static int len(wrapped_pair &x) { return 2; }


### PR DESCRIPTION
Fixes #430 
Fixes #431 - autocomplete still isn't very useful but I suspect that is a Python issue rather than anything we can fix, and it doesn't crash any more.

