### PR TITLE
Fixes issue #445

### DIFF
--- a/ice40/chipdb.py
+++ b/ice40/chipdb.py
@@ -11,6 +11,7 @@ parser.add_argument("-p", "--constids", type=str, help="path to constids.inc")
 parser.add_argument("-g", "--gfxh", type=str, help="path to gfx.h")
 parser.add_argument("--fast", type=str, help="path to timing data for fast part")
 parser.add_argument("--slow", type=str, help="path to timing data for slow part")
+parser.add_argument("-o","--output", type=str, help="save output to file")
 args = parser.parse_args()
 
 dev_name = None
@@ -57,6 +58,9 @@ wire_segments = dict()
 fast_timings = None
 slow_timings = None
 
+if args.output:
+    sys.stdout = open(args.output, 'w')
+    
 with open(args.constids) as f:
     for line in f:
         if line.startswith("//"):

--- a/ice40/family.cmake
+++ b/ice40/family.cmake
@@ -46,7 +46,7 @@ if (NOT EXTERNAL_CHIPDB)
                     )
             else()
                 add_custom_command(OUTPUT ${DEV_CC_BBA_DB}
-                    COMMAND ${PYTHON_EXECUTABLE} ${DB_PY} -p ${DEV_CONSTIDS_INC} -g ${DEV_GFXH} ${OPT_FAST} ${OPT_SLOW} ${DEV_TXT_DB} > ${DEV_CC_BBA_DB}
+                    COMMAND ${PYTHON_EXECUTABLE} ${DB_PY} -p ${DEV_CONSTIDS_INC} -g ${DEV_GFXH} ${OPT_FAST} ${OPT_SLOW} ${DEV_TXT_DB} -o ${DEV_CC_BBA_DB}
                     DEPENDS ${DEV_CONSTIDS_INC} ${DEV_GFXH} ${DEV_TXT_DB} ${DB_PY} ${PREV_DEV_CC_BBA_DB}
                     )
                 add_custom_command(OUTPUT ${DEV_CC_DB}
@@ -93,7 +93,7 @@ if (NOT EXTERNAL_CHIPDB)
                     )
             else()
                 add_custom_command(OUTPUT ${DEV_CC_BBA_DB}
-                    COMMAND ${PYTHON_EXECUTABLE} ${DB_PY} -p ${DEV_CONSTIDS_INC} -g ${DEV_GFXH} ${OPT_FAST} ${OPT_SLOW} ${DEV_TXT_DB} > ${DEV_CC_BBA_DB}.new
+                    COMMAND ${PYTHON_EXECUTABLE} ${DB_PY} -p ${DEV_CONSTIDS_INC} -g ${DEV_GFXH} ${OPT_FAST} ${OPT_SLOW} ${DEV_TXT_DB} -o ${DEV_CC_BBA_DB}.new
                     COMMAND mv ${DEV_CC_BBA_DB}.new ${DEV_CC_BBA_DB}
                     DEPENDS ${DEV_CONSTIDS_INC} ${DEV_GFXH} ${DEV_TXT_DB} ${DB_PY} ${PREV_DEV_CC_BBA_DB}
                     )


### PR DESCRIPTION
Added an output option to ice40/chipdb.py and updated ice40/family.cmake to make use of it. This will speed up the process a bit and avoid any resource starvation issues noticed. 