### PR TITLE
Fix spelling of 'unsupported'

### DIFF
--- a/ecp5/main.cc
+++ b/ecp5/main.cc
@@ -174,12 +174,12 @@ std::unique_ptr<Context> ECP5CommandHandler::createContext(std::unordered_map<st
     if (values.find("arch.name") != values.end()) {
         std::string arch_name = values["arch.name"].as_string();
         if (arch_name != "ecp5")
-            log_error("Unsuported architecture '%s'.\n", arch_name.c_str());
+            log_error("Unsupported architecture '%s'.\n", arch_name.c_str());
     }
     if (values.find("arch.type") != values.end()) {
         std::string arch_type = values["arch.type"].as_string();
         if (chipArgs.type != ArchArgs::NONE)
-            log_error("Overriding architecture is unsuported.\n");
+            log_error("Overriding architecture is unsupported.\n");
 
         if (arch_type == "lfe5u_12f")
             chipArgs.type = ArchArgs::LFE5U_12F;
@@ -203,11 +203,11 @@ std::unique_ptr<Context> ECP5CommandHandler::createContext(std::unordered_map<st
             chipArgs.type = ArchArgs::LFE5UM5G_85F;
 
         if (chipArgs.type == ArchArgs::NONE)
-            log_error("Unsuported FPGA type '%s'.\n", arch_type.c_str());
+            log_error("Unsupported FPGA type '%s'.\n", arch_type.c_str());
     }
     if (values.find("arch.package") != values.end()) {
         if (vm.count("package"))
-            log_error("Overriding architecture is unsuported.\n");
+            log_error("Overriding architecture is unsupported.\n");
         chipArgs.package = values["arch.package"].as_string();
     }
     if (values.find("arch.speed") != values.end()) {
@@ -219,7 +219,7 @@ std::unique_ptr<Context> ECP5CommandHandler::createContext(std::unordered_map<st
         else if (arch_speed == "8")
             chipArgs.speed = ArchArgs::SPEED_8;
         else
-            log_error("Unsuported speed '%s'.\n", arch_speed.c_str());
+            log_error("Unsupported speed '%s'.\n", arch_speed.c_str());
     }
     if (chipArgs.type == ArchArgs::NONE)
         chipArgs.type = ArchArgs::LFE5U_45F;

--- a/generic/main.cc
+++ b/generic/main.cc
@@ -58,7 +58,7 @@ std::unique_ptr<Context> GenericCommandHandler::createContext(std::unordered_map
     if (values.find("arch.name") != values.end()) {
         std::string arch_name = values["arch.name"].as_string();
         if (arch_name != "generic")
-            log_error("Unsuported architecture '%s'.\n", arch_name.c_str());
+            log_error("Unsupported architecture '%s'.\n", arch_name.c_str());
     }
     auto ctx = std::unique_ptr<Context>(new Context(chipArgs));
     if (vm.count("no-iobs"))

--- a/ice40/main.cc
+++ b/ice40/main.cc
@@ -163,12 +163,12 @@ std::unique_ptr<Context> Ice40CommandHandler::createContext(std::unordered_map<s
     if (values.find("arch.name") != values.end()) {
         std::string arch_name = values["arch.name"].as_string();
         if (arch_name != "ice40")
-            log_error("Unsuported architecture '%s'.\n", arch_name.c_str());
+            log_error("Unsupported architecture '%s'.\n", arch_name.c_str());
     }
     if (values.find("arch.type") != values.end()) {
         std::string arch_type = values["arch.type"].as_string();
         if (chipArgs.type != ArchArgs::NONE)
-            log_error("Overriding architecture is unsuported.\n");
+            log_error("Overriding architecture is unsupported.\n");
 
         if (arch_type == "lp384") {
             chipArgs.type = ArchArgs::LP384;
@@ -192,11 +192,11 @@ std::unique_ptr<Context> Ice40CommandHandler::createContext(std::unordered_map<s
             chipArgs.type = ArchArgs::U4K;
         }
         if (chipArgs.type == ArchArgs::NONE)
-            log_error("Unsuported FPGA type '%s'.\n", arch_type.c_str());
+            log_error("Unsupported FPGA type '%s'.\n", arch_type.c_str());
     }
     if (values.find("arch.package") != values.end()) {
         if (vm.count("package"))
-            log_error("Overriding architecture is unsuported.\n");
+            log_error("Overriding architecture is unsupported.\n");
         chipArgs.package = values["arch.package"].as_string();
     }
 


### PR DESCRIPTION
Hello nextpnr developers!

I've been working lately to package nextpnr for Debian, and one of the things that popped up during that process is that "unsupported" happens to be misspelled in a few places.

Thanks, and happy hacking!
Nate Graff