### PR TITLE
ice40/pack/SB_PLL: Force fixed value to 4'b1111 if dynamic delay is used

### DIFF
--- a/ice40/pack.cc
+++ b/ice40/pack.cc
@@ -1304,17 +1304,19 @@ static void pack_special(Context *ctx)
                         log_error("Invalid PLL output selection '%s'\n", param.second.as_string().c_str());
                     packed->params[pos_map_name.at(param.first)] = pos_map_val.at(param.second.as_string());
                 }
-            const std::map<IdString, IdString> delmodes = {
-                    {ctx->id("DELAY_ADJUSTMENT_MODE_FEEDBACK"), ctx->id("DELAY_ADJMODE_FB")},
-                    {ctx->id("DELAY_ADJUSTMENT_MODE_RELATIVE"), ctx->id("DELAY_ADJMODE_REL")},
+            const std::map<IdString, std::pair<IdString, IdString>> delmodes = {
+                    {ctx->id("DELAY_ADJUSTMENT_MODE_FEEDBACK"), {ctx->id("DELAY_ADJMODE_FB"), ctx->id("FDA_FEEDBACK")}},
+                    {ctx->id("DELAY_ADJUSTMENT_MODE_RELATIVE"),
+                     {ctx->id("DELAY_ADJMODE_REL"), ctx->id("FDA_RELATIVE")}},
             };
             for (auto delmode : delmodes) {
                 if (ci->params.count(delmode.first)) {
                     std::string value = str_or_default(ci->params, delmode.first, "");
-                    if (value == "DYNAMIC")
-                        packed->params[delmode.second] = 1;
-                    else if (value == "FIXED")
-                        packed->params[delmode.second] = 0;
+                    if (value == "DYNAMIC") {
+                        packed->params[delmode.second.first] = 1;
+                        packed->params[delmode.second.second] = 15;
+                    } else if (value == "FIXED")
+                        packed->params[delmode.second.first] = 0;
                     else
                         log_error("Invalid PLL %s selection '%s'\n", delmode.first.c_str(ctx), value.c_str());
                 }


### PR DESCRIPTION
It's been confirmed that :
 (1) this is required by the hardware
 (2) icecube will force that field to 4'b1111 in fixed mode

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>