### PR TITLE
Fix MESSAGE indicating where externally-built .bbas live.

### DIFF
--- a/ecp5/CMakeLists.txt
+++ b/ecp5/CMakeLists.txt
@@ -111,6 +111,6 @@ else()
         # serialize chipdb build across multiple architectures
         set(PREVIOUS_CHIPDB_TARGET chipdb-ecp5-bbas PARENT_SCOPE)
     else()
-        message(STATUS "Build nextpnr with -DECP5_CHIPDB=${CMAKE_CURRENT_BINARY_DIR}")
+        message(STATUS "Build nextpnr with -DECP5_CHIPDB=${CMAKE_CURRENT_BINARY_DIR}/chipdb")
     endif()
 endif()

--- a/ice40/CMakeLists.txt
+++ b/ice40/CMakeLists.txt
@@ -85,6 +85,6 @@ else()
         # serialize chipdb build across multiple architectures
         set(PREVIOUS_CHIPDB_TARGET chipdb-ice40-bbas PARENT_SCOPE)
     else()
-        message(STATUS "Build nextpnr with -DICE40_CHIPDB=${CMAKE_CURRENT_BINARY_DIR}")
+        message(STATUS "Build nextpnr with -DICE40_CHIPDB=${CMAKE_CURRENT_BINARY_DIR}\chipdb")
     endif()
 endif()


### PR DESCRIPTION
Since #459 it's become _much_ easier to create `chipdb`s (specifically the `.bba`s) without requiring a machine with 4+GB of RAM. As part of CMake configuration, a message is printed indicating an option you should pass to `cmake` to use your fresh new `.bba`:

```
cmake -G"Ninja" -DCMAKE_INSTALL_PREFIX=/home/william/.local -DSERIALIZE_CHIPDBS=NO ../ice40
-- Enabled iCE40 devices: 384;1k;5k;u4k;8k
-- IceStorm install prefix: /home/william/.local
-- icebox data directory: /home/william/.local/share/icebox
-- Build nextpnr with -DICE40_CHIPDB=/home/william/Projects/FPGA/nextpnr/build-chipdb-ice40
-- Configuring done
-- Generating done
-- Build files have been written to: /home/william/Projects/FPGA/nextpnr/build-chipdb-ice40
```

The message (`Build nextpnr with -DICE40_CHIPDB=/home/william/Projects/FPGA/nextpnr/build-chipdb-ice40`) as-is points to the wrong directory for both `ice40` and `ecp5`. It should point to `/home/william/Projects/FPGA/nextpnr/build-chipdb-ice40/chipdb` instead), as indicated in this example build:

Initial, failing build:
```
william@xubuntu-dtrain:~/Projects/FPGA/nextpnr/build-extern-ice40$ cmake -G"Ninja" -DARCH=ice40 -DCMAKE_INSTALL_PREFIX=/home/william/.local -DICE40_CHIPDB=/home/william/Projects/FPGA/nextpnr/build-chipdb-ice40/ -DBUILD_HEAP=OFF -DBUILD_GUI=OFF -DBUILD_PYTHON=OFF ..
-- The CXX compiler identification is GNU 5.4.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found PythonInterp: /usr/bin/python3.5 (found suitable version "3.5.2", minimum required is "3.5")
-- Looking for C++ include pthread.h
-- Looking for C++ include pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-- Found Boost: /usr/include (found version "1.58.0") found components: filesystem program_options iostreams system thread regex chrono date_time atomic
-- Found Boost: /usr/include (found version "1.58.0") found components: program_options filesystem system
-- Check if the system is big endian
-- Searching 16 bit integer
-- Looking for C++ include sys/types.h
-- Looking for C++ include sys/types.h - found
-- Looking for C++ include stdint.h
-- Looking for C++ include stdint.h - found
-- Looking for C++ include stddef.h
-- Looking for C++ include stddef.h - found
-- Check size of unsigned short
-- Check size of unsigned short - done
-- Searching 16 bit integer - Using unsigned short
-- Check if the system is big endian - little endian
-- Configuring architecture: ice40
-- Enabled iCE40 devices: 384;1k;5k;u4k;8k
-- Using iCE40 chipdb: /home/william/Projects/FPGA/nextpnr/build-chipdb-ice40/
-- Configuring done
-- Generating done
-- Build files have been written to: /home/william/Projects/FPGA/nextpnr/build-extern-ice40
william@xubuntu-dtrain:~/Projects/FPGA/nextpnr/build-extern-ice40$ ninja
ninja: error: '../build-chipdb-ice40/chipdb-384.bba', needed by 'ice40/chipdb/chipdb-384.cc', missing and no known rule to make it
```

Reconfigured, successful build:

```
william@xubuntu-dtrain:~/Projects/FPGA/nextpnr/build-extern-ice40$ cmake -G"Ninja" -DARCH=ice40 -DCMAKE_INSTALL_PREFIX=/home/william/.local -DICE40_CHIPDB=/home/william/Projects/FPGA/nextpnr/build-chipdb-ice40/chipdb -DBUILD_HEAP=OFF -DBUILD_GUI=OFF -DBUILD_PYTHON=OFF ..
-- Found Boost: /usr/include (found version "1.58.0") found components: filesystem program_options iostreams system thread regex chrono date_time atomic
-- Found Boost: /usr/include (found version "1.58.0") found components: program_options filesystem system
-- Configuring architecture: ice40
-- Enabled iCE40 devices: 384;1k;5k;u4k;8k
-- Using iCE40 chipdb: /home/william/Projects/FPGA/nextpnr/build-chipdb-ice40/chipdb
-- Configuring done
-- Generating done
-- Build files have been written to: /home/william/Projects/FPGA/nextpnr/build-extern-ice40
william@xubuntu-dtrain:~/Projects/FPGA/nextpnr/build-extern-ice40$ ninja

william@xubuntu-dtrain:~/Projects/FPGA/nextpnr/build-extern-ice40$ nm ./nextpnr-ice40 | grep chipdb_blob_1k
00000000009bd9c0 r _ZN13nextpnr_ice40L14chipdb_blob_1kE
```

To avoid others in the future having the same problem, I modified the messages to point to the correct directory.

