### PR TITLE
Remove wire alias API

### DIFF
--- a/common/arch_pybindings_shared.h
+++ b/common/arch_pybindings_shared.h
@@ -95,8 +95,6 @@ fn_wrapper_1a<Context, decltype(&Context::getPipsDownhill), &Context::getPipsDow
               conv_from_str<WireId>>::def_wrap(ctx_cls, "getPipsDownhill");
 fn_wrapper_1a<Context, decltype(&Context::getPipsUphill), &Context::getPipsUphill, wrap_context<PipRange>,
               conv_from_str<WireId>>::def_wrap(ctx_cls, "getPipsUphill");
-fn_wrapper_1a<Context, decltype(&Context::getWireAliases), &Context::getWireAliases, wrap_context<PipRange>,
-              conv_from_str<WireId>>::def_wrap(ctx_cls, "getWireAliases");
 
 fn_wrapper_1a<Context, decltype(&Context::getPipSrcWire), &Context::getPipSrcWire, conv_to_str<WireId>,
               conv_from_str<PipId>>::def_wrap(ctx_cls, "getPipSrcWire");

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -335,15 +335,6 @@ Get all pips downhill of a wire, i.e. pips that use this wire as source wire.
 
 Get all pips uphill of a wire, i.e. pips that use this wire as destination wire.
 
-### const\_range\<PipId\> getWireAliases(WireId wire) const
-
-Get all alias pips downhill of a wire.
-
-There is no api for getting the alias pips uphill of a wire.
-
-Alias pips come in antiparallel pairs if a signal can be injected on either
-side of the alias pip.
-
 Group Methods
 -------------
 

--- a/docs/generic.md
+++ b/docs/generic.md
@@ -28,10 +28,6 @@ Adds a pip (programmable connection between two named wires). Pip delays that co
 
 Loc is constructed using `Loc(x, y, z)`. 'z' for pips is only important if region constraints (e.g. for partial reconfiguration regions) are used.
 
-### void addAlias(IdString name, IdString type, IdString srcWire, IdString dstWire, DelayInfo delay);
-
-Adds a wire alias (fixed connection between two named wires). Alias delays that correspond to delay estimates are important for router performance (as the router uses an A* type algorithm), even if timing is otherwise not of importance.
-
 ### void addBel(IdString name, IdString type, Loc loc, bool gb);
 
 Adds a bel to the FPGA description. Bel type should match the type of cells in the netlist that are placed at this bel (see below for information on special bel types supported by the packer). Loc is constructed using `Loc(x, y, z)` and must be unique.

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -886,15 +886,6 @@ struct Arch : BaseCtx
         return range;
     }
 
