### PR TITLE
CMake: rewrite chipdb handling from ground up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TODO: sensible minimum CMake version
 cmake_minimum_required(VERSION 3.3)
-project(nextpnr)
+project(nextpnr CXX)
 
 option(BUILD_GUI "Build GUI" ON)
 option(BUILD_PYTHON "Build Python Integration" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-# TODO: sensible minimum CMake version
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(nextpnr CXX)
 
 option(BUILD_GUI "Build GUI" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,12 @@ option(USE_OPENMP "Use OpenMP to accelerate analytic placer" OFF)
 option(COVERAGE "Add code coverage info" OFF)
 option(STATIC_BUILD "Create static build" OFF)
 option(EXTERNAL_CHIPDB "Create build with pre-built chipdb binaries" OFF)
-option(SERIALIZE_CHIPDB "Never build chipdb in parallel to reduce peak memory use" ON)
+
+if(WIN32 OR EXTERNAL_CHIPDB)
+    set(BBASM_MODE "binary")
+else()
+    set(BBASM_MODE "string")
+endif()
 
 set(Boost_NO_BOOST_CMAKE ON)
 
@@ -56,10 +61,9 @@ if (STATIC_BUILD)
 endif()
 
 if (EXTERNAL_CHIPDB)
-    if (NOT DEFINED EXTERNAL_CHIPDB_ROOT)
-        message(STATUS "EXTERNAL_CHIPDB_ROOT not defined using -DEXTERNAL_CHIPDB_ROOT=/path/to/nextpnr. Default to /usr/share/nextpnr")
-        set(EXTERNAL_CHIPDB_ROOT "/usr/share/nextpnr")
-    endif()
+    set(EXTERNAL_CHIPDB_ROOT "${CMAKE_INSTALL_PREFIX}/share/nextpnr" CACHE STRING
+        "External chipdb path")
+    message(STATUS "Using external chipdb path: ${EXTERNAL_CHIPDB_ROOT}")
     add_definitions("-DEXTERNAL_CHIPDB_ROOT=\"${EXTERNAL_CHIPDB_ROOT}\"")
 endif()
 
@@ -234,10 +238,6 @@ aux_source_directory(frontend/ FRONTEND_FILES)
 set(COMMON_FILES ${COMMON_SRC_FILES} ${EXT_JSON11_FILES} ${JSON_PARSER_FILES} ${FRONTEND_FILES})
 set(CMAKE_BUILD_TYPE Release)
 
-if(MINGW)
-    add_definitions("-Wa,-mbig-obj")
-endif(MINGW)
-
 if(CMAKE_CROSSCOMPILING)
     set(BBA_IMPORT "IMPORTFILE-NOTFOUND" CACHE FILEPATH
         "Path to the `bba-export.cmake` export file from a native build")
@@ -255,7 +255,7 @@ else()
 endif()
 
 foreach (family ${ARCH})
-    message(STATUS "Configuring architecture : ${family}")
+    message(STATUS "Configuring architecture: ${family}")
     string(TOUPPER ${family} ufamily)
     aux_source_directory(${family}/ ${ufamily}_FILES)
 

--- a/bba/CMakeLists.txt
+++ b/bba/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.3)
-project(bba)
+project(bba CXX)
 
 find_package(Boost REQUIRED COMPONENTS
     program_options

--- a/bba/CMakeLists.txt
+++ b/bba/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(bba CXX)
 
 find_package(Boost REQUIRED COMPONENTS

--- a/ecp5/CMakeLists.txt
+++ b/ecp5/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(chipdb-ecp5 NONE)
 
 set(ALL_ECP5_DEVICES 25k 45k 85k)

--- a/ecp5/CMakeLists.txt
+++ b/ecp5/CMakeLists.txt
@@ -1,0 +1,92 @@
+cmake_minimum_required(VERSION 3.3)
+project(chipdb-ecp5 NONE)
+
+set(ALL_ECP5_DEVICES 25k 45k 85k)
+set(ECP5_DEVICES ${ALL_ECP5_DEVICES} CACHE STRING
+    "Include support for these ECP5 devices (available: ${ALL_ECP5_DEVICES})")
+message(STATUS "Enabled ECP5 devices: ${ECP5_DEVICES}")
+
+if(DEFINED ECP5_CHIPDB)
+    add_custom_target(chipdb-ecp5-bbas ALL)
+else()
+    find_package(PythonInterp 3.5 REQUIRED)
+
+    # shared among all families
+    set(SERIALIZE_CHIPDBS TRUE CACHE BOOL
+        "Serialize device data preprocessing to minimize memory use")
+
+    set(TRELLIS_PROGRAM_PREFIX "" CACHE STRING
+        "Trellis name prefix")
+    if(TRELLIS_PROGRAM_PREFIX)
+        message(STATUS "Trellis program prefix: ${TRELLIS_PROGRAM_PREFIX}")
+    endif()
+
+    set(TRELLIS_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX} CACHE STRING
+        "Trellis install prefix")
+    message(STATUS "Trellis install prefix: ${TRELLIS_INSTALL_PREFIX}")
+
+    if(NOT DEFINED TRELLIS_LIBDIR)
+        if(WIN32)
+            set(pytrellis_lib pytrellis.pyd)
+        else()
+            set(pytrellis_lib pytrellis${CMAKE_SHARED_LIBRARY_SUFFIX})
+        endif()
+        find_path(TRELLIS_LIBDIR ${pytrellis_lib}
+            HINTS ${TRELLIS_INSTALL_PREFIX}/lib/${TRELLIS_PROGRAM_PREFIX}trellis
+            PATHS ${CMAKE_SYSTEM_LIBRARY_PATH} ${CMAKE_LIBRARY_PATH}
+            PATH_SUFFIXES ${TRELLIS_PROGRAM_PREFIX}trellis
+            DOC "Location of the pytrellis library")
+        if(NOT TRELLIS_LIBDIR)
+            message(FATAL_ERROR "Failed to locate the pytrellis library")
+        endif()
+    endif()
+    message(STATUS "Trellis library directory: ${TRELLIS_LIBDIR}")
+
+    if(NOT DEFINED TRELLIS_DATADIR)
+        set(TRELLIS_DATADIR ${TRELLIS_INSTALL_PREFIX}/share/${TRELLIS_PROGRAM_PREFIX}trellis)
+    endif()
+    message(STATUS "Trellis data directory: ${TRELLIS_DATADIR}")
+
+    set(all_device_bbas)
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/chipdb)
+    foreach(device ${ECP5_DEVICES})
+        if(NOT device IN_LIST ALL_ECP5_DEVICES)
+            message(FATAL_ERROR "Device ${device} is not a supported ECP5 device")
+        endif()
+
+        set(device_bba chipdb/chipdb-${device}.bba)
+        add_custom_command(
+            OUTPUT ${device_bba}
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/trellis_import.py
+                -L ${TRELLIS_LIBDIR}
+                -L ${TRELLIS_DATADIR}/util/common
+                -L ${TRELLIS_DATADIR}/timing/util
+                -p ${CMAKE_CURRENT_SOURCE_DIR}/constids.inc
+                -g ${CMAKE_CURRENT_SOURCE_DIR}/gfx.h
+                ${device}
+                > ${device_bba}.new
+            # atomically update
+            COMMAND ${CMAKE_COMMAND} -E rename ${device_bba}.new ${device_bba}
+            DEPENDS
+                ${CMAKE_CURRENT_SOURCE_DIR}/trellis_import.py
+                ${CMAKE_CURRENT_SOURCE_DIR}/constids.inc
+                ${CMAKE_CURRENT_SOURCE_DIR}/gfx.h
+                ${PREVIOUS_CHIPDB_TARGET}
+            VERBATIM)
+        list(APPEND all_device_bbas ${device_bba})
+        if(SERIALIZE_CHIPDBS)
+            set(PREVIOUS_CHIPDB_TARGET ${CMAKE_CURRENT_BINARY_DIR}/${device_bba})
+        endif()
+    endforeach()
+
+    add_custom_target(chipdb-ecp5-bbas ALL DEPENDS ${all_device_bbas})
+
+    get_directory_property(has_parent PARENT_DIRECTORY)
+    if(has_parent)
+        set(ECP5_CHIPDB ${CMAKE_CURRENT_BINARY_DIR}/chipdb PARENT_SCOPE)
+        # serialize chipdb build across multiple architectures
+        set(PREVIOUS_CHIPDB_TARGET chipdb-ecp5-bbas PARENT_SCOPE)
+    else()
+        message(STATUS "Build nextpnr with -DECP5_CHIPDB=${CMAKE_CURRENT_BINARY_DIR}")
+    endif()
+endif()

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -62,7 +62,7 @@ void IdString::initialize_arch(const BaseCtx *ctx)
 
 static const ChipInfoPOD *get_chip_info(const RelPtr<ChipInfoPOD> *ptr) { return ptr->get(); }
 
-#if defined(_MSC_VER)
+#if defined(WIN32)
 void load_chipdb();
 #endif
 
@@ -97,7 +97,7 @@ void load_chipdb()
 
 Arch::Arch(ArchArgs args) : args(args)
 {
-#if defined(_MSC_VER) || defined(EXTERNAL_CHIPDB_ROOT)
+#if defined(WIN32) || defined(EXTERNAL_CHIPDB_ROOT)
     load_chipdb();
 #endif
 #ifdef LFE5U_45F_ONLY

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -207,7 +207,7 @@ NPNR_PACKED_STRUCT(struct ChipInfoPOD {
     RelPtr<SpeedGradePOD> speed_grades;
 });
 
-#if defined(_MSC_VER) || defined(EXTERNAL_CHIPDB_ROOT)
+#if defined(WIN32) || defined(EXTERNAL_CHIPDB_ROOT)
 extern const char *chipdb_blob_25k;
 extern const char *chipdb_blob_45k;
 extern const char *chipdb_blob_85k;

--- a/ecp5/resource/chipdb.rc
+++ b/ecp5/resource/chipdb.rc
@@ -1,5 +1,5 @@
 #include "resource.h"
 
-IDR_CHIPDB_25K  BINARYFILE "..\chipdbs\chipdb-25k.bin"
-IDR_CHIPDB_45K  BINARYFILE "..\chipdbs\chipdb-45k.bin"
-IDR_CHIPDB_88K  BINARYFILE "..\chipdbs\chipdb-85k.bin"
+IDR_CHIPDB_25K  BINARYFILE "ecp5/chipdb/chipdb-25k.bin"
+IDR_CHIPDB_45K  BINARYFILE "ecp5/chipdb/chipdb-45k.bin"
+IDR_CHIPDB_88K  BINARYFILE "ecp5/chipdb/chipdb-85k.bin"

--- a/ecp5/trellis_import.py
+++ b/ecp5/trellis_import.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
-import pytrellis
-import database
 import argparse
 import json
-import pip_classes
-import timing_dbs
+import sys
 from os import path
 
 location_types = dict()
@@ -17,7 +14,14 @@ parser = argparse.ArgumentParser(description="import ECP5 routing and bels from 
 parser.add_argument("device", type=str, help="target device")
 parser.add_argument("-p", "--constids", type=str, help="path to constids.inc")
 parser.add_argument("-g", "--gfxh", type=str, help="path to gfx.h")
+parser.add_argument("-L", "--libdir", type=str, action="append", help="extra Python library path")
 args = parser.parse_args()
+
+sys.path += args.libdir
+import pytrellis
+import database
+import pip_classes
+import timing_dbs
 
 with open(args.gfxh) as f:
     state = 0
@@ -437,7 +441,7 @@ def write_database(dev_name, chip, ddrg, endianness):
                 bba.u32(constids[wire_type(ddrg.to_str(wire.name))], "type")
                 if ("TILE_WIRE_" + ddrg.to_str(wire.name)) in gfx_wire_ids:
                     bba.u32(gfx_wire_ids["TILE_WIRE_" + ddrg.to_str(wire.name)], "tile_wire")
-                else:                    
+                else:
                     bba.u32(0, "tile_wire")
                 bba.u32(len(wire.arcsUphill), "num_uphill")
                 bba.u32(len(wire.arcsDownhill), "num_downhill")

--- a/ice40/CMakeLists.txt
+++ b/ice40/CMakeLists.txt
@@ -1,0 +1,90 @@
+cmake_minimum_required(VERSION 3.3)
+project(chipdb-ice40 NONE)
+
+set(ALL_ICE40_DEVICES 384 1k 5k u4k 8k)
+set(ICE40_DEVICES ${ALL_ICE40_DEVICES} CACHE STRING
+    "Include support for these iCE40 devices (available: ${ALL_ICE40_DEVICES})")
+message(STATUS "Enabled iCE40 devices: ${ICE40_DEVICES}")
+
+if(DEFINED ICE40_CHIPDB)
+    add_custom_target(chipdb-ice40-bbas ALL)
+else()
+    find_package(PythonInterp 3.5 REQUIRED)
+
+    # shared among all families
+    set(SERIALIZE_CHIPDBS TRUE CACHE BOOL
+        "Serialize device data preprocessing to minimize memory use")
+
+    set(icestorm_default_install_prefix ${CMAKE_INSTALL_PREFIX})
+    # for compatibility with old build scripts
+    if(DEFINED ICEBOX_ROOT)
+        message(WARNING "-DICEBOX_ROOT= is deprecated, use -DICESTORM_INSTALL_PREFIX=${ICEBOX_ROOT} instead")
+        get_filename_component(dir ${ICEBOX_ROOT} DIRECTORY)
+        get_filename_component(dir ${dir} DIRECTORY)
+        set(icestorm_default_install_prefix ${dir})
+    endif()
+    set(ICESTORM_INSTALL_PREFIX ${icestorm_default_install_prefix} CACHE STRING
+        "IceStorm install prefix")
+    message(STATUS "IceStorm install prefix: ${ICESTORM_INSTALL_PREFIX}")
+
+    if(NOT DEFINED ICEBOX_DATADIR)
+        set(ICEBOX_DATADIR ${ICESTORM_INSTALL_PREFIX}/share/icebox)
+    endif()
+    message(STATUS "icebox data directory: ${ICEBOX_DATADIR}")
+
+    set(all_device_bbas)
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/chipdb)
+    foreach(device ${ICE40_DEVICES})
+        if(NOT device IN_LIST ALL_ICE40_DEVICES)
+            message(FATAL_ERROR "Device ${device} is not a supported iCE40 device")
+        endif()
+
+        if(device STREQUAL "5k")
+            set(timing_opts
+                --slow ${ICEBOX_DATADIR}/timings_up5k.txt)
+        elseif(device STREQUAL "u4k")
+            set(timing_opts
+                --slow ${ICEBOX_DATADIR}/timings_u4k.txt)
+        elseif(device STREQUAL "384")
+            set(timing_opts
+                --slow ${ICEBOX_DATADIR}/timings_lp384.txt)
+        else()
+            set(timing_opts
+                --fast ${ICEBOX_DATADIR}/timings_hx${device}.txt
+                --slow ${ICEBOX_DATADIR}/timings_lp${device}.txt)
+        endif()
+
+        set(device_bba chipdb/chipdb-${device}.bba)
+        add_custom_command(
+            OUTPUT ${device_bba}
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/chipdb.py
+                -p ${CMAKE_CURRENT_SOURCE_DIR}/constids.inc
+                -g ${CMAKE_CURRENT_SOURCE_DIR}/gfx.h
+                ${timing_opts}
+                ${ICEBOX_DATADIR}/chipdb-${device}.txt
+                > ${device_bba}.new
+            # atomically update
+            COMMAND ${CMAKE_COMMAND} -E rename ${device_bba}.new ${device_bba}
+            DEPENDS
+                ${CMAKE_CURRENT_SOURCE_DIR}/chipdb.py
+                ${CMAKE_CURRENT_SOURCE_DIR}/constids.inc
+                ${CMAKE_CURRENT_SOURCE_DIR}/gfx.h
+                ${PREVIOUS_CHIPDB_TARGET}
+            VERBATIM)
+        list(APPEND all_device_bbas ${device_bba})
+        if(SERIALIZE_CHIPDBS)
+            set(PREVIOUS_CHIPDB_TARGET ${CMAKE_CURRENT_BINARY_DIR}/${device_bba})
+        endif()
+    endforeach()
+
+    add_custom_target(chipdb-ice40-bbas ALL DEPENDS ${all_device_bbas})
+
+    get_directory_property(has_parent PARENT_DIRECTORY)
+    if(has_parent)
+        set(ICE40_CHIPDB ${CMAKE_CURRENT_BINARY_DIR}/chipdb PARENT_SCOPE)
+        # serialize chipdb build across multiple architectures
+        set(PREVIOUS_CHIPDB_TARGET chipdb-ice40-bbas PARENT_SCOPE)
+    else()
+        message(STATUS "Build nextpnr with -DICE40_CHIPDB=${CMAKE_CURRENT_BINARY_DIR}")
+    endif()
+endif()

--- a/ice40/CMakeLists.txt
+++ b/ice40/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(chipdb-ice40 NONE)
 
 set(ALL_ICE40_DEVICES 384 1k 5k u4k 8k)

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -46,7 +46,7 @@ void IdString::initialize_arch(const BaseCtx *ctx)
 
 static const ChipInfoPOD *get_chip_info(const RelPtr<ChipInfoPOD> *ptr) { return ptr->get(); }
 
-#if defined(_MSC_VER)
+#if defined(WIN32)
 void load_chipdb();
 #endif
 
@@ -82,7 +82,7 @@ void load_chipdb()
 #endif
 Arch::Arch(ArchArgs args) : args(args)
 {
-#if defined(_MSC_VER) || defined(EXTERNAL_CHIPDB_ROOT)
+#if defined(WIN32) || defined(EXTERNAL_CHIPDB_ROOT)
     load_chipdb();
 #endif
 

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -244,7 +244,7 @@ NPNR_PACKED_STRUCT(struct ChipInfoPOD {
     RelPtr<RelPtr<char>> tile_wire_names;
 });
 
-#if defined(_MSC_VER) || defined(EXTERNAL_CHIPDB_ROOT)
+#if defined(WIN32) || defined(EXTERNAL_CHIPDB_ROOT)
 extern const char *chipdb_blob_384;
 extern const char *chipdb_blob_1k;
 extern const char *chipdb_blob_5k;

--- a/ice40/family.cmake
+++ b/ice40/family.cmake
@@ -1,123 +1,51 @@
-if (NOT EXTERNAL_CHIPDB)
-    if (ICE40_HX1K_ONLY)
-        set(devices 1k)
-        foreach (target ${family_targets})
-            target_compile_definitions(${target} PRIVATE ICE40_HX1K_ONLY=1)
-        endforeach (target)
-    else()
-        set(devices 384 1k 5k u4k 8k)
+add_subdirectory(${family})
+message(STATUS "Using iCE40 chipdb: ${ICE40_CHIPDB}")
+
+set(chipdb_sources)
+set(chipdb_binaries)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${family}/chipdb)
+foreach(device ${ICE40_DEVICES})
+    set(chipdb_bba ${ICE40_CHIPDB}/chipdb-${device}.bba)
+    set(chipdb_bin ${family}/chipdb/chipdb-${device}.bin)
+    set(chipdb_cc  ${family}/chipdb/chipdb-${device}.cc)
+    if(BBASM_MODE STREQUAL "binary")
+        add_custom_command(
+            OUTPUT ${chipdb_bin}
+            COMMAND bbasm ${BBASM_ENDIAN_FLAG} ${chipdb_bba} ${chipdb_bin}
+            DEPENDS bbasm chipdb-${family}-bbas ${chipdb_bba})
+        list(APPEND chipdb_binaries ${chipdb_bin})
+    elseif(BBASM_MODE STREQUAL "embed")
+        add_custom_command(
+            OUTPUT ${chipdb_cc} ${chipdb_bin}
+            COMMAND bbasm ${BBASM_ENDIAN_FLAG} --e ${chipdb_bba} ${chipdb_cc} ${chipdb_bin}
+            DEPENDS bbasm chipdb-${family}-bbas ${chipdb_bba})
+        list(APPEND chipdb_sources ${chipdb_cc})
+        list(APPEND chipdb_binaries ${chipdb_bin})
+    elseif(BBASM_MODE STREQUAL "string")
+        add_custom_command(
+            OUTPUT ${chipdb_cc}
+            COMMAND bbasm ${BBASM_ENDIAN_FLAG} --c ${chipdb_bba} ${chipdb_cc}
+            DEPENDS bbasm chipdb-${family}-bbas ${chipdb_bba})
+        list(APPEND chipdb_sources ${chipdb_cc})
     endif()
-
-    set(DB_PY ${CMAKE_CURRENT_SOURCE_DIR}/ice40/chipdb.py)
-
-    set(ICEBOX_ROOT ${CMAKE_INSTALL_PREFIX}/share/icebox CACHE STRING "icebox location root")
-    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ice40/chipdbs/)
-    add_library(ice40_chipdb OBJECT ${CMAKE_CURRENT_BINARY_DIR}/ice40/chipdbs/)
-    target_compile_definitions(ice40_chipdb PRIVATE NEXTPNR_NAMESPACE=nextpnr_${family})
-    target_include_directories(ice40_chipdb PRIVATE ${family}/)
-
-    if (MSVC)
-        target_sources(ice40_chipdb PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ice40/resource/embed.cc)
-        set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/ice40/resources/chipdb.rc PROPERTIES LANGUAGE RC)
-        set(PREV_DEV_CC_BBA_DB)
-        foreach (dev ${devices})
-            if (dev STREQUAL "5k")
-                set(OPT_FAST "")
-                set(OPT_SLOW --slow ${ICEBOX_ROOT}/timings_up5k.txt)
-            elseif (dev STREQUAL "u4k")
-                set(OPT_FAST "")
-                set(OPT_SLOW --slow ${ICEBOX_ROOT}/timings_u4k.txt)
-            elseif (dev STREQUAL "384")
-                set(OPT_FAST "")
-                set(OPT_SLOW --slow ${ICEBOX_ROOT}/timings_lp384.txt)
-            else()
-                set(OPT_FAST --fast ${ICEBOX_ROOT}/timings_hx${dev}.txt)
-                set(OPT_SLOW --slow ${ICEBOX_ROOT}/timings_lp${dev}.txt)
-            endif()
-            set(DEV_TXT_DB ${ICEBOX_ROOT}/chipdb-${dev}.txt)
-            set(DEV_CC_BBA_DB ${CMAKE_CURRENT_BINARY_DIR}/ice40/chipdbs/chipdb-${dev}.bba)
-            set(DEV_CC_DB ${CMAKE_CURRENT_BINARY_DIR}/ice40/chipdbs/chipdb-${dev}.bin)
-            set(DEV_CONSTIDS_INC ${CMAKE_CURRENT_SOURCE_DIR}/ice40/constids.inc)
-            set(DEV_GFXH ${CMAKE_CURRENT_SOURCE_DIR}/ice40/gfx.h)
-
-            if(PREGENERATED_BBA_PATH)
-                add_custom_command(OUTPUT ${DEV_CC_DB}
-                    COMMAND bbasm ${BBASM_ENDIAN_FLAG} ${PREGENERATED_BBA_PATH}/chipdb-${dev}.bba ${DEV_CC_DB}
-                    )
-            else()
-                add_custom_command(OUTPUT ${DEV_CC_BBA_DB}
-                    COMMAND ${PYTHON_EXECUTABLE} ${DB_PY} -p ${DEV_CONSTIDS_INC} -g ${DEV_GFXH} ${OPT_FAST} ${OPT_SLOW} ${DEV_TXT_DB} > ${DEV_CC_BBA_DB}
-                    DEPENDS ${DEV_CONSTIDS_INC} ${DEV_GFXH} ${DEV_TXT_DB} ${DB_PY} ${PREV_DEV_CC_BBA_DB}
-                    )
-                add_custom_command(OUTPUT ${DEV_CC_DB}
-                    COMMAND bbasm ${BBASM_ENDIAN_FLAG} ${DEV_CC_BBA_DB} ${DEV_CC_DB}
-                    DEPENDS bbasm ${DEV_CC_BBA_DB}
-                    )
-            endif()
-            if (SERIALIZE_CHIPDB)
-                set(PREV_DEV_CC_BBA_DB ${DEV_CC_BBA_DB})
-            endif()
-            target_sources(ice40_chipdb PRIVATE ${DEV_CC_DB})
-            set_source_files_properties(${DEV_CC_DB} PROPERTIES HEADER_FILE_ONLY TRUE)
-            foreach (target ${family_targets})
-                target_sources(${target} PRIVATE $<TARGET_OBJECTS:ice40_chipdb> ${CMAKE_CURRENT_SOURCE_DIR}/ice40/resource/chipdb.rc)
-            endforeach()
-        endforeach()
-    else()
-        target_compile_options(ice40_chipdb PRIVATE -g0 -O0 -w)
-        set(PREV_DEV_CC_BBA_DB)
-        foreach (dev ${devices})
-            if (dev STREQUAL "5k")
-                set(OPT_FAST "")
-                set(OPT_SLOW --slow ${ICEBOX_ROOT}/timings_up5k.txt)
-            elseif (dev STREQUAL "u4k")
-                set(OPT_FAST "")
-                set(OPT_SLOW --slow ${ICEBOX_ROOT}/timings_u4k.txt)
-            elseif (dev STREQUAL "384")
-                set(OPT_FAST "")
-                set(OPT_SLOW --slow ${ICEBOX_ROOT}/timings_lp384.txt)
-            else()
-                set(OPT_FAST --fast ${ICEBOX_ROOT}/timings_hx${dev}.txt)
-                set(OPT_SLOW --slow ${ICEBOX_ROOT}/timings_lp${dev}.txt)
-            endif()
-            set(DEV_TXT_DB ${ICEBOX_ROOT}/chipdb-${dev}.txt)
-            set(DEV_CC_BBA_DB ${CMAKE_CURRENT_BINARY_DIR}/ice40/chipdbs/chipdb-${dev}.bba)
-            set(DEV_CC_DB ${CMAKE_CURRENT_BINARY_DIR}/ice40/chipdbs/chipdb-${dev}.cc)
-            set(DEV_BIN_DB ${CMAKE_CURRENT_BINARY_DIR}/ice40/chipdbs/chipdb-${dev}.bin)
-            set(DEV_CONSTIDS_INC ${CMAKE_CURRENT_SOURCE_DIR}/ice40/constids.inc)
-            set(DEV_GFXH ${CMAKE_CURRENT_SOURCE_DIR}/ice40/gfx.h)
-            if(PREGENERATED_BBA_PATH)
-                add_custom_command(OUTPUT ${DEV_CC_DB}
-                    COMMAND bbasm --c ${BBASM_ENDIAN_FLAG} ${PREGENERATED_BBA_PATH}/chipdb-${dev}.bba ${DEV_CC_DB}.new
-                    COMMAND mv ${DEV_CC_DB}.new ${DEV_CC_DB}
-                    )
-            else()
-                add_custom_command(OUTPUT ${DEV_CC_BBA_DB}
-                    COMMAND ${PYTHON_EXECUTABLE} ${DB_PY} -p ${DEV_CONSTIDS_INC} -g ${DEV_GFXH} ${OPT_FAST} ${OPT_SLOW} ${DEV_TXT_DB} > ${DEV_CC_BBA_DB}.new
-                    COMMAND mv ${DEV_CC_BBA_DB}.new ${DEV_CC_BBA_DB}
-                    DEPENDS ${DEV_CONSTIDS_INC} ${DEV_GFXH} ${DEV_TXT_DB} ${DB_PY} ${PREV_DEV_CC_BBA_DB}
-                    )
-                if(USE_C_EMBED)
-                    add_custom_command(OUTPUT ${DEV_CC_DB}
-                        COMMAND bbasm --e ${BBASM_ENDIAN_FLAG} ${DEV_CC_BBA_DB} ${DEV_CC_DB}.new ${DEV_BIN_DB}
-                        COMMAND mv ${DEV_CC_DB}.new ${DEV_CC_DB}
-                        DEPENDS bbasm ${DEV_CC_BBA_DB}
-                        )
-                else()
-                    add_custom_command(OUTPUT ${DEV_CC_DB}
-                        COMMAND bbasm --c ${BBASM_ENDIAN_FLAG} ${DEV_CC_BBA_DB} ${DEV_CC_DB}.new
-                        COMMAND mv ${DEV_CC_DB}.new ${DEV_CC_DB}
-                        DEPENDS bbasm ${DEV_CC_BBA_DB}
-                        )
-                endif()
-            endif()
-            if (SERIALIZE_CHIPDB)
-                set(PREV_DEV_CC_BBA_DB ${DEV_CC_BBA_DB})
-            endif()
-            target_sources(ice40_chipdb PRIVATE ${DEV_CC_DB})
-            foreach (target ${family_targets})
-                target_sources(${target} PRIVATE $<TARGET_OBJECTS:ice40_chipdb>)
-            endforeach()
-        endforeach()
-    endif()
+endforeach()
+if(WIN32)
+    list(APPEND chipdb_sources
+        ${CMAKE_CURRENT_SOURCE_DIR}/${family}/resource/embed.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/${family}/resource/chipdb.rc)
 endif()
