### PR TITLE
Update generic synth script for dfflegalize changes

### DIFF
--- a/.cirrus/Dockerfile.ubuntu16.04
+++ b/.cirrus/Dockerfile.ubuntu16.04
@@ -37,7 +37,7 @@ RUN set -e -x ;\
     cd /usr/local/src ;\
     git clone --recursive https://github.com/YosysHQ/yosys.git ;\
     cd yosys ;\
-    git reset --hard 292f03355a425ede48051c79d5bf619591531080 ;\
+    git reset --hard cd8b2ed4e6f9447c94d801de7db7ae6ce0976d57 ;\
     make -j $(nproc) ;\
     make install ;\
     rm -rf /usr/local/src/yosys

--- a/generic/synth/synth_generic.tcl
+++ b/generic/synth/synth_generic.tcl
@@ -14,6 +14,7 @@ yosys memory_map
 yosys opt -full
 yosys techmap -map +/techmap.v
 yosys opt -fast
+yosys dfflegalize -cell \$_DFF_P_ 0
 yosys abc -lut $LUT_K -dress
 yosys clean
 yosys techmap -D LUT_K=$LUT_K -map [file dirname [file normalize $argv0]]/cells_map.v


### PR DESCRIPTION
Since the dfflegalize changes, the current script leaks DFF cells, which need to be converted to the right type to synth correctly.

Note this assumes the generic flop initialises to zero. Not 100% sure if this is correct, but supplying `x` will fail to synth anything that uses an init value at all.