### PR TITLE
Building nextpnr on Devuan ascii 2.0 needs the "C" language enabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(nextpnr CXX)
+project(nextpnr CXX C)
 
 option(BUILD_GUI "Build GUI" ON)
 option(BUILD_PYTHON "Build Python Integration" ON)


### PR DESCRIPTION
See https://lists.j-core.org/pipermail/j-core/2020-September/000940.html