+
+add_custom_target(chipdb-${family}-bins DEPENDS ${chipdb_sources} ${chipdb_binaries})
+
+add_library(chipdb-${family} OBJECT ${ICE40_CHIPDB} ${chipdb_sources})
+add_dependencies(chipdb-${family} chipdb-${family}-bins)
+target_compile_options(chipdb-${family} PRIVATE -g0 -O0 -w)
+target_compile_definitions(chipdb-${family} PRIVATE NEXTPNR_NAMESPACE=nextpnr_${family})
+target_include_directories(chipdb-${family} PRIVATE ${family})
+if(ICE40_DEVICES STREQUAL "1k")
+    target_compile_definitions(chipdb-${family} PUBLIC ICE40_HX1K_ONLY=1)
+endif()
+
+foreach(family_target ${family_targets})
+    target_sources(${family_target} PRIVATE $<TARGET_OBJECTS:chipdb-${family}>)
+endforeach()

--- a/ice40/resource/chipdb.rc
+++ b/ice40/resource/chipdb.rc
@@ -1,7 +1,7 @@
 #include "resource.h"
 
-IDR_CHIPDB_384 BINARYFILE "..\chipdbs\chipdb-384.bin"
-IDR_CHIPDB_1K  BINARYFILE "..\chipdbs\chipdb-1k.bin"
-IDR_CHIPDB_5K  BINARYFILE "..\chipdbs\chipdb-5k.bin"
-IDR_CHIPDB_U4K BINARYFILE "..\chipdbs\chipdb-u4k.bin"
-IDR_CHIPDB_8K  BINARYFILE "..\chipdbs\chipdb-8k.bin"
+IDR_CHIPDB_384 BINARYFILE "ice40/chipdb/chipdb-384.bin"
+IDR_CHIPDB_1K  BINARYFILE "ice40/chipdb/chipdb-1k.bin"
+IDR_CHIPDB_5K  BINARYFILE "ice40/chipdb/chipdb-5k.bin"
+IDR_CHIPDB_U4K BINARYFILE "ice40/chipdb/chipdb-u4k.bin"
+IDR_CHIPDB_8K  BINARYFILE "ice40/chipdb/chipdb-8k.bin"


### PR DESCRIPTION
This addresses a lot of different issues:
  * The build system logic that handles the `.bba` files is massively simplified.
  * `.bba` files can now be built separately from the rest of nextpnr, simplifying pre-generation and cross-compilation.
  * `.bba` files can now be included into the binary using any desired approach (selected by the internal variable `BBASM_MODE`), independent from whether they are built separately or from the selected compiler. The default behavior is unchanged, with the exception that non-MSVC Win32 binaries also use the more efficient approach of using resource files.
  * The generation of `.bba` files is now serialized across a multi-architecture build, avoiding OOMs caused by building iCE40 and ECP5 chipdbs in parallel.
  * Both iCE40 and ECP5 can now be subsetted to use only some of the devices. This isn't yet handled by the nextpnr code (other than the existing HX1K case), which is left to a future PR.
  * Since both ECP5 and iCE40 require IceStorm/Trellis to be installed, their configuration options are unified; Trellis uses `-DTRELLIS_INSTALL_PREFIX=`, and IceStorm now uses `-DICESTORM_INSTALL_PREFIX=`. The old `-DICEBOX_ROOT` option is retained for compatibility.
  * Better documentation for cross-compilation and chipdb pre-generation.