### PR TITLE
RelPtr: remove copy constructor and copy assignment

### DIFF
--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -45,6 +45,9 @@ template <typename T> struct RelPtr
     const T &operator*() const { return *(get()); }
 
     const T *operator->() const { return get(); }
+
+    RelPtr(const RelPtr &) = delete;
+    RelPtr &operator=(const RelPtr &) = delete;
 };
 
 NPNR_PACKED_STRUCT(struct BelWirePOD {

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -41,6 +41,9 @@ template <typename T> struct RelPtr
     const T &operator*() const { return *(get()); }
 
     const T *operator->() const { return get(); }
+
+    RelPtr(const RelPtr &) = delete;
+    RelPtr &operator=(const RelPtr &) = delete;
 };
 
 NPNR_PACKED_STRUCT(struct BelWirePOD {


### PR DESCRIPTION
These operations are meaningless for a data structure that references another structure relative to its location.

cc @pepijndevos 

