### PR TITLE
C++17 compatibility: Don't use std::random_shuffle

### DIFF
--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -631,13 +631,19 @@ struct DeterministicRNG
             rng64();
     }
 
+    template <typename Iter> void shuffle(const Iter& begin, const Iter& end)
+    {
+        size_t size = end - begin;
+        for (size_t i = 0; i != size; i++) {
+            size_t j = i + rng(size - i);
+            if (j > i)
+                std::swap(*(begin + i), *(begin + j));
+        }
+    }
+
     template <typename T> void shuffle(std::vector<T> &a)
     {
-        for (size_t i = 0; i != a.size(); i++) {
-            size_t j = i + rng(a.size() - i);
-            if (j > i)
-                std::swap(a[i], a[j]);
-        }
+        shuffle(a.begin(), a.end());
     }
 
     template <typename T> void sorted_shuffle(std::vector<T> &a)

--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -530,7 +530,7 @@ class HeAPPlacer
             available_bels[ctx->getBelType(bel)].push_back(bel);
         }
         for (auto &t : available_bels) {
-            std::random_shuffle(t.second.begin(), t.second.end(), [&](size_t n) { return ctx->rng(int(n)); });
+            ctx->shuffle(t.second.begin(), t.second.end());
         }
         for (auto cell : sorted(ctx->cells)) {
             CellInfo *ci = cell.second;


### PR DESCRIPTION
std::random_shuffle deprecated in C++14 and was removed in C++17.