### PR TITLE
Add option to print critical path source code

### DIFF
--- a/common/command.cc
+++ b/common/command.cc
@@ -158,6 +158,10 @@ po::options_description CommandHandler::getGeneralOptions()
     general.add_options()("no-tmdriv", "disable timing-driven placement");
     general.add_options()("sdf", po::value<std::string>(), "SDF delay back-annotation file to write");
     general.add_options()("sdf-cvc", "enable tweaks for SDF file compatibility with the CVC simulator");
+    general.add_options()("print-critical-path-source",
+                          "print the source code associated with each net in the critical path");
+    general.add_options()("critical-path-source-max-lines", po::value<int>(),
+                          "max number of source lines to print per critical path report entry");
 
     general.add_options()("placed-svg", po::value<std::string>(), "write render of placement to SVG file");
     general.add_options()("routed-svg", po::value<std::string>(), "write render of routing to SVG file");
@@ -177,6 +181,13 @@ void CommandHandler::setupContext(Context *ctx)
     if (vm.count("debug")) {
         ctx->verbose = true;
         ctx->debug = true;
+    }
+
+    if (vm.count("print-critical-path-source")) {
+        ctx->print_critical_path_source = true;
+    }
+    if (vm.count("critical-path-source-max-lines")) {
+        ctx->critical_path_source_max_lines = vm["critical-path-source-max-lines"].as<int>();
     }
 
     if (vm.count("force")) {

--- a/common/command.cc
+++ b/common/command.cc
@@ -158,10 +158,8 @@ po::options_description CommandHandler::getGeneralOptions()
     general.add_options()("no-tmdriv", "disable timing-driven placement");
     general.add_options()("sdf", po::value<std::string>(), "SDF delay back-annotation file to write");
     general.add_options()("sdf-cvc", "enable tweaks for SDF file compatibility with the CVC simulator");
-    general.add_options()("print-critical-path-source",
-                          "print the source code associated with each net in the critical path");
-    general.add_options()("critical-path-source-max-lines", po::value<int>(),
-                          "max number of source lines to print per critical path report entry");
+    general.add_options()("no-print-critical-path-source",
+                          "disable printing of the source lines associated with each net in the critical path");
 
     general.add_options()("placed-svg", po::value<std::string>(), "write render of placement to SVG file");
     general.add_options()("routed-svg", po::value<std::string>(), "write render of routing to SVG file");
@@ -183,11 +181,8 @@ void CommandHandler::setupContext(Context *ctx)
         ctx->debug = true;
     }
 
