### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/ecp5/CMakeLists.txt
+++ b/ecp5/CMakeLists.txt
@@ -52,7 +52,7 @@ else()
         if(WIN32)
             set(pytrellis_lib pytrellis.pyd)
         else()
-            set(pytrellis_lib pytrellis${CMAKE_SHARED_LIBRARY_SUFFIX})
+            set(pytrellis_lib pytrellis${CMAKE_SHARED_MODULE_SUFFIX})
         endif()
 
         find_path(TRELLIS_LIBDIR ${pytrellis_lib}


### PR DESCRIPTION
It seems Prjtrellis has CMAKE define pytrellis as a shared module, not library.
On MacOS, this makes a difference as NextPNR expected ``.dylib``
instead of ``.so``. Shared module also work on Linux.