### PR TITLE
Preserve cmd parameters  when loading json from GUI

### DIFF
--- a/common/command.cc
+++ b/common/command.cc
@@ -430,7 +430,6 @@ int CommandHandler::exec()
 
 std::unique_ptr<Context> CommandHandler::load_json(std::string filename)
 {
-    vm.clear();
     std::unordered_map<std::string, Property> values;
     std::unique_ptr<Context> ctx = createContext(values);
     setupContext(ctx.get());
@@ -442,6 +441,11 @@ std::unique_ptr<Context> CommandHandler::load_json(std::string filename)
     }
     customAfterLoad(ctx.get());
     return ctx;
+}
+
+void CommandHandler::clear()
+{
+    vm.clear();
 }
 
 void CommandHandler::run_script_hook(const std::string &name)

--- a/common/command.h
+++ b/common/command.h
@@ -38,6 +38,7 @@ class CommandHandler
 
     int exec();
     std::unique_ptr<Context> load_json(std::string filename);
+    void clear();
 
   protected:
     virtual void setupArchContext(Context *ctx) = 0;

--- a/gui/ecp5/mainwindow.cc
+++ b/gui/ecp5/mainwindow.cc
@@ -110,6 +110,7 @@ void MainWindow::new_proj()
         QString package = QInputDialog::getItem(this, "Select package", "Package:", packages, 0, false, &ok);
 
         if (ok && !item.isEmpty()) {
+            handler->clear();
             currentProj = "";
             disableActions();
             chipArgs.package = package.toStdString().c_str();

--- a/gui/ice40/mainwindow.cc
+++ b/gui/ice40/mainwindow.cc
@@ -114,6 +114,7 @@ void MainWindow::new_proj()
         QString package = QInputDialog::getItem(this, "Select package", "Package:", packages, 0, false, &ok);
 
         if (ok && !item.isEmpty()) {
+            handler->clear();
             currentProj = "";
             disableActions();
             chipArgs.package = package.toStdString().c_str();


### PR DESCRIPTION
When nextpnr is started with `nextpnr-ice40 --hx8k --package ct256 --gui ` after loading JSON from GUI it would switch to default architecture and package ignoring command line parameters. 
This patch makes sure that currently set command line parameters are effective until "New" option is set and target FPGA is changed.