-    if (vm.count("print-critical-path-source")) {
-        ctx->print_critical_path_source = true;
-    }
-    if (vm.count("critical-path-source-max-lines")) {
-        ctx->critical_path_source_max_lines = vm["critical-path-source-max-lines"].as<int>();
+    if (vm.count("no-print-critical-path-source")) {
+        ctx->disable_critical_path_source_print = true;
     }
 
     if (vm.count("force")) {

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -861,6 +861,11 @@ struct Context : Arch, DeterministicRNG
     bool debug = false;
     bool force = false;
 
+    // Print verilog sources for nets in critical path?
+    bool print_critical_path_source = false;
+    // Max line count to print for critical path sources
+    int critical_path_source_max_lines = 8;
+
     Context(ArchArgs args) : Arch(args) {}
 
     // --------------------------------------------------------------

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -861,10 +861,8 @@ struct Context : Arch, DeterministicRNG
     bool debug = false;
     bool force = false;
 
-    // Print verilog sources for nets in critical path?
-    bool print_critical_path_source = false;
-    // Max line count to print for critical path sources
-    int critical_path_source_max_lines = 8;
+    // Should we disable printing of the location of nets in the critical path?
+    bool disable_critical_path_source_print = false;
 
     Context(ArchArgs args) : Arch(args) {}
 

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <boost/range/adaptor/reversed.hpp>
 #include <deque>
+#include <fstream>
 #include <map>
 #include <unordered_map>
 #include <utility>
@@ -811,6 +812,80 @@ void timing_analysis(Context *ctx, bool print_histogram, bool print_fmax, bool p
     }
 
     if (print_path) {
+        static auto print_net_source = [](Context *ctx, NetInfo *net) {
+            auto sources = net->attrs.find(ctx->id("src"));
+            if (sources == net->attrs.end()) {
+                // No sources for this net, can't print anything
+                return;
+            }
+
+            // Sources are separated by pipe characters, deepest source last
+            auto sourcelist = sources->second.as_string();
+            std::vector<std::string> source_entries;
+            size_t current = 0, prev = 0;
+            while ((current = sourcelist.find("|", prev)) != std::string::npos) {
+                source_entries.emplace_back(sourcelist.substr(prev, current - prev));
+                prev = current + 1;
+            }
+            // Ensure we emplace the final entry
+            source_entries.emplace_back(sourcelist.substr(prev, current - prev));
+
+            // For each source entry, split iinto filename, start line/character
+            // and end line/character
+            const unsigned entry_count = source_entries.size();
+            log_info("               Defined in:\n");
+            for (unsigned i = 0; i < entry_count; i++) {
+                const std::string source_entry = source_entries[i];
+                const bool is_final_entry = i == entry_count - 1;
+
+                log_info("                 %s\n", source_entry.c_str());
+
+                // Split the source entry to get the filename
+                const size_t filename_split = source_entry.find(":");
+                const std::string filename = source_entry.substr(0, filename_split);
+                const std::string location_tuple = source_entry.substr(filename_split + 1);
+
+                // Split the location tuple into start/end groups
+                const size_t start_end_split = location_tuple.find("-");
+                const std::string code_start = location_tuple.substr(0, start_end_split);
+                const std::string code_end = location_tuple.substr(start_end_split + 1);
+
+                // Extract just the line number from those tuples
+                const int code_start_line = std::atoi(code_start.substr(0, code_start.find(".")).c_str());
+                const int code_end_line = std::atoi(code_end.substr(0, code_end.find(".")).c_str());
+
+                // Try and stat the source file
+                std::ifstream in(filename);
+                if (!in) {
+                    // Failed to find source file, can't print the actual source
+                    return;
+                }
+
+                // Skip through to the start line
+                in.seekg(std::ios::beg);
+                for (int i = 0; i < code_start_line - 1; ++i) {
+                    in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+                }
+                // Log each line til we hit the end line / max line count
+                // For non-final entries, just print one line so we don't spam too heavily
+                int max_print_lines = ctx->critical_path_source_max_lines - 1;
+                if (!is_final_entry) {
+                    max_print_lines = 0; // Compare is inclusive
+                }
+                const int print_end =
+                        ((code_end_line < code_start_line + max_print_lines) ? code_end_line
+                                                                             : code_start_line + max_print_lines);
+                for (int i = code_start_line; i <= print_end; i++) {
+                    std::string line;
+                    getline(in, line);
+                    // Strip any whitespace from the start of the line, since we are already aligning it
+                    line.erase(line.begin(),
+                               std::find_if(line.begin(), line.end(), [](char c) { return !(c == ' ' || c == '\t'); }));
+                    log_info("                   %s\n", line.c_str());
+                }
+            }
+        };
+
         auto print_path_report = [ctx](ClockPair &clocks, PortRefVector &crit_path) {
             delay_t total = 0, logic_total = 0, route_total = 0;
             auto &front = crit_path.front();
@@ -887,6 +962,9 @@ void timing_analysis(Context *ctx, bool print_histogram, bool print_fmax, bool p
                                  ctx->getPipName(pip).c_str(ctx));
                         cursor = ctx->getPipSrcWire(pip);
                     }
+                }
+                if (ctx->print_critical_path_source) {
+                    print_net_source(ctx, net);
                 }
                 last_port = sink->port;
             }

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -22,7 +22,6 @@
 #include <algorithm>
 #include <boost/range/adaptor/reversed.hpp>
 #include <deque>
-#include <fstream>
 #include <map>
 #include <unordered_map>
 #include <utility>


### PR DESCRIPTION
In order to make debugging the critical path easier, print the location of the net definitions where known.

This output is on by default, but may be disabled by passing the `--no-print-critical-path-source` flag.

Example output:

```
Info: Critical path report for clock 'clk_48mhz_$glb_clk' (posedge -> posedge):
Info: curr total
Info:  0.5  0.5  Source driver.pixels_to_shift_SB_DFFE_Q_6_D_SB_LUT4_O_LC.O
Info:  0.6  1.1    Net driver.pixels_to_shift[0] budget 0.000000 ns (5,25) -> (5,25)
Info:                Sink driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO_SB_CARRY_CO_4_CI_SB_LUT4_O_LC.I3
Info:                Defined in:
Info:                  top.v:122.7-138.6
Info:                  panel_driver.v:135.44-135.63
Info:                  /usr/local/bin/../share/yosys/ice40/arith_map.v:43.21-43.22
Info:  0.3  1.4  Source driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO_SB_CARRY_CO_4_CI_SB_LUT4_O_LC.O
Info:  0.6  2.0    Net driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO[1] budget 0.000000 ns (5,25) -> (5,24)
Info:                Sink $nextpnr_ICESTORM_LC_48.I1
Info:                Defined in:
Info:                  top.v:122.7-138.6
Info:                  panel_driver.v:119.21-119.40
Info:                  /usr/local/bin/../share/yosys/ice40/arith_map.v:42.21-42.23
Info:  0.3  2.3  Source $nextpnr_ICESTORM_LC_48.COUT
Info:  0.0  2.3    Net $nextpnr_ICESTORM_LC_48$O budget 0.000000 ns (5,24) -> (5,24)
Info:                Sink driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO_SB_CARRY_CO_4$CARRY.CIN
Info:  0.1  2.4  Source driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO_SB_CARRY_CO_4$CARRY.COUT
Info:  0.0  2.4    Net driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO[2] budget 0.000000 ns (5,24) -> (5,24)
Info:                Sink driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO_SB_CARRY_CO_3$CARRY.CIN
Info:                Defined in:
Info:                  top.v:122.7-138.6
Info:                  panel_driver.v:119.21-119.40
Info:                  /usr/local/bin/../share/yosys/ice40/arith_map.v:43.21-43.22
Info:  0.1  2.5  Source driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO_SB_CARRY_CO_3$CARRY.COUT
Info:  0.0  2.5    Net driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO[3] budget 0.000000 ns (5,24) -> (5,24)
Info:                Sink driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO_SB_CARRY_CO_2$CARRY.CIN
Info:                Defined in:
Info:                  top.v:122.7-138.6
Info:                  panel_driver.v:119.21-119.40
Info:                  /usr/local/bin/../share/yosys/ice40/arith_map.v:43.21-43.22
Info:  0.1  2.7  Source driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO_SB_CARRY_CO_2$CARRY.COUT
Info:  0.0  2.7    Net driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO[4] budget 0.000000 ns (5,24) -> (5,24)
Info:                Sink driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO_SB_CARRY_CO_1$CARRY.CIN
Info:                Defined in:
Info:                  top.v:122.7-138.6
Info:                  panel_driver.v:119.21-119.40
Info:                  /usr/local/bin/../share/yosys/ice40/arith_map.v:43.21-43.22
Info:  0.1  2.8  Source driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO_SB_CARRY_CO_1$CARRY.COUT
Info:  0.0  2.8    Net driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO[5] budget 0.000000 ns (5,24) -> (5,24)
Info:                Sink driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO_SB_CARRY_CO$CARRY.CIN
Info:                Defined in:
Info:                  top.v:122.7-138.6
Info:                  panel_driver.v:119.21-119.40
Info:                  /usr/local/bin/../share/yosys/ice40/arith_map.v:43.21-43.22
Info:  0.1  2.9  Source driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO_SB_CARRY_CO$CARRY.COUT
Info:  0.0  2.9    Net driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO[6] budget 0.000000 ns (5,24) -> (5,24)
Info:                Sink driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1$CARRY.CIN
Info:                Defined in:
Info:                  top.v:122.7-138.6
Info:                  panel_driver.v:119.21-119.40
Info:                  /usr/local/bin/../share/yosys/ice40/arith_map.v:43.21-43.22
Info:  0.1  3.0  Source driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1$CARRY.COUT
Info:  0.0  3.0    Net driver.pixels_to_shift_SB_LUT4_O_I3_SB_CARRY_I1_CO[7] budget 0.000000 ns (5,24) -> (5,24)
Info:                Sink driver.data_clock_SB_LUT4_I3_I2_SB_CARRY_CO$CARRY.CIN
Info:                Defined in:
Info:                  top.v:122.7-138.6
Info:                  panel_driver.v:119.21-119.40
Info:                  /usr/local/bin/../share/yosys/ice40/arith_map.v:43.21-43.22
Info:  0.1  3.2  Source driver.data_clock_SB_LUT4_I3_I2_SB_CARRY_CO$CARRY.COUT
Info:  0.5  3.6    Net $nextpnr_ICESTORM_LC_49$I3 budget 0.560000 ns (5,24) -> (5,25)
Info:                Sink $nextpnr_ICESTORM_LC_49.I3
Info:  0.3  3.9  Source $nextpnr_ICESTORM_LC_49.O
Info:  0.6  4.5    Net driver.data_clock_SB_LUT4_I3_I2 budget 6.990000 ns (5,25) -> (5,26)
Info:                Sink driver.data_clock_SB_DFFE_Q_E_SB_LUT4_O_LC.I2
Info:  0.4  4.9  Source driver.data_clock_SB_DFFE_Q_E_SB_LUT4_O_LC.O
Info:  1.3  6.2    Net driver.data_clock_SB_DFFE_Q_E budget 3.446000 ns (5,26) -> (6,22)
Info:                Sink driver.data_clock_SB_LUT4_I2_LC.I3
Info:  0.3  6.5  Source driver.data_clock_SB_LUT4_I2_LC.O
Info:  1.9  8.4    Net driver.data_clock_SB_LUT4_I2_O budget 4.029000 ns (6,22) -> (3,22)
Info:                Sink driver.data_b_SB_DFFE_Q_D_SB_LUT4_O_LC.CEN
Info:  0.1  8.5  Setup driver.data_b_SB_DFFE_Q_D_SB_LUT4_O_LC.CEN
Info: 3.1 ns logic, 5.4 ns routing
```