-    PipRange getWireAliases(WireId wire) const
-    {
-        PipRange range;
-        NPNR_ASSERT(wire != WireId());
-        range.b.cursor = nullptr;
-        range.e.cursor = nullptr;
-        return range;
-    }
-
     std::string getPipTilename(PipId pip) const
     {
         auto &tileloc = chip_info->tile_info[pip.location.y * chip_info->width + pip.location.x];

--- a/generic/arch.cc
+++ b/generic/arch.cc
@@ -90,20 +90,6 @@ void Arch::addPip(IdString name, IdString type, IdString srcWire, IdString dstWi
     tilePipDimZ[loc.x][loc.y] = std::max(tilePipDimZ[loc.x][loc.y], loc.z + 1);
 }
 
-void Arch::addAlias(IdString name, IdString type, IdString srcWire, IdString dstWire, DelayInfo delay)
-{
-    NPNR_ASSERT(pips.count(name) == 0);
-    PipInfo &pi = pips[name];
-    pi.name = name;
-    pi.type = type;
-    pi.srcWire = srcWire;
-    pi.dstWire = dstWire;
-    pi.delay = delay;
-
-    wire_info(srcWire).aliases.push_back(name);
-    pip_ids.push_back(name);
-}
-
 void Arch::addBel(IdString name, IdString type, Loc loc, bool gb)
 {
     NPNR_ASSERT(bels.count(name) == 0);
@@ -466,8 +452,6 @@ DelayInfo Arch::getPipDelay(PipId pip) const { return pips.at(pip).delay; }
 const std::vector<PipId> &Arch::getPipsDownhill(WireId wire) const { return wires.at(wire).downhill; }
 
 const std::vector<PipId> &Arch::getPipsUphill(WireId wire) const { return wires.at(wire).uphill; }
-
-const std::vector<PipId> &Arch::getWireAliases(WireId wire) const { return wires.at(wire).aliases; }
 
 // ---------------------------------------------------------------
 

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -50,7 +50,7 @@ struct WireInfo
     IdString name, type;
     std::map<IdString, std::string> attrs;
     NetInfo *bound_net;
-    std::vector<PipId> downhill, uphill, aliases;
+    std::vector<PipId> downhill, uphill;
     BelPin uphill_bel_pin;
     std::vector<BelPin> downhill_bel_pins;
     std::vector<BelPin> bel_pins;
@@ -142,7 +142,6 @@ struct Arch : BaseCtx
 
     void addWire(IdString name, IdString type, int x, int y);
     void addPip(IdString name, IdString type, IdString srcWire, IdString dstWire, DelayInfo delay, Loc loc);
-    void addAlias(IdString name, IdString type, IdString srcWire, IdString dstWire, DelayInfo delay);
 
     void addBel(IdString name, IdString type, Loc loc, bool gb);
     void addBelInput(IdString bel, IdString name, IdString wire);
@@ -241,7 +240,6 @@ struct Arch : BaseCtx
     DelayInfo getPipDelay(PipId pip) const;
     const std::vector<PipId> &getPipsDownhill(WireId wire) const;
     const std::vector<PipId> &getPipsUphill(WireId wire) const;
-    const std::vector<PipId> &getWireAliases(WireId wire) const;
 
     GroupId getGroupByName(IdString name) const;
     IdString getGroupName(GroupId group) const;

--- a/generic/arch_pybindings.cc
+++ b/generic/arch_pybindings.cc
@@ -120,8 +120,6 @@ void arch_wrap_python(py::module &m)
                                                                                              "getPipsDownhill");
     fn_wrapper_1a<Context, decltype(&Context::getPipsUphill), &Context::getPipsUphill,
                   wrap_context<const std::vector<PipId> &>, conv_from_str<WireId>>::def_wrap(ctx_cls, "getPipsUphill");
-    fn_wrapper_1a<Context, decltype(&Context::getWireAliases), &Context::getWireAliases,
-                  wrap_context<const std::vector<PipId> &>, conv_from_str<WireId>>::def_wrap(ctx_cls, "getWireAliases");
 
     fn_wrapper_1a<Context, decltype(&Context::getPipSrcWire), &Context::getPipSrcWire, conv_to_str<WireId>,
                   conv_from_str<PipId>>::def_wrap(ctx_cls, "getPipSrcWire");
@@ -162,10 +160,6 @@ void arch_wrap_python(py::module &m)
                     conv_from_str<IdString>, conv_from_str<IdString>, conv_from_str<IdString>, pass_through<DelayInfo>,
                     pass_through<Loc>>::def_wrap(ctx_cls, "addPip", "name"_a, "type"_a, "srcWire"_a, "dstWire"_a,
                                                  "delay"_a, "loc"_a);
-    fn_wrapper_5a_v<Context, decltype(&Context::addAlias), &Context::addAlias, conv_from_str<IdString>,
-                    conv_from_str<IdString>, conv_from_str<IdString>, conv_from_str<IdString>,
-                    pass_through<DelayInfo>>::def_wrap(ctx_cls, "addAlias", "name"_a, "type"_a, "srcWire"_a,
-                                                       "dstWire"_a, "delay"_a);
 
     fn_wrapper_4a_v<Context, decltype(&Context::addBel), &Context::addBel, conv_from_str<IdString>,
                     conv_from_str<IdString>, pass_through<Loc>, pass_through<bool>>::def_wrap(ctx_cls, "addBel",

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -782,15 +782,6 @@ struct Arch : BaseCtx
         return range;
     }
 
-    PipRange getWireAliases(WireId wire) const
-    {
-        PipRange range;
-        NPNR_ASSERT(wire != WireId());
-        range.b.cursor = nullptr;
-        range.e.cursor = nullptr;
-        return range;
-    }
-
     BelId getPackagePinBel(const std::string &pin) const;
     std::string getBelPackagePin(BelId bel) const;
 


### PR DESCRIPTION
It has not actually been implemented in any router for over 2.5 years and causes nothing more than confusion. It can always be added back if it forms part of a future solution; possibly as part of a more general database structure rethink.
