### PR TITLE
update doc for ECP5 constraints

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -9,11 +9,18 @@ The iCE40 architecture supports PCF constraints thus:
 
     set_io led[0] 3
 
-and the ECP5 architecture supports a subset of LPF constraints:
+and the ECP5 architecture supports a subset of LPF constraints (for details see Lattice Technical Note "FPGA-TN-02032 1.3"):
 
     LOCATE COMP "led[0]" SITE "E16";
     IOBUF PORT "led[0]" IO_TYPE=LVCMOS25;
-
+    IOBUF ...  DRIVE=8;
+    IOBUF ... OPENDRAIN=ON|OFF;
+    IOBUF ... TERMINATION=50;
+    IOBUF ... DIFFRESISTOR=100; //for differential IO only
+    IOBUF ... CLAMP=ON|OFF;
+    IOBUF ... PULLMODE=UP|DOWN|NONE;
+    IOBUF ... SLEWRATE=FAST|SLOW; //outputs only
+    IOBUF ... HYSTERESIS=ON|OFF;
 
 ## Absolute Placement Constraints
 


### PR DESCRIPTION
It looks like nextpnr does support quite a lot more constraints than currently documented. This is a first attempt to fix this. Please note that i only checked if nextpnr does accept the constraints without an error or warning, i did NOT test if they have an effect on real hardware. Maybe this should be done before merging my changes, but at least with this pull request there is a notice about the need to update the doc.