### PR TITLE
nextpnr: Outline API for partition pins

### DIFF
--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -299,11 +299,19 @@ enum PlaceStrength
     STRENGTH_USER = 5
 };
 
+enum PortRefFlags : uint16_t
+{
+    // If this is set, the PortRef is a top level partition pin
+    // cell is nullptr and port is the pin name
+    PORTREF_PART_PIN = 1,
+};
+
 struct PortRef
 {
     CellInfo *cell = nullptr;
     IdString port;
     delay_t budget = 0;
+    uint16_t flags = 0;
 };
 
 struct PipMap
@@ -443,6 +451,9 @@ struct PortInfo
     NetInfo *net;
     PortType type;
     TimingConstrObjectId tmg_id;
+
+    // For top level partition pins, this is the corresponding wire
+    WireId partpin_wire;
 };
 
 struct CellInfo : ArchCellInfo
@@ -868,6 +879,9 @@ struct Context : Arch, DeterministicRNG
     WireId getNetinfoSourceWire(const NetInfo *net_info) const;
     WireId getNetinfoSinkWire(const NetInfo *net_info, const PortRef &sink) const;
     delay_t getNetinfoRouteDelay(const NetInfo *net_info, const PortRef &sink) const;
+
+    bool isPartPin(const PortRef &pin_ref) const;
+    WireId getPartPinWire(const PortRef &pin_ref) const;
 
     // provided by router1.cc
     bool checkRoutedDesign() const;

--- a/docs/netlist.md
+++ b/docs/netlist.md
@@ -36,8 +36,9 @@ Other structures used by these basic structures include:
 
  - `name` is the IdString name of the net - for nets with multiple names, one name is chosen according to a set of rules by the JSON frontend
  - `hierpath` is name of the hierarchical cell containing the instance, for designs with hierarchy
- - `driver` refers to the source of the net using `PortRef`; `driver.cell == nullptr` means that the net is undriven. Nets must have zero or one driver only. The corresponding cell port must be an output and its `PortInfo::net` must refer back to this net.
+ - `driver` refers to the source of the net using `PortRef`; `driver.cell == nullptr` means that the net is undriven (see caveat below). Nets must have zero or one driver only. The corresponding cell port must be an output and its `PortInfo::net` must refer back to this net.
  - `users` contains a list of `PortRef` references to sink ports on the net. Nets can have zero or more sinks. Each corresponding cell port must be an input or inout; and its `PortInfo::net` must refer back to this net.
+    - If a `PortRef` structure has `PORTREF_PART_PIN` set in `flags`, then it is a reference to a top level partition pin (e.g. for partial reconfiguration etc.). In this case `.cell` will be `nullptr` and `port` will be the partition pin name.
  - `wires` is a map that stores the routing tree of a net, if the net is routed.
     - Each entry in `wires` maps from *sink* wire in the routing tree to its driving pip, and the binding strength of that pip (e.g. how freely the router may rip up the pip)
     - Manipulation of this structure is done automatically by `Arch::bindWire`, `Arch::unbindWire`, `Arch::bindPip` and `Arch::unbindPip`; which should almost always be used in lieu of manual manipulation


### PR DESCRIPTION
This doesn't yet aim to actually implement full partial reconfig/partition support; instead it is the groundwork for such features.

Still TODO: add a Python function for creating these pins, and find out what breaks when we try and use them...