### PR TITLE
Fix opensuse build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,10 @@ foreach (family ${ARCH})
         set(family_targets ${family_targets} ${PROGRAM_PREFIX}nextpnr-${family}-test)
     endif()
 
+    if(BUILD_HEAP)
+        target_link_libraries(${PROGRAM_PREFIX}nextpnr-${family} PRIVATE Eigen3::Eigen)
+    endif()
+
     # Include the family-specific CMakeFile
     include(${family}/family.cmake)
     foreach (target ${family_targets})


### PR DESCRIPTION
Fixes #467.

The `EIGEN3_*` variables could be removed, too. But for the fix, I wanted to keep the changes minimal.