### PR TITLE
ice40: Add support for the 2nd bit of SHIFTREG_DIV_MODE

### DIFF
--- a/ice40/bitstream.cc
+++ b/ice40/bitstream.cc
@@ -718,7 +718,7 @@ void write_asc(const Context *ctx, std::ostream &out)
                                                                          {"PLLOUT_SELECT_A", 2},
                                                                          {"PLLOUT_SELECT_B", 2},
                                                                          {"PLLTYPE", 3},
-                                                                         {"SHIFTREG_DIV_MODE", 1},
+                                                                         {"SHIFTREG_DIV_MODE", 2},
                                                                          {"TEST_MODE", 1}};
             configure_extra_cell(config, ctx, cell.second.get(), pll_params, false, std::string("PLL."));
 

--- a/ice40/bitstream.cc
+++ b/ice40/bitstream.cc
@@ -133,6 +133,16 @@ static const BelConfigPOD &get_ec_config(const ChipInfoPOD *chip, BelId bel)
 
 typedef std::vector<std::vector<std::vector<std::vector<int8_t>>>> chipconfig_t;
 
+static bool has_ec_cbit(const BelConfigPOD &cell_cbits, std::string name)
+{
+    for (int i = 0; i < cell_cbits.num_entries; i++) {
+        const auto &cbit = cell_cbits.entries[i];
+        if (cbit.entry_name.get() == name)
+            return true;
+    }
+    return false;
+}
+
 static void set_ec_cbit(chipconfig_t &config, const Context *ctx, const BelConfigPOD &cell_cbits, std::string name,
                         bool value, std::string prefix)
 {
@@ -190,7 +200,7 @@ void configure_extra_cell(chipconfig_t &config, const Context *ctx, CellInfo *ce
         }
 
         value.resize(p.second);
-        if (p.second == 1) {
+        if ((p.second == 1) || !has_ec_cbit(bc, p.first + "_0")) {
             set_ec_cbit(config, ctx, bc, p.first, value.at(0), prefix);
         } else {
             for (int i = 0; i < p.second; i++) {


### PR DESCRIPTION
This requires the matching chipdb update from icestorm project !

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>