### PR TITLE
Remove dead links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,3 @@ Links and references
 - [Arachne PNR](https://github.com/cseed/arachne-pnr)
 - [VPR/VTR](https://verilogtorouting.org/)
 - [SymbiFlow](https://github.com/SymbiFlow/symbiflow-arch-defs)
-- [Gaffe](https://github.com/gaffe-logic/gaffe)
-- [KinglerPAR](https://github.com/rqou/KinglerPAR)
-


### PR DESCRIPTION
Gaffe is completely gone for unknown reasons, KinglerPAR is just an empty repository