### PR TITLE
Gowin: Add GW1N-4 support

### DIFF
--- a/.cirrus/Dockerfile.ubuntu20.04
+++ b/.cirrus/Dockerfile.ubuntu20.04
@@ -64,4 +64,4 @@ RUN set -e -x ;\
     PATH=$PATH:$HOME/.cargo/bin cargo install --path prjoxide
 
 RUN set -e -x ;\
-    pip3 install apycula==0.0.1a3
+    pip3 install apycula==0.0.1a5

--- a/gowin/CMakeLists.txt
+++ b/gowin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(chipdb-gowin NONE)
 
-set(ALL_GOWIN_DEVICES GW1N-1 GW1N-9)
+set(ALL_GOWIN_DEVICES GW1N-1 GW1N-4 GW1N-9)
 set(GOWIN_DEVICES ${ALL_GOWIN_DEVICES} CACHE STRING
     "Include support for these Gowin devices (available: ${ALL_GOWIN_DEVICES})")
 message(STATUS "Enabled Gowin devices: ${GOWIN_DEVICES}")


### PR DESCRIPTION
I've updated Apicula to generate a Chipdb for the GW1N-4 family of devices, for which this PR adds the bba to the build systems and the CI build.

Seems to work: https://twitter.com/pepijndevos/status/1345747194155040770