### PR TITLE
RFC: Initial refactoring of placer API.

### DIFF
--- a/common/arch_pybindings_shared.h
+++ b/common/arch_pybindings_shared.h
@@ -110,3 +110,19 @@ fn_wrapper_0a<Context, decltype(&Context::archId), &Context::archId, conv_to_str
 
 fn_wrapper_2a_v<Context, decltype(&Context::writeSVG), &Context::writeSVG, pass_through<std::string>,
                 pass_through<std::string>>::def_wrap(ctx_cls, "writeSVG");
+
+// const\_range\<BelBucketId\> getBelBuckets() const
+fn_wrapper_0a<Context, decltype(&Context::getBelBuckets), &Context::getBelBuckets, wrap_context<BelBucketRange>>::def_wrap(ctx_cls,
+                                                                                                         "getBelBuckets");
+// BelBucketId getBelBucketForBel(BelId bel) const
+fn_wrapper_1a<Context, decltype(&Context::getBelBucketForBel), &Context::getBelBucketForBel, conv_to_str<BelBucketId>,
+              conv_from_str<BelId>>::def_wrap(ctx_cls, "getBelBucketForBel");
+// BelBucketId getBelBucketForCellType(IdString cell\_type) const
+fn_wrapper_1a<Context, decltype(&Context::getBelBucketForCellType), &Context::getBelBucketForCellType, conv_to_str<BelBucketId>,
+              conv_from_str<IdString>>::def_wrap(ctx_cls, "getBelBucketForCellType");
+// const\_range\<BelId\> getBelsInBucket(BelBucketId bucket) const
+fn_wrapper_1a<Context, decltype(&Context::getBelsInBucket), &Context::getBelsInBucket, wrap_context<BelRangeForBelBucket>,
+              conv_from_str<BelBucketId>>::def_wrap(ctx_cls, "getBelsInBucket");
+// bool isValidBelForCellType(IdString cell\_type, BelId bel) const
+fn_wrapper_2a<Context, decltype(&Context::isValidBelForCellType), &Context::isValidBelForCellType, pass_through<bool>,
+              conv_from_str<IdString>, conv_from_str<BelId>>::def_wrap(ctx_cls, "isValidBelForCellType");

--- a/common/arch_pybindings_shared.h
+++ b/common/arch_pybindings_shared.h
@@ -112,17 +112,17 @@ fn_wrapper_2a_v<Context, decltype(&Context::writeSVG), &Context::writeSVG, pass_
                 pass_through<std::string>>::def_wrap(ctx_cls, "writeSVG");
 
 // const\_range\<BelBucketId\> getBelBuckets() const
-fn_wrapper_0a<Context, decltype(&Context::getBelBuckets), &Context::getBelBuckets, wrap_context<BelBucketRange>>::def_wrap(ctx_cls,
-                                                                                                         "getBelBuckets");
+fn_wrapper_0a<Context, decltype(&Context::getBelBuckets), &Context::getBelBuckets,
+              wrap_context<BelBucketRange>>::def_wrap(ctx_cls, "getBelBuckets");
 // BelBucketId getBelBucketForBel(BelId bel) const
 fn_wrapper_1a<Context, decltype(&Context::getBelBucketForBel), &Context::getBelBucketForBel, conv_to_str<BelBucketId>,
               conv_from_str<BelId>>::def_wrap(ctx_cls, "getBelBucketForBel");
 // BelBucketId getBelBucketForCellType(IdString cell\_type) const
-fn_wrapper_1a<Context, decltype(&Context::getBelBucketForCellType), &Context::getBelBucketForCellType, conv_to_str<BelBucketId>,
-              conv_from_str<IdString>>::def_wrap(ctx_cls, "getBelBucketForCellType");
+fn_wrapper_1a<Context, decltype(&Context::getBelBucketForCellType), &Context::getBelBucketForCellType,
+              conv_to_str<BelBucketId>, conv_from_str<IdString>>::def_wrap(ctx_cls, "getBelBucketForCellType");
 // const\_range\<BelId\> getBelsInBucket(BelBucketId bucket) const
-fn_wrapper_1a<Context, decltype(&Context::getBelsInBucket), &Context::getBelsInBucket, wrap_context<BelRangeForBelBucket>,
-              conv_from_str<BelBucketId>>::def_wrap(ctx_cls, "getBelsInBucket");
+fn_wrapper_1a<Context, decltype(&Context::getBelsInBucket), &Context::getBelsInBucket,
+              wrap_context<BelRangeForBelBucket>, conv_from_str<BelBucketId>>::def_wrap(ctx_cls, "getBelsInBucket");
 // bool isValidBelForCellType(IdString cell\_type, BelId bel) const
 fn_wrapper_2a<Context, decltype(&Context::isValidBelForCellType), &Context::isValidBelForCellType, pass_through<bool>,
               conv_from_str<IdString>, conv_from_str<BelId>>::def_wrap(ctx_cls, "isValidBelForCellType");

--- a/common/archcheck.cc
+++ b/common/archcheck.cc
@@ -52,12 +52,12 @@ void archcheck_names(const Context *ctx)
         }
     }
 
-    log_info("Checking partition names..\n");
-    for(PartitionId partition : ctx->getPartitions()) {
-        IdString name = ctx->getPartitionName(partition);
-        PartitionId partition2 = ctx->getPartitionByName(name);
-        if (partition != partition2) {
-            log_error("partition != partition2, name = %s\n", name.c_str(ctx));
+    log_info("Checking bucket names..\n");
+    for(BelBucketId bucket : ctx->getBelBuckets()) {
+        IdString name = ctx->getBelBucketName(bucket);
+        BelBucketId bucket2 = ctx->getBelBucketByName(name);
+        if (bucket != bucket2) {
+            log_error("bucket != bucket2, name = %s\n", name.c_str(ctx));
         }
     }
 
@@ -197,38 +197,38 @@ void archcheck_conn(const Context *ctx)
     }
 }
 
