### PR TITLE
ecp5: SYSCONFIG in LPF support

### DIFF
--- a/ecp5/baseconfigs.cc
+++ b/ecp5/baseconfigs.cc
@@ -514,7 +514,6 @@ void config_empty_lfe5u_45f(ChipConfig &cc)
     cc.tiles["MIB_R10C41:CMUX_UR_0"].add_arc("G_DCS0CLK1", "G_VPFN0000");
     cc.tiles["MIB_R58C40:CMUX_LL_0"].add_arc("G_DCS1CLK0", "G_VPFN0000");
     cc.tiles["MIB_R58C41:CMUX_LR_0"].add_arc("G_DCS1CLK1", "G_VPFN0000");
-    cc.tiles["MIB_R71C3:BANKREF8"].add_unknown(18, 0);
     cc.tiles["MIB_R71C4:EFB0_PICB0"].add_unknown(54, 1);
     cc.tiles["MIB_R71C4:EFB0_PICB0"].add_unknown(56, 1);
     cc.tiles["MIB_R71C4:EFB0_PICB0"].add_unknown(82, 1);

--- a/ecp5/bitstream.cc
+++ b/ecp5/bitstream.cc
@@ -701,9 +701,13 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
             auto tiles = ctx->getTilesAtLocation(y, x);
             for (auto tile : tiles) {
                 std::string type = tile.second;
-                if (type.find("BANKREF") != std::string::npos && type != "BANKREF8") {
+                if (type.find("BANKREF") != std::string::npos) {
                     int bank = std::stoi(type.substr(7));
-                    if (bankVcc.find(bank) != bankVcc.end()) {
+                    if (bank == 8 && ctx->settings.count(ctx->id("arch.sysconfig.CONFIG_IOVOLTAGE"))) {
+                        std::string vcc = str_or_default(ctx->settings, ctx->id("arch.sysconfig.CONFIG_IOVOLTAGE"));
+                        vcc.at(1) = 'V';
+                        cc.tiles[tile.first].add_enum("BANK.VCCIO", vcc);
+                    } else if (bankVcc.find(bank) != bankVcc.end()) {
                         if (bankVcc[bank] == IOVoltage::VCC_1V35)
                             cc.tiles[tile.first].add_enum("BANK.VCCIO", "1V2");
                         else
@@ -1404,6 +1408,8 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
             cc.tiles[ctx->getTileByType("EFB1_PICB1")].add_enum("OSC.MODE", "OSCG");
             cc.tiles[ctx->getTileByType("EFB1_PICB1")].add_enum("CCLK.MODE", "_NONE_");
         } else if (ci->type == id_USRMCLK) {
+            if (str_or_default(ctx->settings, ctx->id("arch.sysconfig.MASTER_SPI_PORT"), "") == "ENABLE")
+                log_warning("USRMCLK will not function correctly when MASTER_SPI_PORT is set to ENABLE.\n");
             cc.tiles[ctx->getTileByType("EFB3_PICB1")].add_enum("CCLK.MODE", "USRMCLK");
         } else if (ci->type == id_GSR) {
             cc.tiles[ctx->getTileByType("EFB0_PICB0")].add_enum(
@@ -1482,6 +1488,29 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
                                     str_or_default(ci->params, ctx->id("FORCE_MAX_DELAY"), "NO"));
         } else {
             NPNR_ASSERT_FALSE("unsupported cell type");
+        }
+    }
+
+    // Add some SYSCONFIG settings
+    const std::string prefix = "arch.sysconfig.";
+    for (auto &setting : ctx->settings) {
+        std::string key = setting.first.str(ctx);
+        if (key.substr(0, prefix.length()) != prefix)
+            continue;
+        key = key.substr(prefix.length());
+        std::string value = setting.second.as_string();
+        if (key == "SLAVE_SPI_PORT" || key == "DONE_EX") {
+            cc.tiles[ctx->getTileByType("EFB0_PICB0")].add_enum("SYSCONFIG." + key, value);
+            cc.tiles[ctx->getTileByType("EFB2_PICB0")].add_enum("SYSCONFIG." + key, value);
+        } else if (key == "SLAVE_PARALLEL_PORT" || key == "BACKGROUND_RECONFIG" || key == "WAKE_UP") {
+            cc.tiles[ctx->getTileByType("EFB0_PICB0")].add_enum("SYSCONFIG." + key, value);
+        } else if (key == "MASTER_SPI_PORT") {
+            cc.tiles[ctx->getTileByType("EFB1_PICB1")].add_enum("SYSCONFIG." + key, value);
+        } else if (key == "TRANSFR") {
+            cc.tiles[ctx->getTileByType("EFB0_PICB0")].add_enum("SYSCONFIG." + key, value);
+            cc.tiles[ctx->getTileByType("EFB1_PICB1")].add_enum("SYSCONFIG." + key, value);
+        } else {
+            cc.sysconfig[key] = value;
         }
     }
 

--- a/ecp5/config.cc
+++ b/ecp5/config.cc
@@ -267,6 +267,8 @@ std::ostream &operator<<(std::ostream &out, const ChipConfig &cc)
     out << ".device " << cc.chip_name << std::endl << std::endl;
     for (const auto &meta : cc.metadata)
         out << ".comment " << meta << std::endl;
+    for (const auto &sc : cc.sysconfig)
+        out << ".sysconfig " << sc.first << " " << sc.second << std::endl;
     out << std::endl;
     for (const auto &tile : cc.tiles) {
         if (!tile.second.empty()) {
@@ -311,6 +313,10 @@ std::istream &operator>>(std::istream &in, ChipConfig &cc)
             std::string line;
             getline(in, line);
             cc.metadata.push_back(line);
+        } else if (verb == ".sysconfig") {
+            std::string key, value;
+            in >> key >> value;
+            cc.sysconfig[key] = value;
         } else if (verb == ".tile") {
             std::string tilename;
             in >> tilename;

--- a/ecp5/config.h
+++ b/ecp5/config.h
@@ -114,6 +114,7 @@ class ChipConfig
     std::vector<std::string> metadata;
     std::map<std::string, TileConfig> tiles;
     std::vector<TileGroup> tilegroups;
+    std::map<std::string, std::string> sysconfig;
     std::map<uint16_t, std::vector<uint16_t>> bram_data;
 };
 


### PR DESCRIPTION
This allows config-related options to be specified in the SYSCONFIG line of the lpf file, compatible with Diamond's behaviour, like

```
SYSCONFIG CONFIG_IOVOLTAGE=3.3 COMPRESS_CONFIG=ON MCCLK_FREQ=62 MASTER_SPI_PORT=DISABLE SLAVE_SPI_PORT=DISABLE SLAVE_PARALLEL_PORT=DISABLE;
```
(example from ULX3S)

rather than the options either needing to go on the ecppack command line, or in some cases not being supported at all.

It depends on YosysHQ/prjtrellis#146 for these options to be processed after being included in the .config file.