### PR TITLE
Port nextpnr-{ice40,ecp5} to WASI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,24 @@ option(SERIALIZE_CHIPDB "Never build chipdb in parallel to reduce peak memory us
 
 set(Boost_NO_BOOST_CMAKE ON)
 
+if(WASI)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lwasi-emulated-mman")
+    set(USE_THREADS OFF)
+    add_definitions(
+        -DBOOST_EXCEPTION_DISABLE
+        -DBOOST_NO_EXCEPTIONS
+        -DBOOST_SP_NO_ATOMIC_ACCESS
+        -DBOOST_AC_DISABLE_THREADS
+        -DBOOST_NO_CXX11_HDR_MUTEX
+    )
+else()
+    set(USE_THREADS ON)
+endif()
+
+if (NOT USE_THREADS)
+    add_definitions(-DNPNR_DISABLE_THREADS)
+endif()
+
 set(link_param "")
 if (STATIC_BUILD)
     set(Boost_USE_STATIC_LIBS   ON)
@@ -84,7 +102,6 @@ else()
         set(CMAKE_CXX_FLAGS_RELEASE "-Wall -fPIC -O3 -g -pipe")
     endif()
 endif()
-set(CMAKE_DEFIN)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/3rdparty/sanitizers-cmake/cmake;." ${CMAKE_MODULE_PATH})
 
@@ -99,7 +116,10 @@ endif()
 find_package(Sanitizers)
 
 # List of Boost libraries to include
-set(boost_libs filesystem thread program_options iostreams system)
+set(boost_libs filesystem program_options iostreams system)
+if (USE_THREADS)
+    list(APPEND boost_libs thread)
+endif()
 
 if (BUILD_GUI AND NOT BUILD_PYTHON)
     message(FATAL_ERROR "GUI requires Python to build")
@@ -229,6 +249,10 @@ foreach (family ${ARCH})
 
     # Add the CLI binary target
     add_executable(${PROGRAM_PREFIX}nextpnr-${family} ${COMMON_FILES} ${${ufamily}_FILES})
+    if (WASI)
+        # set(CMAKE_EXECUTABLE_SUFFIX) breaks CMake tests for some reason
+        set_property(TARGET ${PROGRAM_PREFIX}nextpnr-${family} PROPERTY SUFFIX ".wasm")
+    endif()
     install(TARGETS ${PROGRAM_PREFIX}nextpnr-${family} RUNTIME DESTINATION bin)
     target_compile_definitions(${PROGRAM_PREFIX}nextpnr-${family} PRIVATE MAIN_EXECUTABLE)
 

--- a/common/nextpnr.cc
+++ b/common/nextpnr.cc
@@ -23,6 +23,25 @@
 #include "log.h"
 #include "util.h"
 
+#if defined(__wasm)
+extern "C" {
+    // FIXME: WASI does not currently support exceptions.
+    void* __cxa_allocate_exception(size_t thrown_size) throw() {
+        return malloc(thrown_size);
+    }
+    bool __cxa_uncaught_exception() throw();
+    void __cxa_throw(void* thrown_exception, struct std::type_info * tinfo, void (*dest)(void*)) {
+        std::terminate();
+    }
+}
+
+namespace boost {
+    void throw_exception( std::exception const & e ) {
+        NEXTPNR_NAMESPACE::log_error("boost::exception(): %s\n", e.what());
+    }
+}
+#endif
+
 NEXTPNR_NAMESPACE_BEGIN
 
 assertion_failure::assertion_failure(std::string msg, std::string expr_str, std::string filename, int line)

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -71,12 +71,13 @@ const char *chipdb_blob_25k = nullptr;
 const char *chipdb_blob_45k = nullptr;
 const char *chipdb_blob_85k = nullptr;
 
-boost::iostreams::mapped_file_source blob_files[3];
+boost::iostreams::mapped_file blob_files[3];
 
 const char *mmap_file(int index, const char *filename)
 {
     try {
-        blob_files[index].open(filename);
+        // WASI only supports MAP_PRIVATE
+        blob_files[index].open(filename, boost::iostreams::mapped_file::priv);
         if (!blob_files[index].is_open())
             log_error("Unable to read chipdb %s\n", filename);
         return (const char *)blob_files[index].data();

--- a/ecp5/family.cmake
+++ b/ecp5/family.cmake
@@ -70,8 +70,9 @@ if (NOT EXTERNAL_CHIPDB)
         target_compile_options(ecp5_chipdb PRIVATE -g0 -O0 -w)
         set(PREV_DEV_CC_BBA_DB)
         foreach (dev ${devices})
-            set(DEV_CC_DB ${CMAKE_CURRENT_BINARY_DIR}/ecp5/chipdbs/chipdb-${dev}.cc)
             set(DEV_CC_BBA_DB ${CMAKE_CURRENT_BINARY_DIR}/ecp5/chipdbs/chipdb-${dev}.bba)
+            set(DEV_CC_DB ${CMAKE_CURRENT_BINARY_DIR}/ecp5/chipdbs/chipdb-${dev}.cc)
+            set(DEV_BIN_DB ${CMAKE_CURRENT_BINARY_DIR}/ecp5/chipdbs/chipdb-${dev}.bin)
             set(DEV_CONSTIDS_INC ${CMAKE_CURRENT_SOURCE_DIR}/ecp5/constids.inc)
             set(DEV_GFXH ${CMAKE_CURRENT_SOURCE_DIR}/ecp5/gfx.h)
             if (PREGENERATED_BBA_PATH)
@@ -85,11 +86,19 @@ if (NOT EXTERNAL_CHIPDB)
                     COMMAND mv ${DEV_CC_BBA_DB}.new ${DEV_CC_BBA_DB}
                     DEPENDS ${DB_PY} ${DEV_CONSTIDS_INC} ${DEV_GFXH} ${PREV_DEV_CC_BBA_DB}
                     )
-                add_custom_command(OUTPUT ${DEV_CC_DB}
-                    COMMAND bbasm --c ${BBASM_ENDIAN_FLAG} ${DEV_CC_BBA_DB} ${DEV_CC_DB}.new
-                    COMMAND mv ${DEV_CC_DB}.new ${DEV_CC_DB}
-                    DEPENDS bbasm ${DEV_CC_BBA_DB}
-                    )
+                if(USE_C_EMBED)
+                    add_custom_command(OUTPUT ${DEV_CC_DB}
+                        COMMAND bbasm --e ${BBASM_ENDIAN_FLAG} ${DEV_CC_BBA_DB} ${DEV_CC_DB}.new ${DEV_BIN_DB}
+                        COMMAND mv ${DEV_CC_DB}.new ${DEV_CC_DB}
+                        DEPENDS bbasm ${DEV_CC_BBA_DB}
+                        )
+                else()
+                    add_custom_command(OUTPUT ${DEV_CC_DB}
+                        COMMAND bbasm --c ${BBASM_ENDIAN_FLAG} ${DEV_CC_BBA_DB} ${DEV_CC_DB}.new
+                        COMMAND mv ${DEV_CC_DB}.new ${DEV_CC_DB}
+                        DEPENDS bbasm ${DEV_CC_BBA_DB}
+                        )
+                endif()
             endif()
             if (SERIALIZE_CHIPDB)
                 set(PREV_DEV_CC_BBA_DB ${DEV_CC_BBA_DB})

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -57,12 +57,12 @@ const char *chipdb_blob_5k = nullptr;
 const char *chipdb_blob_u4k = nullptr;
 const char *chipdb_blob_8k = nullptr;
 
-boost::iostreams::mapped_file_source blob_files[5];
+boost::iostreams::mapped_file blob_files[5];
 
 const char *mmap_file(int index, const char *filename)
 {
     try {
-        blob_files[index].open(filename);
+        blob_files[index].open(filename, boost::iostreams::mapped_file::priv);
         if (!blob_files[index].is_open())
             log_error("Unable to read chipdb %s\n", filename);
         return (const char *)blob_files[index].data();


### PR DESCRIPTION
This involves very few changes, all typical to WASM ports:
  * WASM doesn't currently [support threads](https://github.com/WebAssembly/threads) or atomics so those are disabled.
  * WASM doesn't currently [support exceptions](https://github.com/WebAssembly/exception-handling) so the exception machinery is stubbed out.
  * WASM doesn't (and can't) have mmap(), so an [emulation library](https://github.com/WebAssembly/wasi-libc/blob/master/libc-bottom-half/mman/mman.c) is used. That library currently doesn't support `MAP_SHARED` flags, so `MAP_PRIVATE` is used instead.

There is also an update to bring ECP5 bbasm CMake rules to parity with iCE40 ones, since although it is possible to embed chipdb into nextpnr on WASM, a 200 MB WASM file has very few practical uses.

The README is not updated and there is no included toolchain file because at the moment it's not possible to build nextpnr with upstream boost and wasi-libc. Boost requires a [patch](https://github.com/boostorg/filesystem/pull/144) (merged, will be available in boost 1.74.0), wasi-libc requires a few [unmerged](https://github.com/WebAssembly/wasi-libc/pull/197) [patches](https://github.com/WebAssembly/wasi-libc/pull/198).

<hr>

Nevertheless I will briefly describe in this PR how to build it. 

 1. Download [wasi-sdk-10](https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-10) and set `$WASI_SDK` to the location where it's unpacked
 2. Check out [wasi-libc](https://github.com/WebAssembly/wasi-libc/blob/master/Makefile)
 3. Apply [this patch](https://paste.debian.net/1148482/) to wasi-libc
 4. Build wasi-libc and note the location of `sysroot/lib/wasm32-wasi/libwasi-emulated-mman.a`
 5. Replace `-lwasi-emulated-mman` in `CMakeLists.txt` with the full path to `libwasi-emulated-mman.a`
 6. Download Boost 1.72.0, apply [this patch](https://paste.debian.net/1148477/) and bootstrap B2
 7. Place [this configuration](https://paste.debian.net/1148478/) into Boost root as `project-config.jam` (replacing `<WASI-SDK>` as appropriate) and run `./b2 threading=single link=static`
 8. Build bba and nextpnr for the host (native) with `-DUSE_C_EMBED=ON`. This will fail because your compiler probably doesn't support `#embed` but that's ok
 9. Place [this toolchain file](https://paste.debian.net/1148480/) into the target (WASM) build directory as `Toolchain-WASI.cmake`
 10. Run `cmake .. -DCMAKE_TOOLCHAIN_FILE=Toolchain-WASI.cmake -DSTATIC_BUILD=ON -DBOOST_ROOT=<Boost root> -DIMPORT_EXECUTABLES=<host build directory>/ImportExecutables.cmake -DARCH=<arch> -DBUILD_GUI=OFF -DBUILD_PYTHON=OFF -DEXTERNAL_CHIPDB=ON -DEXTERNAL_CHIPDB_ROOT=/share/nextpnr`
 11. Run `make`. You should have a `nextpnr-<arch>.wasm` now
 12. Pick a WASI runtime, say [wasmtime](https://github.com/bytecodealliance/wasmtime), then run `wasmtime run ./nextpnr-<arch>.wasm --dir . --mapdir /share/nextpnr/<arch>::<host build directory>/<arch>/chipdbs -- <args>` where `<args>` are the normal nextpnr arguments