-void archcheck_partitions(const Context *ctx)
+void archcheck_buckets(const Context *ctx)
 {
-    log_info("Checking partition data.\n");
+    log_info("Checking bucket data.\n");
 
-    // Partitions should be subsets of BELs that form an exact cover.
-    // In particular that means cell types in a partition should only be
-    // placable in that partition.
-    for(PartitionId partition : ctx->getPartitions()) {
+    // BEL buckets should be subsets of BELs that form an exact cover.
+    // In particular that means cell types in a bucket should only be
+    // placable in that bucket.
+    for(BelBucketId bucket : ctx->getBelBuckets()) {
 
-        // Find out which cell types are in this partition.
-        std::unordered_set<IdString> cell_types_in_partition;
+        // Find out which cell types are in this bucket.
+        std::unordered_set<IdString> cell_types_in_bucket;
         for(IdString cell_type : ctx->getCellTypes()) {
-            if(ctx->getPartitionForCellType(cell_type) == partition) {
-                cell_types_in_partition.insert(cell_type);
+            if(ctx->getBelBucketForCellType(cell_type) == bucket) {
+                cell_types_in_bucket.insert(cell_type);
             }
         }
 
-        // Make sure that all cell types in this partition have at least one
+        // Make sure that all cell types in this bucket have at least one
         // BelId they can be placed at.
         std::unordered_set<IdString> cell_types_unused;
 
-        std::unordered_set<BelId> bels_in_partition;
-        for(BelId bel : ctx->getBelsForPartition(partition)) {
-            PartitionId partition2 = ctx->getPartitionForBel(bel);
-            log_assert(partition == partition2);
+        std::unordered_set<BelId> bels_in_bucket;
+        for(BelId bel : ctx->getBelsInBucket(bucket)) {
+            BelBucketId bucket2 = ctx->getBelBucketForBel(bel);
+            log_assert(bucket == bucket2);
 
-            bels_in_partition.insert(bel);
+            bels_in_bucket.insert(bel);
 
-            // Check to see if a cell type not in this partition can be
-            // placed at a BEL in this partition.
+            // Check to see if a cell type not in this bucket can be
+            // placed at a BEL in this bucket.
             for(IdString cell_type : ctx->getCellTypes()) {
-                if(ctx->getPartitionForCellType(cell_type) == partition) {
+                if(ctx->getBelBucketForCellType(cell_type) == bucket) {
                     if(ctx->isValidBelForCellType(cell_type, bel)) {
                         cell_types_unused.erase(cell_type);
                     }
@@ -238,11 +238,11 @@ void archcheck_partitions(const Context *ctx)
             }
         }
 
-        // Verify that any BEL not in this partition reports a different
-        // partition.
+        // Verify that any BEL not in this bucket reports a different
+        // bucket.
         for(BelId bel : ctx->getBels()) {
-            if(ctx->getPartitionForBel(bel) != partition) {
-                log_assert(bels_in_partition.count(bel) == 0);
+            if(ctx->getBelBucketForBel(bel) != bucket) {
+                log_assert(bels_in_bucket.count(bel) == 0);
             }
         }
 
@@ -262,7 +262,7 @@ void Context::archcheck() const
     archcheck_names(this);
     archcheck_locs(this);
     archcheck_conn(this);
-    archcheck_partitions(this);
+    archcheck_buckets(this);
 }
 
 NEXTPNR_NAMESPACE_END

--- a/common/archcheck.cc
+++ b/common/archcheck.cc
@@ -53,7 +53,7 @@ void archcheck_names(const Context *ctx)
     }
 
     log_info("Checking bucket names..\n");
-    for(BelBucketId bucket : ctx->getBelBuckets()) {
+    for (BelBucketId bucket : ctx->getBelBuckets()) {
         IdString name = ctx->getBelBucketName(bucket);
         BelBucketId bucket2 = ctx->getBelBucketByName(name);
         if (bucket != bucket2) {
@@ -204,12 +204,12 @@ void archcheck_buckets(const Context *ctx)
     // BEL buckets should be subsets of BELs that form an exact cover.
     // In particular that means cell types in a bucket should only be
     // placable in that bucket.
-    for(BelBucketId bucket : ctx->getBelBuckets()) {
+    for (BelBucketId bucket : ctx->getBelBuckets()) {
 
         // Find out which cell types are in this bucket.
         std::unordered_set<IdString> cell_types_in_bucket;
-        for(IdString cell_type : ctx->getCellTypes()) {
-            if(ctx->getBelBucketForCellType(cell_type) == bucket) {
+        for (IdString cell_type : ctx->getCellTypes()) {
+            if (ctx->getBelBucketForCellType(cell_type) == bucket) {
                 cell_types_in_bucket.insert(cell_type);
             }
         }
@@ -219,7 +219,7 @@ void archcheck_buckets(const Context *ctx)
         std::unordered_set<IdString> cell_types_unused;
 
         std::unordered_set<BelId> bels_in_bucket;
-        for(BelId bel : ctx->getBelsInBucket(bucket)) {
+        for (BelId bel : ctx->getBelsInBucket(bucket)) {
             BelBucketId bucket2 = ctx->getBelBucketForBel(bel);
             log_assert(bucket == bucket2);
 
@@ -227,9 +227,9 @@ void archcheck_buckets(const Context *ctx)
 
             // Check to see if a cell type not in this bucket can be
             // placed at a BEL in this bucket.
-            for(IdString cell_type : ctx->getCellTypes()) {
-                if(ctx->getBelBucketForCellType(cell_type) == bucket) {
-                    if(ctx->isValidBelForCellType(cell_type, bel)) {
+            for (IdString cell_type : ctx->getCellTypes()) {
+                if (ctx->getBelBucketForCellType(cell_type) == bucket) {
+                    if (ctx->isValidBelForCellType(cell_type, bel)) {
                         cell_types_unused.erase(cell_type);
                     }
                 } else {
@@ -240,8 +240,8 @@ void archcheck_buckets(const Context *ctx)
 
         // Verify that any BEL not in this bucket reports a different
         // bucket.
-        for(BelId bel : ctx->getBels()) {
-            if(ctx->getBelBucketForBel(bel) != bucket) {
+        for (BelId bel : ctx->getBels()) {
+            if (ctx->getBelBucketForBel(bel) != bucket) {
                 log_assert(bels_in_bucket.count(bel) == 0);
             }
         }

--- a/common/fast_bels.h
+++ b/common/fast_bels.h
@@ -83,7 +83,7 @@ struct FastBels {
         }
     }
 
-    void addPartition(PartitionId partition) {
+    void addBelBucket(BelBucketId partition) {
         auto iter = partition_types.find(partition);
         if(iter != partition_types.end()) {
             // This partition has already been added to the fast BEL lookup.
@@ -98,7 +98,7 @@ struct FastBels {
         auto &bel_data = fast_bels_by_partition_type.at(type_idx);
 
         for (auto bel : ctx->getBels()) {
-            if(ctx->getPartitionForBel(bel) != partition) {
+            if(ctx->getBelBucketForBel(bel) != partition) {
                 continue;
             }
 
@@ -110,7 +110,7 @@ struct FastBels {
                 continue;
             }
 
-            if(ctx->getPartitionForBel(bel) != partition) {
+            if(ctx->getBelBucketForBel(bel) != partition) {
                 continue;
             }
 
@@ -147,10 +147,10 @@ struct FastBels {
         return cell_type_data.number_of_possible_bels;
     }
 
-    size_t getBelsForPartition(PartitionId partition, FastBelsData **data) {
+    size_t getBelsForBelBucket(BelBucketId partition, FastBelsData **data) {
         auto iter = partition_types.find(partition);
         if(iter == partition_types.end()) {
-            addPartition(partition);
+            addBelBucket(partition);
             iter = partition_types.find(partition);
             NPNR_ASSERT(iter != partition_types.end());
         }
@@ -168,7 +168,7 @@ struct FastBels {
     std::unordered_map<IdString, TypeData> cell_types;
     std::vector<FastBelsData> fast_bels_by_cell_type;
 
-    std::unordered_map<PartitionId, TypeData> partition_types;
+    std::unordered_map<BelBucketId, TypeData> partition_types;
     std::vector<FastBelsData> fast_bels_by_partition_type;
 };
 

--- a/common/fast_bels.h
+++ b/common/fast_bels.h
@@ -33,7 +33,7 @@ struct FastBels {
         int number_of_possible_bels;
     };
 
-    FastBels(Context *ctx, int minBelsForGridPick) : ctx(ctx), minBelsForGridPick(minBelsForGridPick) {}
+    FastBels(Context *ctx, bool check_bel_available, int minBelsForGridPick) : ctx(ctx), check_bel_available(check_bel_available), minBelsForGridPick(minBelsForGridPick) {}
 
     void addCellType(IdString cell_type) {
         auto iter = cell_types.find(cell_type);
@@ -58,7 +58,7 @@ struct FastBels {
         }
 
         for (auto bel : ctx->getBels()) {
-            if(!ctx->checkBelAvail(bel)) {
+            if(check_bel_available && !ctx->checkBelAvail(bel)) {
                 continue;
             }
 
@@ -106,7 +106,7 @@ struct FastBels {
         }
 
         for (auto bel : ctx->getBels()) {
-            if(!ctx->checkBelAvail(bel)) {
+            if(check_bel_available && !ctx->checkBelAvail(bel)) {
                 continue;
             }
 
@@ -162,7 +162,8 @@ struct FastBels {
     }
 
     Context *ctx;
-    int minBelsForGridPick;
+    const bool check_bel_available;
+    const int minBelsForGridPick;
 
     std::unordered_map<IdString, TypeData> cell_types;
     std::vector<FastBelsData> fast_bels_by_cell_type;

--- a/common/fast_bels.h
+++ b/common/fast_bels.h
@@ -20,24 +20,30 @@
 
 #pragma once
 
-#include "nextpnr.h"
 #include <cstddef>
+#include "nextpnr.h"
 
 NEXTPNR_NAMESPACE_BEGIN
 
 // FastBels is a lookup class that provides a fast lookup for finding BELs
 // that support a given cell type.
-struct FastBels {
-    struct TypeData {
+struct FastBels
+{
+    struct TypeData
+    {
         size_t type_index;
         int number_of_possible_bels;
     };
 
-    FastBels(Context *ctx, bool check_bel_available, int minBelsForGridPick) : ctx(ctx), check_bel_available(check_bel_available), minBelsForGridPick(minBelsForGridPick) {}
+    FastBels(Context *ctx, bool check_bel_available, int minBelsForGridPick)
+            : ctx(ctx), check_bel_available(check_bel_available), minBelsForGridPick(minBelsForGridPick)
+    {
+    }
 
-    void addCellType(IdString cell_type) {
+    void addCellType(IdString cell_type)
+    {
         auto iter = cell_types.find(cell_type);
-        if(iter != cell_types.end()) {
+        if (iter != cell_types.end()) {
             // This cell type has already been added to the fast BEL lookup.
             return;
         }
@@ -50,7 +56,7 @@ struct FastBels {
         auto &bel_data = fast_bels_by_cell_type.at(type_idx);
 
         for (auto bel : ctx->getBels()) {
-            if(!ctx->isValidBelForCellType(cell_type, bel)) {
+            if (!ctx->isValidBelForCellType(cell_type, bel)) {
                 continue;
             }
 
@@ -58,11 +64,11 @@ struct FastBels {
         }
 
         for (auto bel : ctx->getBels()) {
-            if(check_bel_available && !ctx->checkBelAvail(bel)) {
+            if (check_bel_available && !ctx->checkBelAvail(bel)) {
                 continue;
             }
 
-            if(!ctx->isValidBelForCellType(cell_type, bel)) {
+            if (!ctx->isValidBelForCellType(cell_type, bel)) {
                 continue;
             }
 
@@ -83,9 +89,10 @@ struct FastBels {
         }
     }
 
-    void addBelBucket(BelBucketId partition) {
+    void addBelBucket(BelBucketId partition)
+    {
         auto iter = partition_types.find(partition);
-        if(iter != partition_types.end()) {
+        if (iter != partition_types.end()) {
             // This partition has already been added to the fast BEL lookup.
             return;
         }
@@ -98,7 +105,7 @@ struct FastBels {
         auto &bel_data = fast_bels_by_partition_type.at(type_idx);
 
         for (auto bel : ctx->getBels()) {
-            if(ctx->getBelBucketForBel(bel) != partition) {
+            if (ctx->getBelBucketForBel(bel) != partition) {
                 continue;
             }
 
@@ -106,11 +113,11 @@ struct FastBels {
         }
 
         for (auto bel : ctx->getBels()) {
-            if(check_bel_available && !ctx->checkBelAvail(bel)) {
+            if (check_bel_available && !ctx->checkBelAvail(bel)) {
                 continue;
             }
 
-            if(ctx->getBelBucketForBel(bel) != partition) {
+            if (ctx->getBelBucketForBel(bel) != partition) {
                 continue;
             }
 
@@ -133,9 +140,10 @@ struct FastBels {
 
     typedef std::vector<std::vector<std::vector<BelId>>> FastBelsData;
 
-    int getBelsForCellType(IdString cell_type, FastBelsData **data) {
+    int getBelsForCellType(IdString cell_type, FastBelsData **data)
+    {
         auto iter = cell_types.find(cell_type);
-        if(iter == cell_types.end()) {
+        if (iter == cell_types.end()) {
             addCellType(cell_type);
             iter = cell_types.find(cell_type);
             NPNR_ASSERT(iter != cell_types.end());
@@ -147,9 +155,10 @@ struct FastBels {
         return cell_type_data.number_of_possible_bels;
     }
 
-    size_t getBelsForBelBucket(BelBucketId partition, FastBelsData **data) {
+    size_t getBelsForBelBucket(BelBucketId partition, FastBelsData **data)
+    {
         auto iter = partition_types.find(partition);
-        if(iter == partition_types.end()) {
+        if (iter == partition_types.end()) {
             addBelBucket(partition);
             iter = partition_types.find(partition);
             NPNR_ASSERT(iter != partition_types.end());

--- a/common/fast_bels.h
+++ b/common/fast_bels.h
@@ -30,7 +30,7 @@ NEXTPNR_NAMESPACE_BEGIN
 struct FastBels {
     struct TypeData {
         size_t type_index;
-        size_t number_of_possible_bels;
+        int number_of_possible_bels;
     };
 
     FastBels(Context *ctx, int minBelsForGridPick) : ctx(ctx), minBelsForGridPick(minBelsForGridPick) {}
@@ -133,7 +133,7 @@ struct FastBels {
 
     typedef std::vector<std::vector<std::vector<BelId>>> FastBelsData;
 
-    size_t getBelsForCellType(IdString cell_type, FastBelsData **data) {
+    int getBelsForCellType(IdString cell_type, FastBelsData **data) {
         auto iter = cell_types.find(cell_type);
         if(iter == cell_types.end()) {
             addCellType(cell_type);

--- a/common/fast_bels.h
+++ b/common/fast_bels.h
@@ -1,0 +1,105 @@
+/*
+ *  nextpnr -- Next Generation Place and Route
+ *
+ *  Copyright (C) 2018  Clifford Wolf <clifford@symbioticeda.com>
+ *  Copyright (C) 2018  David Shah <david@symbioticeda.com>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include "nextpnr.h"
+#include <cstddef>
+
+NEXTPNR_NAMESPACE_BEGIN
+
+// FastBels is a lookup class that provides a fast lookup for finding BELs
+// that support a given cell type.
+struct FastBels {
+    struct CellTypeData {
+        size_t cell_type_index;
+        size_t number_of_possible_bels;
+    };
+
+    FastBels(Context *ctx, int minBelsForGridPick) : ctx(ctx), minBelsForGridPick(minBelsForGridPick) {}
+
+    void addCellType(IdString cell_type) {
+        auto iter = cell_types.find(cell_type);
+        if(iter != cell_types.end()) {
+            // This cell type has already been added to the fast BEL lookup.
+            return;
+        }
+
+        size_t type_idx = cell_types.size();
+        auto &cell_type_data = cell_types[cell_type];
+        cell_type_data.cell_type_index = type_idx;
+
+        fast_bels.resize(type_idx + 1);
+        auto &bel_data = fast_bels.at(type_idx);
+
+        for (auto bel : ctx->getBels()) {
+            if(!ctx->isValidBelForCellType(cell_type, bel)) {
+                continue;
+            }
+
+            cell_type_data.number_of_possible_bels += 1;
+        }
+
+        for (auto bel : ctx->getBels()) {
+            if(!ctx->checkBelAvail(bel)) {
+                continue;
+            }
+
+            Loc loc = ctx->getBelLocation(bel);
+            if (minBelsForGridPick >= 0 && cell_type_data.number_of_possible_bels < minBelsForGridPick) {
+                loc.x = loc.y = 0;
+            }
+
+            if (int(bel_data.size()) < (loc.x + 1)) {
+                bel_data.resize(loc.x + 1);
+            }
+
+            if (int(bel_data.at(loc.x).size()) < (loc.y + 1)) {
+                bel_data.at(loc.x).resize(loc.y + 1);
+            }
+
+            bel_data.at(loc.x).at(loc.y).push_back(bel);
+        }
+    }
+
+    typedef std::vector<std::vector<std::vector<BelId>>> FastBelsData;
+
+    size_t getBelsForCellType(IdString cell_type, FastBelsData **data) {
+        auto iter = cell_types.find(cell_type);
+        if(iter == cell_types.end()) {
+            addCellType(cell_type);
+            iter = cell_types.find(cell_type);
+            NPNR_ASSERT(iter != cell_types.end());
+        }
+
+        auto cell_type_data = iter->second;
+
+        *data = &fast_bels.at(cell_type_data.cell_type_index);
+        return cell_type_data.number_of_possible_bels;
+    }
+
+    Context *ctx;
+    int minBelsForGridPick;
+
+    std::unordered_map<IdString, CellTypeData> cell_types;
+    std::vector<FastBelsData> fast_bels;
+};
+
+NEXTPNR_NAMESPACE_END

--- a/common/place_common.cc
+++ b/common/place_common.cc
@@ -118,7 +118,7 @@ bool place_single_cell(Context *ctx, CellInfo *cell, bool require_legality)
         }
         IdString targetType = cell->type;
         for (auto bel : ctx->getBels()) {
-            if (ctx->getBelType(bel) == targetType && (!require_legality || ctx->isValidBelForCell(cell, bel))) {
+            if (ctx->isValidBelForCellType(targetType, bel) && (!require_legality || ctx->isValidBelForCell(cell, bel))) {
                 if (ctx->checkBelAvail(bel)) {
                     wirelen_t wirelen = get_cell_metric_at_bel(ctx, cell, bel, MetricType::COST);
                     if (iters >= 4)
@@ -229,7 +229,7 @@ class ConstraintLegaliseWorker
         if (locBel == BelId()) {
             return false;
         }
-        if (ctx->getBelType(locBel) != cell->type) {
+        if (!ctx->isValidBelForCellType(cell->type, locBel)) {
             return false;
         }
         if (!ctx->checkBelAvail(locBel)) {

--- a/common/place_common.cc
+++ b/common/place_common.cc
@@ -118,7 +118,8 @@ bool place_single_cell(Context *ctx, CellInfo *cell, bool require_legality)
         }
         IdString targetType = cell->type;
         for (auto bel : ctx->getBels()) {
-            if (ctx->isValidBelForCellType(targetType, bel) && (!require_legality || ctx->isValidBelForCell(cell, bel))) {
+            if (ctx->isValidBelForCellType(targetType, bel) &&
+                (!require_legality || ctx->isValidBelForCell(cell, bel))) {
                 if (ctx->checkBelAvail(bel)) {
                     wirelen_t wirelen = get_cell_metric_at_bel(ctx, cell, bel, MetricType::COST);
                     if (iters >= 4)

--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -43,6 +43,7 @@
 #include "place_common.h"
 #include "timing.h"
 #include "util.h"
+#include "fast_bels.h"
 
 namespace std {
 template <> struct hash<std::pair<NEXTPNR_NAMESPACE_PREFIX IdString, std::size_t>>
@@ -75,33 +76,12 @@ class SAPlacer
     };
 
   public:
-    SAPlacer(Context *ctx, Placer1Cfg cfg) : ctx(ctx), cfg(cfg)
+    SAPlacer(Context *ctx, Placer1Cfg cfg) : ctx(ctx), fast_bels(ctx, cfg.minBelsForGridPick), cfg(cfg)
     {
-        int num_bel_types = 0;
-        for (auto bel : ctx->getBels()) {
-            IdString type = ctx->getBelType(bel);
-            if (bel_types.find(type) == bel_types.end()) {
-                bel_types[type] = std::tuple<int, int>(num_bel_types++, 1);
-            } else {
-                std::get<1>(bel_types.at(type))++;
-            }
-        }
         for (auto bel : ctx->getBels()) {
             Loc loc = ctx->getBelLocation(bel);
-            IdString type = ctx->getBelType(bel);
-            int type_idx = std::get<0>(bel_types.at(type));
-            int type_cnt = std::get<1>(bel_types.at(type));
-            if (type_cnt < cfg.minBelsForGridPick)
-                loc.x = loc.y = 0;
-            if (int(fast_bels.size()) < type_idx + 1)
-                fast_bels.resize(type_idx + 1);
-            if (int(fast_bels.at(type_idx).size()) < (loc.x + 1))
-                fast_bels.at(type_idx).resize(loc.x + 1);
-            if (int(fast_bels.at(type_idx).at(loc.x).size()) < (loc.y + 1))
-                fast_bels.at(type_idx).at(loc.x).resize(loc.y + 1);
             max_x = std::max(max_x, loc.x);
             max_y = std::max(max_y, loc.y);
-            fast_bels.at(type_idx).at(loc.x).at(loc.y).push_back(bel);
         }
         diameter = std::max(max_x, max_y) + 1;
 
@@ -170,13 +150,14 @@ class SAPlacer
                                   loc_name.c_str(), cell->name.c_str(ctx));
                     }
 
-                    IdString bel_type = ctx->getBelType(bel);
-                    if (bel_type != cell->type) {
+                    if (!ctx->isValidBelForCellType(cell->type, bel)) {
+                        IdString bel_type = ctx->getBelType(bel);
                         log_error("Bel \'%s\' of type \'%s\' does not match cell "
                                   "\'%s\' of type \'%s\'\n",
                                   loc_name.c_str(), bel_type.c_str(ctx), cell->name.c_str(ctx), cell->type.c_str(ctx));
                     }
                     if (!ctx->isValidBelForCell(cell, bel)) {
+                        IdString bel_type = ctx->getBelType(bel);
                         log_error("Bel \'%s\' of type \'%s\' is not valid for cell "
                                   "\'%s\' of type \'%s\'\n",
                                   loc_name.c_str(), bel_type.c_str(ctx), cell->name.c_str(ctx), cell->type.c_str(ctx));
@@ -452,7 +433,7 @@ class SAPlacer
             IdString targetType = cell->type;
 
             auto proc_bel = [&](BelId bel) {
-                if (ctx->getBelType(bel) == targetType && ctx->isValidBelForCell(cell, bel)) {
+                if (ctx->isValidBelForCellType(targetType, bel) && ctx->isValidBelForCell(cell, bel)) {
                     if (ctx->checkBelAvail(bel)) {
                         uint64_t score = ctx->rng64();
                         if (score <= best_score) {
@@ -651,7 +632,7 @@ class SAPlacer
             BelId targetBel = ctx->getBelByLocation(targetLoc);
             if (targetBel == BelId())
                 return false;
-            if (ctx->getBelType(targetBel) != cell->type)
+            if (!ctx->isValidBelForCellType(cell->type, targetBel))
                 return false;
             CellInfo *bound = ctx->getBoundBelCell(targetBel);
             // We don't consider swapping chains with other chains, at least for the time being - unless it is
@@ -733,15 +714,15 @@ class SAPlacer
         while (true) {
             int nx = ctx->rng(2 * dx + 1) + std::max(curr_loc.x - dx, 0);
             int ny = ctx->rng(2 * dy + 1) + std::max(curr_loc.y - dy, 0);
-            int beltype_idx, beltype_cnt;
-            std::tie(beltype_idx, beltype_cnt) = bel_types.at(targetType);
-            if (beltype_cnt < cfg.minBelsForGridPick)
+            FastBels::FastBelsData *bel_data;
+            auto type_cnt = fast_bels.getBelsForCellType(targetType, &bel_data);
+            if (cfg.minBelsForGridPick >= 0 && type_cnt < cfg.minBelsForGridPick)
                 nx = ny = 0;
-            if (nx >= int(fast_bels.at(beltype_idx).size()))
+            if (nx >= int(bel_data->size()))
                 continue;
-            if (ny >= int(fast_bels.at(beltype_idx).at(nx).size()))
+            if (ny >= int(bel_data->at(nx).size()))
                 continue;
-            const auto &fb = fast_bels.at(beltype_idx).at(nx).at(ny);
+            const auto &fb = bel_data->at(nx).at(ny);
             if (fb.size() == 0)
                 continue;
             BelId bel = fb.at(ctx->rng(int(fb.size())));
@@ -1217,7 +1198,7 @@ class SAPlacer
     int diameter = 35, max_x = 1, max_y = 1;
     std::unordered_map<IdString, std::tuple<int, int>> bel_types;
     std::unordered_map<IdString, BoundingBox> region_bounds;
-    std::vector<std::vector<std::vector<std::vector<BelId>>>> fast_bels;
+    FastBels fast_bels;
     std::unordered_set<BelId> locked_bels;
     std::vector<NetInfo *> net_by_udata;
     std::vector<decltype(NetInfo::udata)> old_udata;

--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -39,11 +39,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <vector>
+#include "fast_bels.h"
 #include "log.h"
 #include "place_common.h"
 #include "timing.h"
 #include "util.h"
-#include "fast_bels.h"
 
 namespace std {
 template <> struct hash<std::pair<NEXTPNR_NAMESPACE_PREFIX IdString, std::size_t>>
@@ -76,7 +76,8 @@ class SAPlacer
     };
 
   public:
-    SAPlacer(Context *ctx, Placer1Cfg cfg) : ctx(ctx), fast_bels(ctx, /*check_bel_available=*/false, cfg.minBelsForGridPick), cfg(cfg)
+    SAPlacer(Context *ctx, Placer1Cfg cfg)
+            : ctx(ctx), fast_bels(ctx, /*check_bel_available=*/false, cfg.minBelsForGridPick), cfg(cfg)
     {
         for (auto bel : ctx->getBels()) {
             Loc loc = ctx->getBelLocation(bel);
@@ -91,7 +92,7 @@ class SAPlacer
             cell_types_in_use.insert(cell_type);
         }
 
-        for(auto cell_type : cell_types_in_use) {
+        for (auto cell_type : cell_types_in_use) {
             fast_bels.addCellType(cell_type);
         }
 

--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -523,20 +523,29 @@ class HeAPPlacer
                 bool placed = false;
                 int attempt_count = 0;
                 while (!placed) {
-                    if (!available_bels.count(ci->type) || available_bels.at(ci->type).empty()) {
-                        log_error("Unable to place cell '%s', no BELs remaining to implement cell type '%s'\n",
-                                ci->name.c_str(ctx),
-                                ci->type.c_str(ctx));
-                    }
                     ++attempt_count;
                     if (attempt_count > 25000) {
                         log_error("Unable to find a placement location for cell '%s'\n", ci->name.c_str(ctx));
+                    }
+
+                    // Make sure this cell type is in the available BEL map at
+                    // all.
+                    if (!available_bels.count(ci->type)) {
+                        log_error("Unable to place cell '%s', no BELs remaining to implement cell type '%s'\n",
+                                ci->name.c_str(ctx),
+                                ci->type.c_str(ctx));
                     }
 
                     // Find an unused BEL from bels_for_cell_type.
                     auto &bels_for_cell_type = available_bels.at(ci->type);
                     BelId bel;
                     while(true) {
+                        if (bels_for_cell_type.empty()) {
+                            log_error("Unable to place cell '%s', no BELs remaining to implement cell type '%s'\n",
+                                    ci->name.c_str(ctx),
+                                    ci->type.c_str(ctx));
+                        }
+
                         BelId candidate_bel = bels_for_cell_type.back();
                         bels_for_cell_type.pop_back();
                         if(bels_used.count(candidate_bel)) {

--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -1065,7 +1065,7 @@ class HeAPPlacer
         CutSpreader(HeAPPlacer *p, const std::unordered_set<PartitionId> &partitions) : p(p), ctx(p->ctx), partitions(partitions)
         {
             // Get fast BELs data for all partitions being Cut/Spread.
-            int idx = 0;
+            size_t idx = 0;
             for (PartitionId partition : sorted(partitions)) {
                 type_index[partition] = idx;
                 FastBels::FastBelsData *fast_bels;

--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -44,13 +44,13 @@
 #include <queue>
 #include <tuple>
 #include <unordered_map>
+#include "fast_bels.h"
 #include "log.h"
 #include "nextpnr.h"
 #include "place_common.h"
 #include "placer1.h"
 #include "timing.h"
 #include "util.h"
-#include "fast_bels.h"
 
 NEXTPNR_NAMESPACE_BEGIN
 
@@ -138,7 +138,10 @@ template <typename T> struct EquationSystem
 class HeAPPlacer
 {
   public:
-    HeAPPlacer(Context *ctx, PlacerHeapCfg cfg) : ctx(ctx), cfg(cfg), fast_bels(ctx, /*check_bel_available=*/true, -1) { Eigen::initParallel(); }
+    HeAPPlacer(Context *ctx, PlacerHeapCfg cfg) : ctx(ctx), cfg(cfg), fast_bels(ctx, /*check_bel_available=*/true, -1)
+    {
+        Eigen::initParallel();
+    }
 
     bool place()
     {
@@ -429,10 +432,10 @@ class HeAPPlacer
             buckets_in_use.insert(bucket);
         }
 
-        for(auto cell_type : cell_types_in_use) {
+        for (auto cell_type : cell_types_in_use) {
             fast_bels.addCellType(cell_type);
         }
-        for(auto bucket : buckets_in_use) {
+        for (auto bucket : buckets_in_use) {
             fast_bels.addBelBucket(bucket);
         }
 
@@ -500,8 +503,8 @@ class HeAPPlacer
                 continue;
             }
 
-            for(auto cell_type : cell_types) {
-                if(ctx->isValidBelForCellType(cell_type, bel)) {
+            for (auto cell_type : cell_types) {
+                if (ctx->isValidBelForCellType(cell_type, bel)) {
                     available_bels[cell_type].push_back(bel);
                 }
             }
@@ -532,23 +535,21 @@ class HeAPPlacer
                     // all.
                     if (!available_bels.count(ci->type)) {
                         log_error("Unable to place cell '%s', no BELs remaining to implement cell type '%s'\n",
-                                ci->name.c_str(ctx),
-                                ci->type.c_str(ctx));
+                                  ci->name.c_str(ctx), ci->type.c_str(ctx));
                     }
 
                     // Find an unused BEL from bels_for_cell_type.
                     auto &bels_for_cell_type = available_bels.at(ci->type);
                     BelId bel;
-                    while(true) {
+                    while (true) {
                         if (bels_for_cell_type.empty()) {
                             log_error("Unable to place cell '%s', no BELs remaining to implement cell type '%s'\n",
-                                    ci->name.c_str(ctx),
-                                    ci->type.c_str(ctx));
+                                      ci->name.c_str(ctx), ci->type.c_str(ctx));
                         }
 
                         BelId candidate_bel = bels_for_cell_type.back();
                         bels_for_cell_type.pop_back();
-                        if(bels_used.count(candidate_bel)) {
+                        if (bels_used.count(candidate_bel)) {
                             // candidate_bel has already been used by another
                             // cell type, skip it.
                             continue;
@@ -1202,13 +1203,12 @@ class HeAPPlacer
             return int(fb.at(type)->at(x).at(y).size());
         }
 
-        bool is_cell_fixed(const CellInfo & cell) const {
+        bool is_cell_fixed(const CellInfo &cell) const
+        {
             return buckets.count(ctx->getBelBucketForCellType(cell.type)) == 0;
         }
 
-        size_t cell_index(const CellInfo & cell) const {
-            return type_index.at(ctx->getBelBucketForCellType(cell.type));
-        }
+        size_t cell_index(const CellInfo &cell) const { return type_index.at(ctx->getBelBucketForCellType(cell.type)); }
 
         void init()
         {
@@ -1239,9 +1239,9 @@ class HeAPPlacer
 
             for (auto &cell_loc : p->cell_locs) {
                 IdString cell_name = cell_loc.first;
-                const CellInfo & cell = *ctx->cells.at(cell_name);
-                const CellLocation & loc = cell_loc.second;
-                if(is_cell_fixed(cell)) {
+                const CellInfo &cell = *ctx->cells.at(cell_name);
+                const CellLocation &loc = cell_loc.second;
+                if (is_cell_fixed(cell)) {
                     continue;
                 }
 
@@ -1261,9 +1261,9 @@ class HeAPPlacer
 
             for (auto &cell_loc : p->cell_locs) {
                 IdString cell_name = cell_loc.first;
-                const CellInfo & cell = *ctx->cells.at(cell_name);
-                const CellLocation & loc = cell_loc.second;
-                if(is_cell_fixed(cell)) {
+                const CellInfo &cell = *ctx->cells.at(cell_name);
+                const CellLocation &loc = cell_loc.second;
+                if (is_cell_fixed(cell)) {
                     continue;
                 }
 
@@ -1285,7 +1285,7 @@ class HeAPPlacer
             }
 
             for (auto cell : p->solve_cells) {
-                if(is_cell_fixed(*cell)) {
+                if (is_cell_fixed(*cell)) {
                     continue;
                 }
 
@@ -1476,8 +1476,7 @@ class HeAPPlacer
                             if (reg.cells > reg.bels) {
                                 IdString bucket_name = ctx->getBelBucketName(bucket);
                                 log_error("Failed to expand region (%d, %d) |_> (%d, %d) of %d %ss\n", reg.x0, reg.y0,
-                                          reg.x1, reg.y1, reg.cells.at(type_index.at(bucket)),
-                                          bucket_name.c_str(ctx));
+                                          reg.x1, reg.y1, reg.cells.at(type_index.at(bucket)), bucket_name.c_str(ctx));
                             }
                         }
                         break;

--- a/common/placer_heap.h
+++ b/common/placer_heap.h
@@ -49,7 +49,7 @@ struct PlacerHeapCfg
     std::unordered_set<IdString> ioBufTypes;
     // These cell types are part of the same unit (e.g. slices split into
     // components) so will always be spread together
-    std::vector<std::unordered_set<PartitionId>> cellGroups;
+    std::vector<std::unordered_set<BelBucketId>> cellGroups;
 };
 
 extern bool placer_heap(Context *ctx, PlacerHeapCfg cfg);

--- a/common/placer_heap.h
+++ b/common/placer_heap.h
@@ -49,7 +49,7 @@ struct PlacerHeapCfg
     std::unordered_set<IdString> ioBufTypes;
     // These cell types are part of the same unit (e.g. slices split into
     // components) so will always be spread together
-    std::vector<std::unordered_set<IdString>> cellGroups;
+    std::vector<std::unordered_set<PartitionId>> cellGroups;
 };
 
 extern bool placer_heap(Context *ctx, PlacerHeapCfg cfg);

--- a/common/timing_opt.cc
+++ b/common/timing_opt.cc
@@ -215,7 +215,7 @@ class TimingOptimiser
                 std::vector<BelId> free_bels_at_loc;
                 std::vector<BelId> bound_bels_at_loc;
                 for (auto bel : ctx->getBelsByTile(curr_loc.x + dx, curr_loc.y + dy)) {
-                    if (ctx->getBelType(bel) != cell->type)
+                    if (!ctx->isValidBelForCellType(cell->type, bel))
                         continue;
                     CellInfo *bound = ctx->getBoundBelCell(bel);
                     if (bound == nullptr) {

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -493,15 +493,15 @@ during placement.
 
 Return a list of all partitions on the device.
 
-### IdString partitionName(PartitionId partition) const
+### IdString getPartitionName(PartitionId partition) const
 
 Return the name of the partition.
 
-### PartitionId partitionForBel(BelId bel) const
+### PartitionId getPartitionForBel(BelId bel) const
 
 Returns the partition for a particular cell type.
 
-### const\_range\<BelId\> partitionForBel(PartitionId partition) const
+### const\_range\<BelId\> getBelsForPartition(PartitionId partition) const
 
 Return the list of BELs within a partition.
 

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -42,7 +42,7 @@ A type representing a pip name. `PipId()` must construct a unique null-value. Mu
 
 ### BelBucketId
 
-A type representing a BEL bucket. `BelBucketId()` must construct a unique null-value. Must provide `==`, `!=`, and `<` operators and a specialization for `std::hash<BelBucketId>`.
+A type representing a bel bucket. `BelBucketId()` must construct a unique null-value. Must provide `==`, `!=`, and `<` operators and a specialization for `std::hash<BelBucketId>`.
 
 ### GroupId
 
@@ -487,23 +487,23 @@ Return the _clocking info_ (including port name of clock, clock polarity and set
 port. Where ports have more than one clock edge associated with them (such as DDR outputs), `index` can be used to obtain
 information for all edges. `index` must be in [0, clockInfoCount), behaviour is undefined otherwise.
 
-BEL Buckets Methods
+Bel Buckets Methods
 -------------------
 
-BEL buckets are subsets of BelIds and cell types used by analytic placer to
-seperate types of BELs during placement. The buckets should form an exact
+Bel buckets are subsets of BelIds and cell types used by analytic placer to
+seperate types of bels during placement. The buckets should form an exact
 cover over all BelIds and cell types.
 
-Each BEL bucket should be BelIds and cell types that are roughly
+Each bel bucket should be BelIds and cell types that are roughly
 interchangable during placement.  Typical buckets are:
- - All LUT BELs
- - All FF BELs
- - All multipliers BELs
- - All block RAM BELs
+ - All LUT bels
+ - All FF bels
+ - All multipliers bels
+ - All block RAM bels
  - etc.
 
-The BEL buckets will be used during analytic placement for spreading prior to
-strict legality enforcement.  It is not required that all BELs within a bucket
+The bel buckets will be used during analytic placement for spreading prior to
+strict legality enforcement.  It is not required that all bels within a bucket
 are strictly equivelant.
 
 Strict legality step will enforce those differences, along with additional
@@ -512,11 +512,11 @@ local constraints.  `isValidBelForCell`, `isValidBelForCellType`, and
 
 ### const\_range\<BelBucketId\> getBelBuckets() const
 
-Return a list of all BEL buckets on the device.
+Return a list of all bel buckets on the device.
 
 ### IdString getBelBucketName(BelBucketId bucket) const
 
-Return the name of this BEL bucket.
+Return the name of this bel bucket.
 
 ### BelBucketId getBelBucketByName(IdString bucket\_name) const
 
@@ -524,30 +524,30 @@ Return the BelBucketId for the specified bucket name.
 
 ### BelBucketId getBelBucketForBel(BelId bel) const
 
-Returns the bucket for a particular BEL.
+Returns the bucket for a particular bel.
 
 ### BelBucketId getBelBucketForCell(IdString cell\_type) const
 
-Returns the BEL bucket for a particular cell type.
+Returns the bel bucket for a particular cell type.
 
 ### const\_range\<BelId\> getBelsInBucket(BelBucketId bucket) const
 
-Return the list of BELs within a bucket.
+Return the list of bels within a bucket.
 
 Placer Methods
 --------------
 
 ### bool isValidBelForCellType(IdString cell\_type, BelId bel) const
 
-Returns true if the given cell can be bound to the given BEL.  This check
+Returns true if the given cell can be bound to the given bel.  This check
 should be fast, compared with isValidBelForCell.  This check should always
 return the same value regardless if other cells are placed within the fabric.
 
 ### bool isValidBelForCell(CellInfo \*cell, BelId bel) const
 
-Returns true if the given cell can be bound to the given BEL, considering
+Returns true if the given cell can be bound to the given bel, considering
 other bound resources. For example, this can be used if there is only
-a certain number of different clock signals allowed for a group of BELs.
+a certain number of different clock signals allowed for a group of bels.
 
 ### bool isBelLocationValid(BelId bel) const
 

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -40,6 +40,10 @@ A type representing a wire name. `WireId()` must construct a unique null-value. 
 
 A type representing a pip name. `PipId()` must construct a unique null-value. Must provide `==`, `!=`, and `<` operators and a specialization for `std::hash<PipId>`.
 
+### BelBucketId
+
+A type representing a BEL bucket. `BelBucketId()` must construct a unique null-value. Must provide `==`, `!=`, and `<` operators and a specialization for `std::hash<BelBucketId>`.
+
 ### GroupId
 
 A type representing a group name. `GroupId()` must construct a unique null-value. Must provide `==` and `!=` operators and a specialization for `std::hash<GroupId>`.
@@ -483,44 +487,52 @@ Return the _clocking info_ (including port name of clock, clock polarity and set
 port. Where ports have more than one clock edge associated with them (such as DDR outputs), `index` can be used to obtain
 information for all edges. `index` must be in [0, clockInfoCount), behaviour is undefined otherwise.
 
-Partition Methods
------------------
+BEL Buckets Methods
+-------------------
 
-Partitions are subsets of BelIds and cell types used by analytic placer to
-seperate types of BELs during placement.  Typical partitions are:
+BEL buckets are subsets of BelIds and cell types used by analytic placer to
+seperate types of BELs during placement. The buckets should form an exact
+cover over all BelIds and cell types.
+
+Each BEL bucket should be BelIds and cell types that are roughly
+interchangable during placement.  Typical buckets are:
  - All LUT BELs
  - All FF BELs
  - All multipliers BELs
  - All block RAM BELs
  - etc.
 
-The general rule here is to include all BELs that are roughly interchangable
-during placement.  Partitions should form an exact cover over all BelIds and
-cell types.
+The BEL buckets will be used during analytic placement for spreading prior to
+strict legality enforcement.  It is not required that all BELs within a bucket
+are strictly equivelant.
 
-### const\_range\<PartitionId\> getPartitions() const
+Strict legality step will enforce those differences, along with additional
+local constraints.  `isValidBelForCell`, `isValidBelForCellType`, and
+`isBelLocationValid` are used to enforce strict legality checks.
 
-Return a list of all partitions on the device.
+### const\_range\<BelBucketId\> getBelBuckets() const
 
-### IdString getPartitionName(PartitionId partition) const
+Return a list of all BEL buckets on the device.
 
-Return the name of the partition.
+### IdString getBelBucketName(BelBucketId bucket) const
 
-### PartitionId getPartitionByName(IdString partition\_name) const
+Return the name of this BEL bucket.
 
-Return the partition for the specified partition name.
+### BelBucketId getBelBucketByName(IdString bucket\_name) const
 
-### PartitionId getPartitionForBel(BelId bel) const
+Return the BelBucketId for the specified bucket name.
 
-Returns the partition for a particular BEL.
+### BelBucketId getBelBucketForBel(BelId bel) const
 
-### PartitionId getPartitionForCell(IdString cell\_type) const
+Returns the bucket for a particular BEL.
 
-Returns the partition for a particular cell type.
+### BelBucketId getBelBucketForCell(IdString cell\_type) const
 
-### const\_range\<BelId\> getBelsForPartition(PartitionId partition) const
+Returns the BEL bucket for a particular cell type.
 
-Return the list of BELs within a partition.
+### const\_range\<BelId\> getBelsInBucket(BelBucketId bucket) const
+
+Return the list of BELs within a bucket.
 
 Placer Methods
 --------------
@@ -533,9 +545,9 @@ return the same value regardless if other cells are placed within the fabric.
 
 ### bool isValidBelForCell(CellInfo \*cell, BelId bel) const
 
-Returns true if the given cell can be bound to the given bel, considering
+Returns true if the given cell can be bound to the given BEL, considering
 other bound resources. For example, this can be used if there is only
-a certain number of different clock signals allowed for a group of bels.
+a certain number of different clock signals allowed for a group of BELs.
 
 ### bool isBelLocationValid(BelId bel) const
 

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -377,7 +377,7 @@ the given dst wire.
 This should return a low upper bound for the fastest route from `src` to `dst`.
 
 Or in other words it should assume an otherwise unused chip (thus "fastest route").
-But it only produces an estimate for that fastest route, not an exact 
+But it only produces an estimate for that fastest route, not an exact
 result, and for that estimate it is considered more acceptable to return a
 slightly too high result and it is considered less acceptable to return a
 too low result (thus "low upper bound").
@@ -463,20 +463,56 @@ Cell Delay Methods
 Returns the delay for the specified path through a cell in the `&delay` argument. The method returns
 false if there is no timing relationship from `fromPort` to `toPort`.
 
-### TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const
+### TimingPortClass getPortTimingClass(const CellInfo \*cell, IdString port, int &clockInfoCount) const
 
 Return the _timing port class_ of a port. This can be a register or combinational input or output; clock input or
 output; general startpoint or endpoint; or a port ignored for timing purposes. For register ports, clockInfoCount is set
 to the number of associated _clock edges_ that can be queried by getPortClockingInfo.
 
-### TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const
+### TimingClockingInfo getPortClockingInfo(const CellInfo \*cell, IdString port, int index) const
 
 Return the _clocking info_ (including port name of clock, clock polarity and setup/hold/clock-to-out times) of a
 port. Where ports have more than one clock edge associated with them (such as DDR outputs), `index` can be used to obtain
 information for all edges. `index` must be in [0, clockInfoCount), behaviour is undefined otherwise.
 
+Partition Methods
+-----------------
+
+Partitions are used by analytic placement to seperate types of BELs during
+placement.  Typical partitions are:
+ - All LUT BELs
+ - All FF BELs
+ - All multipliers BELs
+ - All block RAM BELs
+ - etc.
+
+The general rule here is to include all BELs that are roughly interchangable
+during placement.
+
+### const\_range\<PartitionId\> getPartitions() const
+
+Return a list of all partitions on the device.
+
+### IdString partitionName(PartitionId partition) const
+
+Return the name of the partition.
+
+### PartitionId partitionForBel(BelId bel) const
+
+Returns the partition for a particular cell type.
+
+### const\_range\<BelId\> partitionForBel(PartitionId partition) const
+
+Return the list of BELs within a partition.
+
 Placer Methods
 --------------
+
+### bool isValidBelForCellType(IdString cell\_type, BelId bel) const
+
+Returns true if the given cell can be bound to the given BEL.  This check
+should be fast, compared with isValidBelForCell.  This check should always
+return the same value regardless if other cells are placed within the fabric.
 
 ### bool isValidBelForCell(CellInfo \*cell, BelId bel) const
 
@@ -488,7 +524,6 @@ a certain number of different clock signals allowed for a group of bels.
 
 Returns true if a bell in the current configuration is valid, i.e. if
 `isValidBelForCell()` would return true for the current mapping.
-
 
 ### static const std::string defaultPlacer
 

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -486,7 +486,7 @@ information for all edges. `index` must be in [0, clockInfoCount), behaviour is 
 Partition Methods
 -----------------
 
-Partitions are subsets of BelIds and cell types used by analytic placement to 
+Partitions are subsets of BelIds and cell types used by analytic placer to
 seperate types of BELs during placement.  Typical partitions are:
  - All LUT BELs
  - All FF BELs

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -88,6 +88,14 @@ Get Z dimension for the specified tile for bels. All bels with at specified X an
 
 Get Z dimension for the specified tile for pips. All pips with at specified X and Y coordinates must have a Z coordinate in the range `0 .. getTileDimZ(X,Y)-1` (inclusive).
 
+Cell Methods
+-----------
+
+### const\_range\<IdString\> getCellTypes() const
+
+Get list of cell types that this architecture accepts.
+
+
 Bel Methods
 -----------
 
@@ -478,8 +486,8 @@ information for all edges. `index` must be in [0, clockInfoCount), behaviour is 
 Partition Methods
 -----------------
 
-Partitions are used by analytic placement to seperate types of BELs during
-placement.  Typical partitions are:
+Partitions are subsets of BelIds and cell types used by analytic placement to 
+seperate types of BELs during placement.  Typical partitions are:
  - All LUT BELs
  - All FF BELs
  - All multipliers BELs
@@ -487,7 +495,8 @@ placement.  Typical partitions are:
  - etc.
 
 The general rule here is to include all BELs that are roughly interchangable
-during placement.
+during placement.  Partitions should form an exact cover over all BelIds and
+cell types.
 
 ### const\_range\<PartitionId\> getPartitions() const
 
@@ -497,7 +506,15 @@ Return a list of all partitions on the device.
 
 Return the name of the partition.
 
+### PartitionId getPartitionByName(IdString partition\_name) const
+
+Return the partition for the specified partition name.
+
 ### PartitionId getPartitionForBel(BelId bel) const
+
+Returns the partition for a particular BEL.
+
+### PartitionId getPartitionForCell(IdString cell\_type) const
 
 Returns the partition for a particular cell type.
 

--- a/docs/coding.md
+++ b/docs/coding.md
@@ -24,9 +24,9 @@ This function allows architectures in nextpnr to do significantly less packing t
 
 Additionally to this; architectures provide functions for checking the availability and conflicts between resources (e.g. `checkBelAvail`, `checkPipAvail`, etc). This enables arbitrary constraints between resource availability to be defined, for example:
 
- - where a group of PIPs share bitstream bits, only one can be used at a time
- - PIPs that represent LUT permutation are not available when the LUT is in memory mode
- - only a certain total number of PIPs in a switchbox can be used at once due to power supply limitations
+ - where a group of pips share bitstream bits, only one can be used at a time
+ - Pips that represent LUT permutation are not available when the LUT is in memory mode
+ - only a certain total number of pips in a switchbox can be used at once due to power supply limitations
 
 ## `IdString`s
 
@@ -39,22 +39,22 @@ Note that `IdString`s need a `Context` (or `BaseCtx`) pointer to convert them ba
 ## Developing CAD algorithms - packing
 
 Packing in nextpnr could be done in two ways (if significant packing is done at all):
- - replacing multiple cells with a single larger cell that corresponds to a BEL
+ - replacing multiple cells with a single larger cell that corresponds to a bel
  - combining smaller cells using relative placement constraints
 
 The packer will also have to add relative constraints for fixed structures such as carry chains or LUT-MUX cascades.
 
 There are several helper functions that are useful for developing packers and other passes that perform significant netlist modifications in `util.h`. It is often preferable to use these compared to direct modification of the netlist structures due to the "double linking" nextpnr does - e.g. when connecting a port you must update both the `net` field of the ports and the `driver`/`users` of the net.
 
-### Cell to BEL mapping
+### Cell to bel mapping
 
 There is an Arch API choice when it comes to representing the relationship
-between cell types and BEL types.  One option is to transform cells into
-common types that correspond to a BEL (e.g. convert multiple flipflop
+between cell types and bel types.  One option is to transform cells into
+common types that correspond to a bel (e.g. convert multiple flipflop
 primitives to a single common type with some extra parameters). In Arch APIs
 designed like this, packer transformations are required to convert input cell
 types into nextpnr specific cell types that have a 1 to 1 relationship with
-BEL types.
+bel types.
 
 For Arch APIs of this type, the method `isValidBelForCellType` reduces to:
 
@@ -65,15 +65,15 @@ bool isValidBelForCellType(IdString cell_type, BelId bel) const {
 ```
 
 The alternative is to implement a fast `isValidBelForCellType` method that
-determines if this cell type can be bound to this BEL.
+determines if this cell type can be bound to this bel.
 
 ## Developing CAD algorithms - placement
 
-The job of the placer in nextpnr is to find a suitable BEL for each cell in the design; while respecting legality and relative constraints.
+The job of the placer in nextpnr is to find a suitable bel for each cell in the design; while respecting legality and relative constraints.
 
-Placers might want to create their own indices of BELs (for example, BELs by type and location) to speed up the search.
+Placers might want to create their own indices of bels (for example, bels by type and location) to speed up the search.
 
-As nextpnr allows arbitrary constraints on BELs for more advanced packer-free flows and complex real-world architectures; placements must be checked for legality using `isValidBelForCell` (before placement) or `isBelLocationValid` (after placement) and the placement rejected if invalid. For analytical placement algorithms; after creating a spread-out AP solution the legality of placing each cell needs to be checked. In practice, the cost of this is fairly low as the architecture should ensure these functions are as fast as possible.
+As nextpnr allows arbitrary constraints on bels for more advanced packer-free flows and complex real-world architectures; placements must be checked for legality using `isValidBelForCell` (before placement) or `isBelLocationValid` (after placement) and the placement rejected if invalid. For analytical placement algorithms; after creating a spread-out AP solution the legality of placing each cell needs to be checked. In practice, the cost of this is fairly low as the architecture should ensure these functions are as fast as possible.
 
 There are several routes for timing information in the placer:
     - sink `PortRef`s have a `budget` value annotated by calling `assign_budget` which is an estimate of the maximum delay that an arc may have
@@ -81,14 +81,14 @@ There are several routes for timing information in the placer:
     - `predictDelay` returns an estimated delay for a sink port based on placement information
 
 
-### BEL Buckets
+### Bel Buckets
 
-The BEL Bucket Arch APIs can be used by an analytical placer (AP) for getting 
-groups of BELs and cell types placed together.  This grouping is important for
+The bel Bucket Arch APIs can be used by an analytical placer (AP) for getting
+groups of bels and cell types placed together.  This grouping is important for
 algorithms like HeAP which typically want to do operate on subsets of the
 design for some portions of the placement.
 
-The HeAP implementation allows for multiple BEL buckets to be placed on 
+The HeAP implementation allows for multiple bel buckets to be placed on
 together, see the "cellGroups" field.
 
 ## Routing

--- a/docs/coding.md
+++ b/docs/coding.md
@@ -14,9 +14,9 @@ This document aims to provide an overview into the philosophy behind nextpnr's c
 
 An architecture in nextpnr is described first and foremost as code. The exact details are given in the [Arch API reference](archapi.md); this aims to explain the core concept.
 
-By choosing this approach; this gives architectures significant flexibility to use more advanced database representations than a simple flat database - for example deduplicated approaches that store similar tiles only once. 
+By choosing this approach; this gives architectures significant flexibility to use more advanced database representations than a simple flat database - for example deduplicated approaches that store similar tiles only once.
 
-Architectures can also implement custom algorithms for packing (or other initial netlist transformations) and specialized parts of placement and routing such as global clock networks. This is because architectures provide the `pack()`, `place()` and `route()` functions, although the latter two will normally use generic algorithms (such as HeAP and router1) to do most of the work. 
+Architectures can also implement custom algorithms for packing (or other initial netlist transformations) and specialized parts of placement and routing such as global clock networks. This is because architectures provide the `pack()`, `place()` and `route()` functions, although the latter two will normally use generic algorithms (such as HeAP and router1) to do most of the work.
 
 Another important function provided by architectures is placement validity checking. This allows the placer to check whether or not a given cell placement is valid. An example of this is for iCE40, where 8 logic cells in a tile share one clock signal - this is checked here.
 
@@ -24,13 +24,13 @@ This function allows architectures in nextpnr to do significantly less packing t
 
 Additionally to this; architectures provide functions for checking the availability and conflicts between resources (e.g. `checkBelAvail`, `checkPipAvail`, etc). This enables arbitrary constraints between resource availability to be defined, for example:
 
- - where a group of Pips share bitstream bits, only one can be used at a time
- - Pips that represent LUT permutation are not available when the LUT is in memory mode
- - only a certain total number of Pips in a switchbox can be used at once due to power supply limitations
+ - where a group of PIPs share bitstream bits, only one can be used at a time
+ - PIPs that represent LUT permutation are not available when the LUT is in memory mode
+ - only a certain total number of PIPs in a switchbox can be used at once due to power supply limitations
 
 ## `IdString`s
 
-To avoid the high cost of using strings as identifiers directly; almost all "string" identifiers in nextpnr (such as cell names and types) use an indexed string pool type named `IdString`. Unlike Yosys, which has a global garbage collected pool, nextpnr has a per-Context pool without any garbage collection. 
+To avoid the high cost of using strings as identifiers directly; almost all "string" identifiers in nextpnr (such as cell names and types) use an indexed string pool type named `IdString`. Unlike Yosys, which has a global garbage collected pool, nextpnr has a per-Context pool without any garbage collection.
 
 `IdString`s can be created in two ways. Architectures can add `IdString`s with constant indices - allowing `IdString` constants to be provided too - using `initialize_add` at startup. See how `constids.inc` is used in iCE40 for an example of this. The main way to create `IdString`s, however, is at runtime using the `id` member function of `BaseCtx` given the string to create from (if an `IdString` of that string already exists, the existing `IdString` will be returned).
 
@@ -39,25 +39,57 @@ Note that `IdString`s need a `Context` (or `BaseCtx`) pointer to convert them ba
 ## Developing CAD algorithms - packing
 
 Packing in nextpnr could be done in two ways (if significant packing is done at all):
- - replacing multiple cells with a single larger cell that corresponds to a bel
+ - replacing multiple cells with a single larger cell that corresponds to a BEL
  - combining smaller cells using relative placement constraints
 
-In flows with minimal packing the main task of the packer is to transform cells into common types that correspond to a bel (e.g. convert multiple flipflop primitives to a single common type with some extra parameters). The packer will also have to add relative constraints for fixed structures such as carry chains or LUT-MUX cascades.
+The packer will also have to add relative constraints for fixed structures such as carry chains or LUT-MUX cascades.
 
 There are several helper functions that are useful for developing packers and other passes that perform significant netlist modifications in `util.h`. It is often preferable to use these compared to direct modification of the netlist structures due to the "double linking" nextpnr does - e.g. when connecting a port you must update both the `net` field of the ports and the `driver`/`users` of the net.
 
+### Cell to BEL mapping
+
+There is an Arch API choice when it comes to representing the relationship
+between cell types and BEL types.  One option is to transform cells into
+common types that correspond to a BEL (e.g. convert multiple flipflop
+primitives to a single common type with some extra parameters). In Arch APIs
+designed like this, packer transformations are required to convert input cell
+types into nextpnr specific cell types that have a 1 to 1 relationship with
+BEL types.
+
+For Arch APIs of this type, the method `isValidBelForCellType` reduces to:
+
+```
+bool isValidBelForCellType(IdString cell_type, BelId bel) const {
+    return cell_type == getBelType(bel);
+}
+```
+
+The alternative is to implement a fast `isValidBelForCellType` method that
+determines if this cell type can be bound to this BEL.
+
 ## Developing CAD algorithms - placement
 
-The job of the placer in nextpnr is to find a suitable bel for each cell in the design; while respecting legality and relative constraints.
+The job of the placer in nextpnr is to find a suitable BEL for each cell in the design; while respecting legality and relative constraints.
 
-Placers might want to create their own indices of bels (for example, bels by type and location) to speed up the search. 
+Placers might want to create their own indices of BELs (for example, BELs by type and location) to speed up the search.
 
-As nextpnr allows arbitrary constraints on bels for more advanced packer-free flows and complex real-world architectures; placements must be checked for legality using `isValidBelForCell` (before placement) or `isBelLocationValid` (after placement) and the placement rejected if invalid. For analytical placement algorithms; after creating a spread-out AP solution the legality of placing each cell needs to be checked. In practice, the cost of this is fairly low as the architecture should ensure these functions are as fast as possible.
+As nextpnr allows arbitrary constraints on BELs for more advanced packer-free flows and complex real-world architectures; placements must be checked for legality using `isValidBelForCell` (before placement) or `isBelLocationValid` (after placement) and the placement rejected if invalid. For analytical placement algorithms; after creating a spread-out AP solution the legality of placing each cell needs to be checked. In practice, the cost of this is fairly low as the architecture should ensure these functions are as fast as possible.
 
 There are several routes for timing information in the placer:
     - sink `PortRef`s have a `budget` value annotated by calling `assign_budget` which is an estimate of the maximum delay that an arc may have
     - sink ports can have a criticality (value between 0 and 1 where 1 is the critical path) associated with them by using `get_criticalities` and a `NetCriticalityMap`
     - `predictDelay` returns an estimated delay for a sink port based on placement information
+
+
+### BEL Buckets
+
+The BEL Bucket Arch APIs can be used by an analytical placer (AP) for getting 
+groups of BELs and cell types placed together.  This grouping is important for
+algorithms like HeAP which typically want to do operate on subsets of the
+design for some portions of the placement.
+
+The HeAP implementation allows for multiple BEL buckets to be placed on 
+together, see the "cellGroups" field.
 
 ## Routing
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -23,6 +23,7 @@ For nextpnr we are using the following terminology.
 - **Wire**: a fixed physical connection inside the FPGA between Pips and/or Bel pins.
 - **Alias**: a special automatic-on Pip to represent a permanent connection between two wires
 - **Group**: a collection of bels, pips, wires, and/or other groups
+- **BelBucket**: a collection of BELs and cell types.  All of the BEL buckets form a set cover of BELs and cell types.
 
 ### Flow Terminology
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -23,7 +23,7 @@ For nextpnr we are using the following terminology.
 - **Wire**: a fixed physical connection inside the FPGA between Pips and/or Bel pins.
 - **Alias**: a special automatic-on Pip to represent a permanent connection between two wires
 - **Group**: a collection of bels, pips, wires, and/or other groups
-- **BelBucket**: a collection of BELs and cell types.  All of the BEL buckets form a set cover of BELs and cell types.
+- **BelBucket**: a collection of bels and cell types.  All of the bel buckets form a set cover of bels and cell types.
 
 ### Flow Terminology
 

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -115,6 +115,19 @@ Arch::Arch(ArchArgs args) : args(args)
         log_error("Unsupported package '%s' for '%s'.\n", args.package.c_str(), getChipName().c_str());
 
     bel_to_cell.resize(chip_info->height * chip_info->width * max_loc_bels, nullptr);
+
+    std::unordered_set<IdString> bel_types;
+    for(BelId bel : getBels()) {
+        bel_types.insert(getBelType(bel));
+    }
+
+    for(IdString bel_type : bel_types) {
+        cell_types.push_back(bel_type);
+
+        PartitionId partition;
+        partition.name = bel_type;
+        partitions.push_back(partitions);
+    }
 }
 
 // -----------------------------------------------------------------------

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -124,9 +124,9 @@ Arch::Arch(ArchArgs args) : args(args)
     for(IdString bel_type : bel_types) {
         cell_types.push_back(bel_type);
 
-        PartitionId partition;
-        partition.name = bel_type;
-        partitions.push_back(partition);
+        BelBucketId bucket;
+        bucket.name = bel_type;
+        buckets.push_back(bucket);
     }
 }
 

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -126,7 +126,7 @@ Arch::Arch(ArchArgs args) : args(args)
 
         PartitionId partition;
         partition.name = bel_type;
-        partitions.push_back(partitions);
+        partitions.push_back(partition);
     }
 }
 

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -117,11 +117,11 @@ Arch::Arch(ArchArgs args) : args(args)
     bel_to_cell.resize(chip_info->height * chip_info->width * max_loc_bels, nullptr);
 
     std::unordered_set<IdString> bel_types;
-    for(BelId bel : getBels()) {
+    for (BelId bel : getBels()) {
         bel_types.insert(getBelType(bel));
     }
 
-    for(IdString bel_type : bel_types) {
+    for (IdString bel_type : bel_types) {
         cell_types.push_back(bel_type);
 
         BelBucketId bucket;

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -950,44 +950,40 @@ struct Arch : BaseCtx
 
     // -------------------------------------------------
     // Placement validity checks
-    bool isValidBelForCellType(IdString cell_type, BelId bel) const {
-        return cell_type == getBelType(bel);
-    }
+    bool isValidBelForCellType(IdString cell_type, BelId bel) const { return cell_type == getBelType(bel); }
 
-    const std::vector<IdString> &getCellTypes() const {
-        return cell_types;
-    }
+    const std::vector<IdString> &getCellTypes() const { return cell_types; }
 
-    std::vector<BelBucketId> getBelBuckets() const {
-        return buckets;
-    }
+    std::vector<BelBucketId> getBelBuckets() const { return buckets; }
 
-    IdString getBelBucketName(BelBucketId bucket) const {
-        return bucket.name;
-    }
+    IdString getBelBucketName(BelBucketId bucket) const { return bucket.name; }
 
-    BelBucketId getBelBucketByName(IdString name) const {
+    BelBucketId getBelBucketByName(IdString name) const
+    {
         BelBucketId bucket;
         bucket.name = name;
         return bucket;
     }
 
-    BelBucketId getBelBucketForBel(BelId bel) const {
+    BelBucketId getBelBucketForBel(BelId bel) const
+    {
         BelBucketId bucket;
         bucket.name = getBelType(bel);
         return bucket;
     }
 
-    BelBucketId getBelBucketForCellType(IdString cell_type) const {
+    BelBucketId getBelBucketForCellType(IdString cell_type) const
+    {
         BelBucketId bucket;
         bucket.name = cell_type;
         return bucket;
     }
 
-    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const {
+    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const
+    {
         std::vector<BelId> bels;
-        for(BelId bel : getBels()) {
-            if(getBelType(bel) == bucket.name) {
+        for (BelId bel : getBels()) {
+            if (getBelType(bel) == bucket.name) {
                 bels.push_back(bel);
             }
         }

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -958,36 +958,36 @@ struct Arch : BaseCtx
         return cell_types;
     }
 
-    std::vector<PartitionId> getPartitions() const {
-        return partitions;
+    std::vector<BelBucketId> getBelBuckets() const {
+        return buckets;
     }
 
-    IdString getPartitionName(PartitionId partition) const {
-        return partition.name;
+    IdString getBelBucketName(BelBucketId bucket) const {
+        return bucket.name;
     }
 
-    PartitionId getPartitionByName(IdString name) const {
-        PartitionId partition;
-        partition.name = name;
-        return partition;
+    BelBucketId getBelBucketByName(IdString name) const {
+        BelBucketId bucket;
+        bucket.name = name;
+        return bucket;
     }
 
-    PartitionId getPartitionForBel(BelId bel) const {
-        PartitionId partition;
-        partition.name = getBelType(bel);
-        return partition;
+    BelBucketId getBelBucketForBel(BelId bel) const {
+        BelBucketId bucket;
+        bucket.name = getBelType(bel);
+        return bucket;
     }
 
-    PartitionId getPartitionForCellType(IdString cell_type) const {
-        PartitionId partition;
-        partition.name = cell_type;
-        return partition;
+    BelBucketId getBelBucketForCellType(IdString cell_type) const {
+        BelBucketId bucket;
+        bucket.name = cell_type;
+        return bucket;
     }
 
-    std::vector<BelId> getBelsForPartition(PartitionId partition) const {
+    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const {
         std::vector<BelId> bels;
         for(BelId bel : getBels()) {
-            if(getBelType(bel) == partition.name) {
+            if(getBelType(bel) == bucket.name) {
                 bels.push_back(bel);
             }
         }
@@ -1068,7 +1068,7 @@ struct Arch : BaseCtx
     static const std::vector<std::string> availableRouters;
 
     std::vector<IdString> cell_types;
-    std::vector<PartitionId> partitions;
+    std::vector<BelBucketId> buckets;
 };
 
 NEXTPNR_NAMESPACE_END

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -953,6 +953,47 @@ struct Arch : BaseCtx
     bool isValidBelForCellType(IdString cell_type, BelId bel) const {
         return cell_type == getBelType(bel);
     }
+
+    const std::vector<IdString> &getCellTypes() const {
+        return cell_types;
+    }
+
+    std::vector<PartitionId> getPartitions() const {
+        return partitions;
+    }
+
+    IdString getPartitionName(PartitionId partition) const {
+        return partition.name;
+    }
+
+    PartitionId getPartitionByName(IdString name) const {
+        PartitionId partition;
+        partition.name = name;
+        return partition;
+    }
+
+    PartitionId getPartitionForBel(BelId bel) const {
+        PartitionId partition;
+        partition.name = getBelType(bel);
+        return partition;
+    }
+
+    PartitionId getPartitionForCellType(IdString cell_type) const {
+        PartitionId partition;
+        partition.name = cell_type;
+        return partition;
+    }
+
+    std::vector<BelId> getBelsForPartition(PartitionId partition) const {
+        std::vector<BelId> bels;
+        for(BelId bel : getBels()) {
+            if(getBelType(bel) == partition.name) {
+                bels.push_back(bel);
+            }
+        }
+        return bels;
+    }
+
     bool isValidBelForCell(CellInfo *cell, BelId bel) const;
     bool isBelLocationValid(BelId bel) const;
 
@@ -1025,6 +1066,9 @@ struct Arch : BaseCtx
     static const std::vector<std::string> availablePlacers;
     static const std::string defaultRouter;
     static const std::vector<std::string> availableRouters;
+
+    std::vector<IdString> cell_types;
+    std::vector<PartitionId> partitions;
 };
 
 NEXTPNR_NAMESPACE_END

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -950,6 +950,9 @@ struct Arch : BaseCtx
 
     // -------------------------------------------------
     // Placement validity checks
+    bool isValidBelForCellType(IdString cell_type, BelId bel) const {
+        return cell_type == getBelType(bel);
+    }
     bool isValidBelForCell(CellInfo *cell, BelId bel) const;
     bool isBelLocationValid(BelId bel) const;
 

--- a/ecp5/arch_pybindings.cc
+++ b/ecp5/arch_pybindings.cc
@@ -59,6 +59,8 @@ void arch_wrap_python(py::module &m)
     typedef const PipRange UphillPipRange;
     typedef const PipRange DownhillPipRange;
 
+    typedef const std::vector<BelBucketId> & BelBucketRange;
+    typedef const std::vector<BelId> & BelRangeForBelBucket;
 #include "arch_pybindings_shared.h"
 
     WRAP_RANGE(m, Bel, conv_to_str<BelId>);

--- a/ecp5/arch_pybindings.cc
+++ b/ecp5/arch_pybindings.cc
@@ -59,8 +59,8 @@ void arch_wrap_python(py::module &m)
     typedef const PipRange UphillPipRange;
     typedef const PipRange DownhillPipRange;
 
-    typedef const std::vector<BelBucketId> & BelBucketRange;
-    typedef const std::vector<BelId> & BelRangeForBelBucket;
+    typedef const std::vector<BelBucketId> &BelBucketRange;
+    typedef const std::vector<BelId> &BelRangeForBelBucket;
 #include "arch_pybindings_shared.h"
 
     WRAP_RANGE(m, Bel, conv_to_str<BelId>);

--- a/ecp5/arch_pybindings.h
+++ b/ecp5/arch_pybindings.h
@@ -76,6 +76,18 @@ template <> struct string_converter<PipId>
     }
 };
 
+template <> struct string_converter<BelBucketId>
+{
+    BelBucketId from_str(Context *ctx, std::string name) { return ctx->getBelBucketByName(ctx->id(name)); }
+
+    std::string to_str(Context *ctx, BelBucketId id)
+    {
+        if (id == BelBucketId())
+            throw bad_wrap();
+        return ctx->getBelBucketName(id).str(ctx);
+    }
+};
+
 template <> struct string_converter<BelPin>
 {
     BelPin from_str(Context *ctx, std::string name)

--- a/ecp5/archdefs.h
+++ b/ecp5/archdefs.h
@@ -131,6 +131,10 @@ struct PartitionId {
 
     bool operator==(const PartitionId &other) const { return (name == other.name); }
     bool operator!=(const PartitionId &other) const { return (name != other.name); }
+    bool operator<(const PartitionId &other) const
+    {
+        return name < other.name;
+    }
 };
 
 struct GroupId
@@ -265,6 +269,16 @@ template <> struct hash<NEXTPNR_NAMESPACE_PREFIX DecalId>
         boost::hash_combine(seed, hash<NEXTPNR_NAMESPACE_PREFIX Location>()(decal.location));
         boost::hash_combine(seed, hash<int>()(decal.z));
         boost::hash_combine(seed, hash<bool>()(decal.active));
+        return seed;
+    }
+};
+
+template <> struct hash<NEXTPNR_NAMESPACE_PREFIX PartitionId>
+{
+    std::size_t operator()(const NEXTPNR_NAMESPACE_PREFIX PartitionId &partition) const noexcept
+    {
+        std::size_t seed = 0;
+        boost::hash_combine(seed, hash<NEXTPNR_NAMESPACE_PREFIX IdString>()(partition.name));
         return seed;
     }
 };

--- a/ecp5/archdefs.h
+++ b/ecp5/archdefs.h
@@ -126,6 +126,13 @@ struct PipId
     }
 };
 
+struct PartitionId {
+    IdString name;
+
+    bool operator==(const PartitionId &other) const { return (name == other.name); }
+    bool operator!=(const PartitionId &other) const { return (name != other.name); }
+};
+
 struct GroupId
 {
     enum : int8_t

--- a/ecp5/archdefs.h
+++ b/ecp5/archdefs.h
@@ -126,15 +126,13 @@ struct PipId
     }
 };
 
-struct BelBucketId {
+struct BelBucketId
+{
     IdString name;
 
     bool operator==(const BelBucketId &other) const { return (name == other.name); }
     bool operator!=(const BelBucketId &other) const { return (name != other.name); }
-    bool operator<(const BelBucketId &other) const
-    {
-        return name < other.name;
-    }
+    bool operator<(const BelBucketId &other) const { return name < other.name; }
 };
 
 struct GroupId

--- a/ecp5/archdefs.h
+++ b/ecp5/archdefs.h
@@ -126,12 +126,12 @@ struct PipId
     }
 };
 
-struct PartitionId {
+struct BelBucketId {
     IdString name;
 
-    bool operator==(const PartitionId &other) const { return (name == other.name); }
-    bool operator!=(const PartitionId &other) const { return (name != other.name); }
-    bool operator<(const PartitionId &other) const
+    bool operator==(const BelBucketId &other) const { return (name == other.name); }
+    bool operator!=(const BelBucketId &other) const { return (name != other.name); }
+    bool operator<(const BelBucketId &other) const
     {
         return name < other.name;
     }
@@ -273,9 +273,9 @@ template <> struct hash<NEXTPNR_NAMESPACE_PREFIX DecalId>
     }
 };
 
-template <> struct hash<NEXTPNR_NAMESPACE_PREFIX PartitionId>
+template <> struct hash<NEXTPNR_NAMESPACE_PREFIX BelBucketId>
 {
-    std::size_t operator()(const NEXTPNR_NAMESPACE_PREFIX PartitionId &partition) const noexcept
+    std::size_t operator()(const NEXTPNR_NAMESPACE_PREFIX BelBucketId &partition) const noexcept
     {
         std::size_t seed = 0;
         boost::hash_combine(seed, hash<NEXTPNR_NAMESPACE_PREFIX IdString>()(partition.name));

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -272,11 +272,17 @@ struct Arch : BaseCtx
     bool route();
 
     std::vector<IdString> getCellTypes() const {
-        return {};
+        std::vector<IdString> cell_types;
+        cell_types.reserve(bels.size());
+        for(auto bel : bels) {
+            cell_types.push_back(bel.first);
+        }
+
+        return cell_types;
     }
 
     std::vector<PartitionId> getPartitions() const {
-        return {};
+        return getCellTypes();
     }
 
     IdString getPartitionName(PartitionId partition) const {
@@ -296,7 +302,13 @@ struct Arch : BaseCtx
     }
 
     std::vector<BelId> getBelsForPartition(PartitionId partition) const {
-        return {};
+        std::vector<BelId> bels;
+        for(BelId bel : getBels()) {
+            if(partition == getPartitionForBel(bel)) {
+                bels.push_back(bel);
+            }
+        }
+        return bels;
     }
 
     const std::vector<GraphicElement> &getDecalGraphics(DecalId decal) const;

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -271,40 +271,32 @@ struct Arch : BaseCtx
     bool place();
     bool route();
 
-    std::vector<IdString> getCellTypes() const {
+    std::vector<IdString> getCellTypes() const
+    {
         std::vector<IdString> cell_types;
         cell_types.reserve(bels.size());
-        for(auto bel : bels) {
+        for (auto bel : bels) {
             cell_types.push_back(bel.first);
         }
 
         return cell_types;
     }
 
-    std::vector<BelBucketId> getBelBuckets() const {
-        return getCellTypes();
-    }
+    std::vector<BelBucketId> getBelBuckets() const { return getCellTypes(); }
 
-    IdString getBelBucketName(BelBucketId bucket) const {
-        return bucket;
-    }
+    IdString getBelBucketName(BelBucketId bucket) const { return bucket; }
 
-    BelBucketId getBelBucketByName(IdString bucket) const {
-        return bucket;
-    }
+    BelBucketId getBelBucketByName(IdString bucket) const { return bucket; }
 
-    BelBucketId getBelBucketForBel(BelId bel) const {
-        return getBelType(bel);
-    }
+    BelBucketId getBelBucketForBel(BelId bel) const { return getBelType(bel); }
 
-    BelBucketId getBelBucketForCellType(IdString cell_type) const {
-        return cell_type;
-    }
+    BelBucketId getBelBucketForCellType(IdString cell_type) const { return cell_type; }
 
-    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const {
+    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const
+    {
         std::vector<BelId> bels;
-        for(BelId bel : getBels()) {
-            if(bucket == getBelBucketForBel(bel)) {
+        for (BelId bel : getBels()) {
+            if (bucket == getBelBucketForBel(bel)) {
                 bels.push_back(bel);
             }
         }
@@ -323,9 +315,7 @@ struct Arch : BaseCtx
     // Get the TimingClockingInfo of a port
     TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const;
 
-    bool isValidBelForCellType(IdString cell_type, BelId bel) const {
-        return cell_type == getBelType(bel);
-    }
+    bool isValidBelForCellType(IdString cell_type, BelId bel) const { return cell_type == getBelType(bel); }
     bool isValidBelForCell(CellInfo *cell, BelId bel) const;
     bool isBelLocationValid(BelId bel) const;
 

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -271,6 +271,34 @@ struct Arch : BaseCtx
     bool place();
     bool route();
 
+    std::vector<IdString> getCellTypes() const {
+        return {};
+    }
+
+    std::vector<PartitionId> getPartitions() const {
+        return {};
+    }
+
+    IdString getPartitionName(PartitionId partition) const {
+        return partition;
+    }
+
+    PartitionId getPartitionByName(IdString partition) const {
+        return partition;
+    }
+
+    PartitionId getPartitionForBel(BelId bel) const {
+        return getBelType(bel);
+    }
+
+    PartitionId getPartitionForCellType(IdString cell_type) const {
+        return cell_type;
+    }
+
+    std::vector<BelId> getBelsForPartition(PartitionId partition) const {
+        return {};
+    }
+
     const std::vector<GraphicElement> &getDecalGraphics(DecalId decal) const;
     DecalXY getBelDecal(BelId bel) const;
     DecalXY getWireDecal(WireId wire) const;

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -281,30 +281,30 @@ struct Arch : BaseCtx
         return cell_types;
     }
 
-    std::vector<PartitionId> getPartitions() const {
+    std::vector<BelBucketId> getBelBuckets() const {
         return getCellTypes();
     }
 
-    IdString getPartitionName(PartitionId partition) const {
-        return partition;
+    IdString getBelBucketName(BelBucketId bucket) const {
+        return bucket;
     }
 
-    PartitionId getPartitionByName(IdString partition) const {
-        return partition;
+    BelBucketId getBelBucketByName(IdString bucket) const {
+        return bucket;
     }
 
-    PartitionId getPartitionForBel(BelId bel) const {
+    BelBucketId getBelBucketForBel(BelId bel) const {
         return getBelType(bel);
     }
 
-    PartitionId getPartitionForCellType(IdString cell_type) const {
+    BelBucketId getBelBucketForCellType(IdString cell_type) const {
         return cell_type;
     }
 
-    std::vector<BelId> getBelsForPartition(PartitionId partition) const {
+    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const {
         std::vector<BelId> bels;
         for(BelId bel : getBels()) {
-            if(partition == getPartitionForBel(bel)) {
+            if(bucket == getBelBucketForBel(bel)) {
                 bels.push_back(bel);
             }
         }

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -283,6 +283,9 @@ struct Arch : BaseCtx
     // Get the TimingClockingInfo of a port
     TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const;
 
+    bool isValidBelForCellType(IdString cell_type, BelId bel) const {
+        return cell_type == getBelType(bel);
+    }
     bool isValidBelForCell(CellInfo *cell, BelId bel) const;
     bool isBelLocationValid(BelId bel) const;
 

--- a/generic/arch_pybindings.cc
+++ b/generic/arch_pybindings.cc
@@ -226,6 +226,32 @@ void arch_wrap_python(py::module &m)
                     pass_through<DelayInfo>>::def_wrap(ctx_cls, "addCellTimingClockToOut", "cell"_a, "port"_a,
                                                        "clock"_a, "clktoq"_a);
 
+    // const\_range\<BelBucketId\> getBelBuckets() const
+    fn_wrapper_0a<Context, decltype(&Context::getBelBuckets),
+        &Context::getBelBuckets,
+        wrap_context<const std::vector<BelBucketId> &>>::def_wrap(ctx_cls, "getBelBuckets");
+
+    // BelBucketId getBelBucketForBel(BelId bel) const
+    fn_wrapper_1a<Context, decltype(&Context::getBelBucketForBel),
+        &Context::getBelBucketForBel, conv_to_str<BelBucketId>,
+        conv_from_str<BelId>>::def_wrap(ctx_cls, "getBelBucketForBel");
+
+    // BelBucketId getBelBucketForCellType(IdString cell\_type) const
+    fn_wrapper_1a<Context, decltype(&Context::getBelBucketForCellType),
+        &Context::getBelBucketForCellType, conv_to_str<BelBucketId>,
+        conv_from_str<IdString>>::def_wrap(ctx_cls, "getBelBucketForCellType");
+
+    // const\_range\<BelId\> getBelsInBucket(BelBucketId bucket) const
+    fn_wrapper_1a<Context, decltype(&Context::getBelsInBucket),
+        &Context::getBelsInBucket, wrap_context<const std::vector<BelId> &>,
+        conv_from_str<BelBucketId>>::def_wrap(ctx_cls, "getBelsInBucket");
+
+    // bool isValidBelForCellType(IdString cell\_type, BelId bel) const
+    fn_wrapper_2a<Context, decltype(&Context::isValidBelForCellType),
+        &Context::isValidBelForCellType, pass_through<bool>,
+        conv_from_str<IdString>, conv_from_str<BelId>>::def_wrap(
+                ctx_cls, "isValidBelForCellType");
+
     WRAP_MAP_UPTR(m, CellMap, "IdCellMap");
     WRAP_MAP_UPTR(m, NetMap, "IdNetMap");
     WRAP_MAP(m, HierarchyMap, wrap_context<HierarchicalCell &>, "HierarchyMap");

--- a/generic/arch_pybindings.cc
+++ b/generic/arch_pybindings.cc
@@ -227,30 +227,26 @@ void arch_wrap_python(py::module &m)
                                                        "clock"_a, "clktoq"_a);
 
     // const\_range\<BelBucketId\> getBelBuckets() const
-    fn_wrapper_0a<Context, decltype(&Context::getBelBuckets),
-        &Context::getBelBuckets,
-        wrap_context<const std::vector<BelBucketId> &>>::def_wrap(ctx_cls, "getBelBuckets");
+    fn_wrapper_0a<Context, decltype(&Context::getBelBuckets), &Context::getBelBuckets,
+                  wrap_context<const std::vector<BelBucketId> &>>::def_wrap(ctx_cls, "getBelBuckets");
 
     // BelBucketId getBelBucketForBel(BelId bel) const
-    fn_wrapper_1a<Context, decltype(&Context::getBelBucketForBel),
-        &Context::getBelBucketForBel, conv_to_str<BelBucketId>,
-        conv_from_str<BelId>>::def_wrap(ctx_cls, "getBelBucketForBel");
+    fn_wrapper_1a<Context, decltype(&Context::getBelBucketForBel), &Context::getBelBucketForBel,
+                  conv_to_str<BelBucketId>, conv_from_str<BelId>>::def_wrap(ctx_cls, "getBelBucketForBel");
 
     // BelBucketId getBelBucketForCellType(IdString cell\_type) const
-    fn_wrapper_1a<Context, decltype(&Context::getBelBucketForCellType),
-        &Context::getBelBucketForCellType, conv_to_str<BelBucketId>,
-        conv_from_str<IdString>>::def_wrap(ctx_cls, "getBelBucketForCellType");
+    fn_wrapper_1a<Context, decltype(&Context::getBelBucketForCellType), &Context::getBelBucketForCellType,
+                  conv_to_str<BelBucketId>, conv_from_str<IdString>>::def_wrap(ctx_cls, "getBelBucketForCellType");
 
     // const\_range\<BelId\> getBelsInBucket(BelBucketId bucket) const
-    fn_wrapper_1a<Context, decltype(&Context::getBelsInBucket),
-        &Context::getBelsInBucket, wrap_context<const std::vector<BelId> &>,
-        conv_from_str<BelBucketId>>::def_wrap(ctx_cls, "getBelsInBucket");
+    fn_wrapper_1a<Context, decltype(&Context::getBelsInBucket), &Context::getBelsInBucket,
+                  wrap_context<const std::vector<BelId> &>, conv_from_str<BelBucketId>>::def_wrap(ctx_cls,
+                                                                                                  "getBelsInBucket");
 
     // bool isValidBelForCellType(IdString cell\_type, BelId bel) const
-    fn_wrapper_2a<Context, decltype(&Context::isValidBelForCellType),
-        &Context::isValidBelForCellType, pass_through<bool>,
-        conv_from_str<IdString>, conv_from_str<BelId>>::def_wrap(
-                ctx_cls, "isValidBelForCellType");
+    fn_wrapper_2a<Context, decltype(&Context::isValidBelForCellType), &Context::isValidBelForCellType,
+                  pass_through<bool>, conv_from_str<IdString>, conv_from_str<BelId>>::def_wrap(ctx_cls,
+                                                                                               "isValidBelForCellType");
 
     WRAP_MAP_UPTR(m, CellMap, "IdCellMap");
     WRAP_MAP_UPTR(m, NetMap, "IdNetMap");

--- a/generic/archdefs.h
+++ b/generic/archdefs.h
@@ -51,6 +51,7 @@ typedef IdString WireId;
 typedef IdString PipId;
 typedef IdString GroupId;
 typedef IdString DecalId;
+typedef IdString PartitionId;
 
 struct ArchNetInfo
 {

--- a/generic/archdefs.h
+++ b/generic/archdefs.h
@@ -51,7 +51,7 @@ typedef IdString WireId;
 typedef IdString PipId;
 typedef IdString GroupId;
 typedef IdString DecalId;
-typedef IdString PartitionId;
+typedef IdString BelBucketId;
 
 struct ArchNetInfo
 {

--- a/gowin/arch.cc
+++ b/gowin/arch.cc
@@ -739,6 +739,15 @@ Arch::Arch(ArchArgs args) : args(args)
     }
     // Dummy for empty decals
     decal_graphics[IdString()];
+
+    std::unordered_set<IdString> bel_types;
+    for(BelId bel : getBels()) {
+        bel_types.insert(getBelType(bel));
+    }
+
+    for(IdString bel_type : bel_types) {
+        cell_types.push_back(bel_type);
+    }
 }
 
 void IdString::initialize_arch(const BaseCtx *ctx)

--- a/gowin/arch.cc
+++ b/gowin/arch.cc
@@ -741,11 +741,11 @@ Arch::Arch(ArchArgs args) : args(args)
     decal_graphics[IdString()];
 
     std::unordered_set<IdString> bel_types;
-    for(BelId bel : getBels()) {
+    for (BelId bel : getBels()) {
         bel_types.insert(getBelType(bel));
     }
 
-    for(IdString bel_type : bel_types) {
+    for (IdString bel_type : bel_types) {
         cell_types.push_back(bel_type);
     }
 }

--- a/gowin/arch.h
+++ b/gowin/arch.h
@@ -430,30 +430,30 @@ struct Arch : BaseCtx
         return cell_types;
     }
 
-    std::vector<PartitionId> getPartitions() const {
+    std::vector<BelBucketId> getBelBuckets() const {
         return cell_types;
     }
 
-    IdString getPartitionName(PartitionId partition) const {
-        return partition;
+    IdString getBelBucketName(BelBucketId bucket) const {
+        return bucket;
     }
 
-    PartitionId getPartitionByName(IdString name) const {
+    BelBucketId getBelBucketByName(IdString name) const {
         return name;
     }
 
-    PartitionId getPartitionForBel(BelId bel) const {
+    BelBucketId getBelBucketForBel(BelId bel) const {
         return getBelType(bel);
     }
 
-    PartitionId getPartitionForCellType(IdString cell_type) const {
+    BelBucketId getBelBucketForCellType(IdString cell_type) const {
         return cell_type;
     }
 
-    std::vector<BelId> getBelsForPartition(PartitionId partition) const {
+    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const {
         std::vector<BelId> bels;
         for(BelId bel : getBels()) {
-            if(getBelType(bel) == partition) {
+            if(getBelType(bel) == bucket) {
                 bels.push_back(bel);
             }
         }

--- a/gowin/arch.h
+++ b/gowin/arch.h
@@ -422,6 +422,9 @@ struct Arch : BaseCtx
     // Get the TimingClockingInfo of a port
     TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const;
 
+    bool isValidBelForCellType(IdString cell_type, BelId bel) const {
+        return cell_type == getBelType(bel);
+    }
     bool isValidBelForCell(CellInfo *cell, BelId bel) const;
     bool isBelLocationValid(BelId bel) const;
 

--- a/gowin/arch.h
+++ b/gowin/arch.h
@@ -422,38 +422,25 @@ struct Arch : BaseCtx
     // Get the TimingClockingInfo of a port
     TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const;
 
-    bool isValidBelForCellType(IdString cell_type, BelId bel) const {
-        return cell_type == getBelType(bel);
-    }
+    bool isValidBelForCellType(IdString cell_type, BelId bel) const { return cell_type == getBelType(bel); }
 
-    const std::vector<IdString> &getCellTypes() const {
-        return cell_types;
-    }
+    const std::vector<IdString> &getCellTypes() const { return cell_types; }
 
-    std::vector<BelBucketId> getBelBuckets() const {
-        return cell_types;
-    }
+    std::vector<BelBucketId> getBelBuckets() const { return cell_types; }
 
-    IdString getBelBucketName(BelBucketId bucket) const {
-        return bucket;
-    }
+    IdString getBelBucketName(BelBucketId bucket) const { return bucket; }
 
-    BelBucketId getBelBucketByName(IdString name) const {
-        return name;
-    }
+    BelBucketId getBelBucketByName(IdString name) const { return name; }
 
-    BelBucketId getBelBucketForBel(BelId bel) const {
-        return getBelType(bel);
-    }
+    BelBucketId getBelBucketForBel(BelId bel) const { return getBelType(bel); }
 
-    BelBucketId getBelBucketForCellType(IdString cell_type) const {
-        return cell_type;
-    }
+    BelBucketId getBelBucketForCellType(IdString cell_type) const { return cell_type; }
 
-    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const {
+    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const
+    {
         std::vector<BelId> bels;
-        for(BelId bel : getBels()) {
-            if(getBelType(bel) == bucket) {
+        for (BelId bel : getBels()) {
+            if (getBelType(bel) == bucket) {
                 bels.push_back(bel);
             }
         }

--- a/gowin/arch.h
+++ b/gowin/arch.h
@@ -425,6 +425,41 @@ struct Arch : BaseCtx
     bool isValidBelForCellType(IdString cell_type, BelId bel) const {
         return cell_type == getBelType(bel);
     }
+
+    const std::vector<IdString> &getCellTypes() const {
+        return cell_types;
+    }
+
+    std::vector<PartitionId> getPartitions() const {
+        return cell_types;
+    }
+
+    IdString getPartitionName(PartitionId partition) const {
+        return partition;
+    }
+
+    PartitionId getPartitionByName(IdString name) const {
+        return name;
+    }
+
+    PartitionId getPartitionForBel(BelId bel) const {
+        return getBelType(bel);
+    }
+
+    PartitionId getPartitionForCellType(IdString cell_type) const {
+        return cell_type;
+    }
+
+    std::vector<BelId> getBelsForPartition(PartitionId partition) const {
+        std::vector<BelId> bels;
+        for(BelId bel : getBels()) {
+            if(getBelType(bel) == partition) {
+                bels.push_back(bel);
+            }
+        }
+        return bels;
+    }
+
     bool isValidBelForCell(CellInfo *cell, BelId bel) const;
     bool isBelLocationValid(BelId bel) const;
 
@@ -437,6 +472,8 @@ struct Arch : BaseCtx
     // Internal usage
     void assignArchInfo();
     bool cellsCompatible(const CellInfo **cells, int count) const;
+
+    std::vector<IdString> cell_types;
 };
 
 NEXTPNR_NAMESPACE_END

--- a/gowin/archdefs.h
+++ b/gowin/archdefs.h
@@ -72,7 +72,7 @@ typedef IdString WireId;
 typedef IdString PipId;
 typedef IdString GroupId;
 typedef IdString DecalId;
-typedef IdString PartitionId;
+typedef IdString BelBucketId;
 
 struct ArchNetInfo
 {

--- a/gowin/archdefs.h
+++ b/gowin/archdefs.h
@@ -72,6 +72,7 @@ typedef IdString WireId;
 typedef IdString PipId;
 typedef IdString GroupId;
 typedef IdString DecalId;
+typedef IdString PartitionId;
 
 struct ArchNetInfo
 {

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -124,9 +124,9 @@ Arch::Arch(ArchArgs args) : args(args)
     for(IdString bel_type : bel_types) {
         cell_types.push_back(bel_type);
 
-        PartitionId partition;
-        partition.name = bel_type;
-        partitions.push_back(partition);
+        BelBucketId bucket;
+        bucket.name = bel_type;
+        buckets.push_back(bucket);
     }
 }
 

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -117,11 +117,11 @@ Arch::Arch(ArchArgs args) : args(args)
     switches_locked.resize(chip_info->num_switches);
 
     std::unordered_set<IdString> bel_types;
-    for(BelId bel : getBels()) {
+    for (BelId bel : getBels()) {
         bel_types.insert(getBelType(bel));
     }
 
-    for(IdString bel_type : bel_types) {
+    for (IdString bel_type : bel_types) {
         cell_types.push_back(bel_type);
 
         BelBucketId bucket;

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -115,6 +115,19 @@ Arch::Arch(ArchArgs args) : args(args)
     wire_to_net.resize(chip_info->wire_data.size());
     pip_to_net.resize(chip_info->pip_data.size());
     switches_locked.resize(chip_info->num_switches);
+
+    std::unordered_set<IdString> bel_types;
+    for(BelId bel : getBels()) {
+        bel_types.insert(getBelType(bel));
+    }
+
+    for(IdString bel_type : bel_types) {
+        cell_types.push_back(bel_type);
+
+        PartitionId partition;
+        partition.name = bel_type;
+        partitions.push_back(partition);
+    }
 }
 
 // -----------------------------------------------------------------------

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -822,44 +822,40 @@ struct Arch : BaseCtx
     // implemented in arch_place.cc)
 
     // Whether this cell type can be placed at this BEL.
-    bool isValidBelForCellType(IdString cell_type, BelId bel) const {
-        return cell_type == getBelType(bel);
-    }
+    bool isValidBelForCellType(IdString cell_type, BelId bel) const { return cell_type == getBelType(bel); }
 
-    const std::vector<IdString> &getCellTypes() const {
-        return cell_types;
-    }
+    const std::vector<IdString> &getCellTypes() const { return cell_types; }
 
-    std::vector<BelBucketId> getBelBuckets() const {
-        return buckets;
-    }
+    std::vector<BelBucketId> getBelBuckets() const { return buckets; }
 
-    IdString getBelBucketName(BelBucketId bucket) const {
-        return bucket.name;
-    }
+    IdString getBelBucketName(BelBucketId bucket) const { return bucket.name; }
 
-    BelBucketId getBelBucketByName(IdString name) const {
+    BelBucketId getBelBucketByName(IdString name) const
+    {
         BelBucketId bucket;
         bucket.name = name;
         return bucket;
     }
 
-    BelBucketId getBelBucketForBel(BelId bel) const {
+    BelBucketId getBelBucketForBel(BelId bel) const
+    {
         BelBucketId bucket;
         bucket.name = getBelType(bel);
         return bucket;
     }
 
-    BelBucketId getBelBucketForCellType(IdString cell_type) const {
+    BelBucketId getBelBucketForCellType(IdString cell_type) const
+    {
         BelBucketId bucket;
         bucket.name = cell_type;
         return bucket;
     }
 
-    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const {
+    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const
+    {
         std::vector<BelId> bels;
-        for(BelId bel : getBels()) {
-            if(getBelType(bel) == bucket.name) {
+        for (BelId bel : getBels()) {
+            if (getBelType(bel) == bucket.name) {
                 bels.push_back(bel);
             }
         }

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -821,6 +821,11 @@ struct Arch : BaseCtx
     // Perform placement validity checks, returning false on failure (all
     // implemented in arch_place.cc)
 
+    // Whether this cell type can be placed at this BEL.
+    bool isValidBelForCellType(IdString cell_type, BelId bel) const {
+        return cell_type == getBelType(bel);
+    }
+
     // Whether or not a given cell can be placed at a given Bel
     // This is not intended for Bel type checks, but finer-grained constraints
     // such as conflicting set/reset signals, etc

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -826,6 +826,46 @@ struct Arch : BaseCtx
         return cell_type == getBelType(bel);
     }
 
+    const std::vector<IdString> &getCellTypes() const {
+        return cell_types;
+    }
+
+    std::vector<PartitionId> getPartitions() const {
+        return partitions;
+    }
+
+    IdString getPartitionName(PartitionId partition) const {
+        return partition.name;
+    }
+
+    PartitionId getPartitionByName(IdString name) const {
+        PartitionId partition;
+        partition.name = name;
+        return partition;
+    }
+
+    PartitionId getPartitionForBel(BelId bel) const {
+        PartitionId partition;
+        partition.name = getBelType(bel);
+        return partition;
+    }
+
+    PartitionId getPartitionForCellType(IdString cell_type) const {
+        PartitionId partition;
+        partition.name = cell_type;
+        return partition;
+    }
+
+    std::vector<BelId> getBelsForPartition(PartitionId partition) const {
+        std::vector<BelId> bels;
+        for(BelId bel : getBels()) {
+            if(getBelType(bel) == partition.name) {
+                bels.push_back(bel);
+            }
+        }
+        return bels;
+    }
+
     // Whether or not a given cell can be placed at a given Bel
     // This is not intended for Bel type checks, but finer-grained constraints
     // such as conflicting set/reset signals, etc
@@ -867,6 +907,9 @@ struct Arch : BaseCtx
     static const std::vector<std::string> availablePlacers;
     static const std::string defaultRouter;
     static const std::vector<std::string> availableRouters;
+
+    std::vector<IdString> cell_types;
+    std::vector<PartitionId> partitions;
 };
 
 void ice40DelayFuzzerMain(Context *ctx);

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -830,36 +830,36 @@ struct Arch : BaseCtx
         return cell_types;
     }
 
-    std::vector<PartitionId> getPartitions() const {
-        return partitions;
+    std::vector<BelBucketId> getBelBuckets() const {
+        return buckets;
     }
 
-    IdString getPartitionName(PartitionId partition) const {
-        return partition.name;
+    IdString getBelBucketName(BelBucketId bucket) const {
+        return bucket.name;
     }
 
-    PartitionId getPartitionByName(IdString name) const {
-        PartitionId partition;
-        partition.name = name;
-        return partition;
+    BelBucketId getBelBucketByName(IdString name) const {
+        BelBucketId bucket;
+        bucket.name = name;
+        return bucket;
     }
 
-    PartitionId getPartitionForBel(BelId bel) const {
-        PartitionId partition;
-        partition.name = getBelType(bel);
-        return partition;
+    BelBucketId getBelBucketForBel(BelId bel) const {
+        BelBucketId bucket;
+        bucket.name = getBelType(bel);
+        return bucket;
     }
 
-    PartitionId getPartitionForCellType(IdString cell_type) const {
-        PartitionId partition;
-        partition.name = cell_type;
-        return partition;
+    BelBucketId getBelBucketForCellType(IdString cell_type) const {
+        BelBucketId bucket;
+        bucket.name = cell_type;
+        return bucket;
     }
 
-    std::vector<BelId> getBelsForPartition(PartitionId partition) const {
+    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const {
         std::vector<BelId> bels;
         for(BelId bel : getBels()) {
-            if(getBelType(bel) == partition.name) {
+            if(getBelType(bel) == bucket.name) {
                 bels.push_back(bel);
             }
         }
@@ -909,7 +909,7 @@ struct Arch : BaseCtx
     static const std::vector<std::string> availableRouters;
 
     std::vector<IdString> cell_types;
-    std::vector<PartitionId> partitions;
+    std::vector<BelBucketId> buckets;
 };
 
 void ice40DelayFuzzerMain(Context *ctx);

--- a/ice40/arch_pybindings.cc
+++ b/ice40/arch_pybindings.cc
@@ -75,6 +75,8 @@ void arch_wrap_python(py::module &m)
     typedef const PipRange UphillPipRange;
     typedef const PipRange DownhillPipRange;
 
+    typedef const std::vector<BelBucketId> & BelBucketRange;
+    typedef const std::vector<BelId> & BelRangeForBelBucket;
 #include "arch_pybindings_shared.h"
 
     WRAP_RANGE(m, Bel, conv_to_str<BelId>);

--- a/ice40/arch_pybindings.cc
+++ b/ice40/arch_pybindings.cc
@@ -75,8 +75,8 @@ void arch_wrap_python(py::module &m)
     typedef const PipRange UphillPipRange;
     typedef const PipRange DownhillPipRange;
 
-    typedef const std::vector<BelBucketId> & BelBucketRange;
-    typedef const std::vector<BelId> & BelRangeForBelBucket;
+    typedef const std::vector<BelBucketId> &BelBucketRange;
+    typedef const std::vector<BelId> &BelRangeForBelBucket;
 #include "arch_pybindings_shared.h"
 
     WRAP_RANGE(m, Bel, conv_to_str<BelId>);
@@ -84,7 +84,6 @@ void arch_wrap_python(py::module &m)
     WRAP_RANGE(m, AllPip, conv_to_str<PipId>);
     WRAP_RANGE(m, Pip, conv_to_str<PipId>);
     WRAP_RANGE(m, BelPin, wrap_context<BelPin>);
-
 
     WRAP_MAP_UPTR(m, CellMap, "IdCellMap");
     WRAP_MAP_UPTR(m, NetMap, "IdNetMap");

--- a/ice40/arch_pybindings.h
+++ b/ice40/arch_pybindings.h
@@ -76,6 +76,18 @@ template <> struct string_converter<PipId>
     }
 };
 
+template <> struct string_converter<BelBucketId>
+{
+    BelBucketId from_str(Context *ctx, std::string name) { return ctx->getBelBucketByName(ctx->id(name)); }
+
+    std::string to_str(Context *ctx, BelBucketId id)
+    {
+        if (id == BelBucketId())
+            throw bad_wrap();
+        return ctx->getBelBucketName(id).str(ctx);
+    }
+};
+
 template <> struct string_converter<BelPin>
 {
     BelPin from_str(Context *ctx, std::string name)

--- a/ice40/archdefs.h
+++ b/ice40/archdefs.h
@@ -170,15 +170,13 @@ struct ArchCellInfo
     };
 };
 
-struct BelBucketId {
+struct BelBucketId
+{
     IdString name;
 
     bool operator==(const BelBucketId &other) const { return (name == other.name); }
     bool operator!=(const BelBucketId &other) const { return (name != other.name); }
-    bool operator<(const BelBucketId &other) const
-    {
-        return name < other.name;
-    }
+    bool operator<(const BelBucketId &other) const { return name < other.name; }
 };
 
 NEXTPNR_NAMESPACE_END

--- a/ice40/archdefs.h
+++ b/ice40/archdefs.h
@@ -170,6 +170,17 @@ struct ArchCellInfo
     };
 };
 
+struct PartitionId {
+    IdString name;
+
+    bool operator==(const PartitionId &other) const { return (name == other.name); }
+    bool operator!=(const PartitionId &other) const { return (name != other.name); }
+    bool operator<(const PartitionId &other) const
+    {
+        return name < other.name;
+    }
+};
+
 NEXTPNR_NAMESPACE_END
 
 namespace std {
@@ -213,4 +224,15 @@ template <> struct hash<NEXTPNR_NAMESPACE_PREFIX DecalId>
         return seed;
     }
 };
+
+template <> struct hash<NEXTPNR_NAMESPACE_PREFIX PartitionId>
+{
+    std::size_t operator()(const NEXTPNR_NAMESPACE_PREFIX PartitionId &partition) const noexcept
+    {
+        std::size_t seed = 0;
+        boost::hash_combine(seed, hash<NEXTPNR_NAMESPACE_PREFIX IdString>()(partition.name));
+        return seed;
+    }
+};
+
 } // namespace std

--- a/ice40/archdefs.h
+++ b/ice40/archdefs.h
@@ -170,12 +170,12 @@ struct ArchCellInfo
     };
 };
 
-struct PartitionId {
+struct BelBucketId {
     IdString name;
 
-    bool operator==(const PartitionId &other) const { return (name == other.name); }
-    bool operator!=(const PartitionId &other) const { return (name != other.name); }
-    bool operator<(const PartitionId &other) const
+    bool operator==(const BelBucketId &other) const { return (name == other.name); }
+    bool operator!=(const BelBucketId &other) const { return (name != other.name); }
+    bool operator<(const BelBucketId &other) const
     {
         return name < other.name;
     }
@@ -225,12 +225,12 @@ template <> struct hash<NEXTPNR_NAMESPACE_PREFIX DecalId>
     }
 };
 
-template <> struct hash<NEXTPNR_NAMESPACE_PREFIX PartitionId>
+template <> struct hash<NEXTPNR_NAMESPACE_PREFIX BelBucketId>
 {
-    std::size_t operator()(const NEXTPNR_NAMESPACE_PREFIX PartitionId &partition) const noexcept
+    std::size_t operator()(const NEXTPNR_NAMESPACE_PREFIX BelBucketId &bucket) const noexcept
     {
         std::size_t seed = 0;
-        boost::hash_combine(seed, hash<NEXTPNR_NAMESPACE_PREFIX IdString>()(partition.name));
+        boost::hash_combine(seed, hash<NEXTPNR_NAMESPACE_PREFIX IdString>()(bucket.name));
         return seed;
     }
 };

--- a/nexus/arch.cc
+++ b/nexus/arch.cc
@@ -171,6 +171,19 @@ Arch::Arch(ArchArgs args) : args(args)
     }
     if (!speed_grade)
         log_error("Unknown speed grade '%s'.\n", speed.c_str());
+
+    std::unordered_set<IdString> bel_types;
+    for(BelId bel : getBels()) {
+        bel_types.insert(getBelType(bel));
+    }
+
+    for(IdString bel_type : bel_types) {
+        cell_types.push_back(bel_type);
+
+        PartitionId partition;
+        partition.name = bel_type;
+        partitions.push_back(partition);
+    }
 }
 
 // -----------------------------------------------------------------------
@@ -635,8 +648,8 @@ bool Arch::place()
         cfg.ioBufTypes.insert(id_SEIO18_CORE);
         cfg.ioBufTypes.insert(id_OSC_CORE);
         cfg.cellGroups.emplace_back();
-        cfg.cellGroups.back().insert(id_OXIDE_COMB);
-        cfg.cellGroups.back().insert(id_OXIDE_FF);
+        cfg.cellGroups.back().insert({id_OXIDE_COMB});
+        cfg.cellGroups.back().insert({id_OXIDE_FF});
 
         cfg.beta = 0.5;
         cfg.criticalityExponent = 7;

--- a/nexus/arch.cc
+++ b/nexus/arch.cc
@@ -173,11 +173,11 @@ Arch::Arch(ArchArgs args) : args(args)
         log_error("Unknown speed grade '%s'.\n", speed.c_str());
 
     std::unordered_set<IdString> bel_types;
-    for(BelId bel : getBels()) {
+    for (BelId bel : getBels()) {
         bel_types.insert(getBelType(bel));
     }
 
-    for(IdString bel_type : bel_types) {
+    for (IdString bel_type : bel_types) {
         cell_types.push_back(bel_type);
 
         BelBucketId bucket;

--- a/nexus/arch.cc
+++ b/nexus/arch.cc
@@ -180,9 +180,9 @@ Arch::Arch(ArchArgs args) : args(args)
     for(IdString bel_type : bel_types) {
         cell_types.push_back(bel_type);
 
-        PartitionId partition;
-        partition.name = bel_type;
-        partitions.push_back(partition);
+        BelBucketId bucket;
+        bucket.name = bel_type;
+        buckets.push_back(bucket);
     }
 }
 

--- a/nexus/arch.h
+++ b/nexus/arch.h
@@ -1336,44 +1336,40 @@ struct Arch : BaseCtx
     // implemented in arch_place.cc)
 
     // Whether this cell type can be placed at this BEL.
-    bool isValidBelForCellType(IdString cell_type, BelId bel) const {
-        return cell_type == getBelType(bel);
-    }
+    bool isValidBelForCellType(IdString cell_type, BelId bel) const { return cell_type == getBelType(bel); }
 
-    const std::vector<IdString> &getCellTypes() const {
-        return cell_types;
-    }
+    const std::vector<IdString> &getCellTypes() const { return cell_types; }
 
-    std::vector<BelBucketId> getBelBuckets() const {
-        return buckets;
-    }
+    std::vector<BelBucketId> getBelBuckets() const { return buckets; }
 
-    IdString getBelBucketName(BelBucketId bucket) const {
-        return bucket.name;
-    }
+    IdString getBelBucketName(BelBucketId bucket) const { return bucket.name; }
 
-    BelBucketId getBelBucketByName(IdString name) const {
+    BelBucketId getBelBucketByName(IdString name) const
+    {
         BelBucketId bucket;
         bucket.name = name;
         return bucket;
     }
 
-    BelBucketId getBelBucketForBel(BelId bel) const {
+    BelBucketId getBelBucketForBel(BelId bel) const
+    {
         BelBucketId bucket;
         bucket.name = getBelType(bel);
         return bucket;
     }
 
-    BelBucketId getBelBucketForCellType(IdString cell_type) const {
+    BelBucketId getBelBucketForCellType(IdString cell_type) const
+    {
         BelBucketId bucket;
         bucket.name = cell_type;
         return bucket;
     }
 
-    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const {
+    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const
+    {
         std::vector<BelId> bels;
-        for(BelId bel : getBels()) {
-            if(getBelType(bel) == bucket.name) {
+        for (BelId bel : getBels()) {
+            if (getBelType(bel) == bucket.name) {
                 bels.push_back(bel);
             }
         }

--- a/nexus/arch.h
+++ b/nexus/arch.h
@@ -1335,6 +1335,11 @@ struct Arch : BaseCtx
     // Perform placement validity checks, returning false on failure (all
     // implemented in arch_place.cc)
 
+    // Whether this cell type can be placed at this BEL.
+    bool isValidBelForCellType(IdString cell_type, BelId bel) const {
+        return cell_type == getBelType(bel);
+    }
+
     // Whether or not a given cell can be placed at a given Bel
     // This is not intended for Bel type checks, but finer-grained constraints
     // such as conflicting set/reset signals, etc

--- a/nexus/arch.h
+++ b/nexus/arch.h
@@ -1344,36 +1344,36 @@ struct Arch : BaseCtx
         return cell_types;
     }
 
-    std::vector<PartitionId> getPartitions() const {
-        return partitions;
+    std::vector<BelBucketId> getBelBuckets() const {
+        return buckets;
     }
 
-    IdString getPartitionName(PartitionId partition) const {
-        return partition.name;
+    IdString getBelBucketName(BelBucketId bucket) const {
+        return bucket.name;
     }
 
-    PartitionId getPartitionByName(IdString name) const {
-        PartitionId partition;
-        partition.name = name;
-        return partition;
+    BelBucketId getBelBucketByName(IdString name) const {
+        BelBucketId bucket;
+        bucket.name = name;
+        return bucket;
     }
 
-    PartitionId getPartitionForBel(BelId bel) const {
-        PartitionId partition;
-        partition.name = getBelType(bel);
-        return partition;
+    BelBucketId getBelBucketForBel(BelId bel) const {
+        BelBucketId bucket;
+        bucket.name = getBelType(bel);
+        return bucket;
     }
 
-    PartitionId getPartitionForCellType(IdString cell_type) const {
-        PartitionId partition;
-        partition.name = cell_type;
-        return partition;
+    BelBucketId getBelBucketForCellType(IdString cell_type) const {
+        BelBucketId bucket;
+        bucket.name = cell_type;
+        return bucket;
     }
 
-    std::vector<BelId> getBelsForPartition(PartitionId partition) const {
+    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const {
         std::vector<BelId> bels;
         for(BelId bel : getBels()) {
-            if(getBelType(bel) == partition.name) {
+            if(getBelType(bel) == bucket.name) {
                 bels.push_back(bel);
             }
         }
@@ -1583,7 +1583,7 @@ struct Arch : BaseCtx
     void write_fasm(std::ostream &out) const;
 
     std::vector<IdString> cell_types;
-    std::vector<PartitionId> partitions;
+    std::vector<BelBucketId> buckets;
 };
 
 NEXTPNR_NAMESPACE_END

--- a/nexus/arch.h
+++ b/nexus/arch.h
@@ -1340,6 +1340,46 @@ struct Arch : BaseCtx
         return cell_type == getBelType(bel);
     }
 
+    const std::vector<IdString> &getCellTypes() const {
+        return cell_types;
+    }
+
+    std::vector<PartitionId> getPartitions() const {
+        return partitions;
+    }
+
+    IdString getPartitionName(PartitionId partition) const {
+        return partition.name;
+    }
+
+    PartitionId getPartitionByName(IdString name) const {
+        PartitionId partition;
+        partition.name = name;
+        return partition;
+    }
+
+    PartitionId getPartitionForBel(BelId bel) const {
+        PartitionId partition;
+        partition.name = getBelType(bel);
+        return partition;
+    }
+
+    PartitionId getPartitionForCellType(IdString cell_type) const {
+        PartitionId partition;
+        partition.name = cell_type;
+        return partition;
+    }
+
+    std::vector<BelId> getBelsForPartition(PartitionId partition) const {
+        std::vector<BelId> bels;
+        for(BelId bel : getBels()) {
+            if(getBelType(bel) == partition.name) {
+                bels.push_back(bel);
+            }
+        }
+        return bels;
+    }
+
     // Whether or not a given cell can be placed at a given Bel
     // This is not intended for Bel type checks, but finer-grained constraints
     // such as conflicting set/reset signals, etc
@@ -1541,6 +1581,9 @@ struct Arch : BaseCtx
 
     // -------------------------------------------------
     void write_fasm(std::ostream &out) const;
+
+    std::vector<IdString> cell_types;
+    std::vector<PartitionId> partitions;
 };
 
 NEXTPNR_NAMESPACE_END

--- a/nexus/arch_pybindings.cc
+++ b/nexus/arch_pybindings.cc
@@ -55,8 +55,8 @@ void arch_wrap_python(py::module &m)
     typedef UpDownhillPipRange DownhillPipRange;
     typedef WireBelPinRange BelPinRange;
 
-    typedef const std::vector<BelBucketId> & BelBucketRange;
-    typedef const std::vector<BelId> & BelRangeForBelBucket;
+    typedef const std::vector<BelBucketId> &BelBucketRange;
+    typedef const std::vector<BelId> &BelRangeForBelBucket;
 
 #include "arch_pybindings_shared.h"
 

--- a/nexus/arch_pybindings.cc
+++ b/nexus/arch_pybindings.cc
@@ -55,6 +55,9 @@ void arch_wrap_python(py::module &m)
     typedef UpDownhillPipRange DownhillPipRange;
     typedef WireBelPinRange BelPinRange;
 
+    typedef const std::vector<BelBucketId> & BelBucketRange;
+    typedef const std::vector<BelId> & BelRangeForBelBucket;
+
 #include "arch_pybindings_shared.h"
 
     WRAP_RANGE(m, Bel, conv_to_str<BelId>);

--- a/nexus/arch_pybindings.h
+++ b/nexus/arch_pybindings.h
@@ -76,6 +76,18 @@ template <> struct string_converter<PipId>
     }
 };
 
+template <> struct string_converter<BelBucketId>
+{
+    BelBucketId from_str(Context *ctx, std::string name) { return ctx->getBelBucketByName(ctx->id(name)); }
+
+    std::string to_str(Context *ctx, BelBucketId id)
+    {
+        if (id == BelBucketId())
+            throw bad_wrap();
+        return ctx->getBelBucketName(id).str(ctx);
+    }
+};
+
 template <> struct string_converter<BelPin>
 {
     BelPin from_str(Context *ctx, std::string name)

--- a/nexus/archdefs.h
+++ b/nexus/archdefs.h
@@ -114,15 +114,13 @@ struct PipId
     }
 };
 
-struct BelBucketId {
+struct BelBucketId
+{
     IdString name;
 
     bool operator==(const BelBucketId &other) const { return (name == other.name); }
     bool operator!=(const BelBucketId &other) const { return (name != other.name); }
-    bool operator<(const BelBucketId &other) const
-    {
-        return name < other.name;
-    }
+    bool operator<(const BelBucketId &other) const { return name < other.name; }
 };
 
 struct GroupId

--- a/nexus/archdefs.h
+++ b/nexus/archdefs.h
@@ -114,12 +114,12 @@ struct PipId
     }
 };
 
-struct PartitionId {
+struct BelBucketId {
     IdString name;
 
-    bool operator==(const PartitionId &other) const { return (name == other.name); }
-    bool operator!=(const PartitionId &other) const { return (name != other.name); }
-    bool operator<(const PartitionId &other) const
+    bool operator==(const BelBucketId &other) const { return (name == other.name); }
+    bool operator!=(const BelBucketId &other) const { return (name != other.name); }
+    bool operator<(const BelBucketId &other) const
     {
         return name < other.name;
     }
@@ -262,12 +262,12 @@ template <> struct hash<NEXTPNR_NAMESPACE_PREFIX DecalId>
     }
 };
 
-template <> struct hash<NEXTPNR_NAMESPACE_PREFIX PartitionId>
+template <> struct hash<NEXTPNR_NAMESPACE_PREFIX BelBucketId>
 {
-    std::size_t operator()(const NEXTPNR_NAMESPACE_PREFIX PartitionId &partition) const noexcept
+    std::size_t operator()(const NEXTPNR_NAMESPACE_PREFIX BelBucketId &bucket) const noexcept
     {
         std::size_t seed = 0;
-        boost::hash_combine(seed, hash<NEXTPNR_NAMESPACE_PREFIX IdString>()(partition.name));
+        boost::hash_combine(seed, hash<NEXTPNR_NAMESPACE_PREFIX IdString>()(bucket.name));
         return seed;
     }
 };

--- a/nexus/archdefs.h
+++ b/nexus/archdefs.h
@@ -114,6 +114,17 @@ struct PipId
     }
 };
 
+struct PartitionId {
+    IdString name;
+
+    bool operator==(const PartitionId &other) const { return (name == other.name); }
+    bool operator!=(const PartitionId &other) const { return (name != other.name); }
+    bool operator<(const PartitionId &other) const
+    {
+        return name < other.name;
+    }
+};
+
 struct GroupId
 {
     enum : int8_t
@@ -250,4 +261,15 @@ template <> struct hash<NEXTPNR_NAMESPACE_PREFIX DecalId>
         return seed;
     }
 };
+
+template <> struct hash<NEXTPNR_NAMESPACE_PREFIX PartitionId>
+{
+    std::size_t operator()(const NEXTPNR_NAMESPACE_PREFIX PartitionId &partition) const noexcept
+    {
+        std::size_t seed = 0;
+        boost::hash_combine(seed, hash<NEXTPNR_NAMESPACE_PREFIX IdString>()(partition.name));
+        return seed;
+    }
+};
+
 } // namespace std


### PR DESCRIPTION
This PR is in service of seperating the requirement that cell type == BEL type.  The concrete example of this is Xilinx fabrics, where there are multiple FF types, multiple LUT types.  To avoid contortions to force incoming cell type to merge with the BEL type, some new arch APIs are being proposed.

The first is the simplest, which is `isValidBelForCellType`.  For arch's where the cell and BEL type are equivalent, this is simply:
```
    bool isValidBelForCellType(IdString cell_type, BelId bel) const {
        return cell_type == getBelType(bel);
    }
```

The other set of APIs is to enable the analytic placer to operate.  The analytic placer wants to partition the design to seperate LUTs, FFs, BRAMs, etc.  This is where the "Partition Methods" come in.  These provide a way for an analytic placer to partition BELs into buckets for AP purposes.