### PR TITLE
Alter MULT18X18D timing db based on register config

### DIFF
--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -855,7 +855,7 @@ bool Arch::getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort
         std::string fn = fromPort.str(this), tn = toPort.str(this);
         if (fn.size() > 1 && (fn.front() == 'A' || fn.front() == 'B') && std::isdigit(fn.at(1))) {
             if (tn.size() > 1 && tn.front() == 'P' && std::isdigit(tn.at(1)))
-                return getDelayFromTimingDatabase(id_MULT18X18D_REGS_NONE, id(std::string("") + fn.front()), id_P,
+                return getDelayFromTimingDatabase(cell->multInfo.timing_id, id(std::string("") + fn.front()), id_P,
                                                   delay);
         }
         return false;

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -852,6 +852,8 @@ bool Arch::getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort
     } else if (cell->type == id_DP16KD) {
         return false;
     } else if (cell->type == id_MULT18X18D) {
+        if (cell->multInfo.is_clocked)
+            return false;
         std::string fn = fromPort.str(this), tn = toPort.str(this);
         if (fn.size() > 1 && (fn.front() == 'A' || fn.front() == 'B') && std::isdigit(fn.at(1))) {
             if (tn.size() > 1 && tn.front() == 'P' && std::isdigit(tn.at(1)))

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -940,10 +940,12 @@ TimingPortClass Arch::getPortTimingClass(const CellInfo *cell, IdString port, in
             return TMG_CLOCK_INPUT;
         std::string pname = port.str(this);
         if (pname.size() > 1) {
-            if ((pname.front() == 'A' || pname.front() == 'B') && std::isdigit(pname.at(1)))
-                return TMG_COMB_INPUT;
+            if (pname.front() == 'A' && std::isdigit(pname.at(1)))
+                return cell->multInfo.is_in_a_registered ? TMG_REGISTER_INPUT : TMG_COMB_INPUT;
+            if (pname.front() == 'B' && std::isdigit(pname.at(1)))
+                return cell->multInfo.is_in_b_registered ? TMG_REGISTER_INPUT : TMG_COMB_INPUT;
             if (pname.front() == 'P' && std::isdigit(pname.at(1)))
-                return TMG_COMB_OUTPUT;
+                return cell->multInfo.is_output_registered ? TMG_REGISTER_OUTPUT : TMG_COMB_OUTPUT;
         }
         return TMG_IGNORE;
     } else if (cell->type == id_ALU54B) {

--- a/ecp5/archdefs.h
+++ b/ecp5/archdefs.h
@@ -187,8 +187,14 @@ struct ArchCellInfo
         // Which timing information to use for a DP16KD. Depends on registering
         // configuration.
         nextpnr_ecp5::IdString regmode_timing_id;
-
     } ramInfo;
+    struct
+    {
+        bool is_in_a_registered;
+        bool is_in_b_registered;
+        bool is_output_registered;
+        nextpnr_ecp5::IdString timing_id;
+    } multInfo;
 };
 
 NEXTPNR_NAMESPACE_END

--- a/ecp5/archdefs.h
+++ b/ecp5/archdefs.h
@@ -190,9 +190,7 @@ struct ArchCellInfo
     } ramInfo;
     struct
     {
-        bool is_in_a_registered;
-        bool is_in_b_registered;
-        bool is_output_registered;
+        bool is_clocked;
         nextpnr_ecp5::IdString timing_id;
     } multInfo;
 };

--- a/ecp5/pack.cc
+++ b/ecp5/pack.cc
@@ -3042,24 +3042,25 @@ void Arch::assignArchInfo()
             // Get the input clock setting from the cell
             std::string reg_inputa_clk = str_or_default(ci->params, id("REG_INPUTA_CLK"), "NONE");
             std::string reg_inputb_clk = str_or_default(ci->params, id("REG_INPUTB_CLK"), "NONE");
+
+            // The clock check is the same IN_A/B and OUT, so hoist it to a function
+            auto verify_clock_parameter = [&](std::string param_name, std::string clk) {
+                if (clk != "NONE" && clk != "CLK0" && clk != "CLK1" && clk != "CLK2" && clk != "CLK3")
+                    log_error("MULT18X18D %s has invalid %s configuration '%s'\n", ci->name.c_str(this),
+                              param_name.c_str(), clk.c_str());
+            };
+
             // Assert we have valid settings for the input clocks
-            if (reg_inputa_clk != "NONE" && reg_inputa_clk != "CLK0" && reg_inputa_clk != "CLK1" &&
-                reg_inputa_clk != "CLK2" && reg_inputa_clk != "CLK3")
-                log_error("MULT18X18D %s has invalid REG_INPUTA_CLK configuration '%s'\n", ci->name.c_str(this),
-                          reg_inputa_clk.c_str());
-            if (reg_inputb_clk != "NONE" && reg_inputb_clk != "CLK0" && reg_inputb_clk != "CLK1" &&
-                reg_inputb_clk != "CLK2" && reg_inputb_clk != "CLK3")
-                log_error("MULT18X18D %s has invalid REG_INPUTB_CLK configuration '%s'\n", ci->name.c_str(this),
-                          reg_inputb_clk.c_str());
+            verify_clock_parameter("REG_INPUTA_CLK", reg_inputa_clk);
+            verify_clock_parameter("REG_INPUTB_CLK", reg_inputb_clk);
+
             // Inputs are registered IFF the REG_INPUT value is not NONE
             const bool is_in_a_registered = reg_inputa_clk != "NONE";
             const bool is_in_b_registered = reg_inputb_clk != "NONE";
+
             // Similarly, get the output register clock
             std::string reg_output_clk = str_or_default(ci->params, id("REG_OUTPUT_CLK"), "NONE");
-            if (reg_output_clk != "NONE" && reg_output_clk != "CLK0" && reg_output_clk != "CLK1" &&
-                reg_output_clk != "CLK2" && reg_output_clk != "CLK3")
-                log_error("MULT18X18D %s has invalid REG_OUTPUT_CLK configuration '%s'\n", ci->name.c_str(this),
-                          reg_output_clk.c_str());
+            verify_clock_parameter("REG_OUTPUT_CLK", reg_output_clk);
             const bool is_output_registered = reg_output_clk != "NONE";
 
             // If only one of the inputs is registered, we are going to treat that as


### PR DESCRIPTION
If the REG_INPUTA_CLK and REG_INPUTB_CLK values are set, then we should
use the faster setup/hold timings for the 18x8 multiplier.
Similarly, check the value of REG_OUTPUT_CLK for whether or not to use
faster timings for the output.

This is based on how I currently understand the registers to work - if
anyone knows the actual rules for when each timing applies please do
chime in to correct this implementation if necessary.

Along the same lines, this PR does not address the case when the
pipeline registers are enabled, since it is not clear to me how exactly
that affects the timing.