### PR TITLE
Use snake case consistently for non-Arch-API functions

### DIFF
--- a/docs/coding.md
+++ b/docs/coding.md
@@ -28,6 +28,8 @@ Additionally to this; architectures provide functions for checking the availabil
  - Pips that represent LUT permutation are not available when the LUT is in memory mode
  - only a certain total number of pips in a switchbox can be used at once due to power supply limitations
 
+As well as implementing all of the standard [Arch API](archapi.md) functions; arches may include their own helper functions for various purposes. By convention these are in `snake_case`, to distinguish them from the `camelCase` Arch API functions.
+
 ## `IdString`s
 
 To avoid the high cost of using strings as identifiers directly; almost all "string" identifiers in nextpnr (such as cell names and types) use an indexed string pool type named `IdString`. Unlike Yosys, which has a global garbage collected pool, nextpnr has a per-Context pool without any garbage collection.

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -70,9 +70,9 @@ static const ChipInfoPOD *get_chip_info(ArchArgs::ArchArgsTypes chip)
     return ptr->get();
 }
 
-bool Arch::isAvailable(ArchArgs::ArchArgsTypes chip) { return get_chip_info(chip) != nullptr; }
+bool Arch::is_available(ArchArgs::ArchArgsTypes chip) { return get_chip_info(chip) != nullptr; }
 
-std::vector<std::string> Arch::getSupportedPackages(ArchArgs::ArchArgsTypes chip)
+std::vector<std::string> Arch::get_supported_packages(ArchArgs::ArchArgsTypes chip)
 {
     const ChipInfoPOD *chip_info = get_chip_info(chip);
     std::vector<std::string> packages;
@@ -164,7 +164,7 @@ std::string Arch::getChipName() const
     }
 }
 
-std::string Arch::getFullChipName() const
+std::string Arch::get_full_chip_name() const
 {
     std::string name = getChipName();
     name += "-";
@@ -222,7 +222,7 @@ BelId Arch::getBelByName(IdStringList name) const
     loc.x = id_to_x.at(name[0]);
     loc.y = id_to_y.at(name[1]);
     ret.location = loc;
-    const LocationTypePOD *loci = locInfo(ret);
+    const LocationTypePOD *loci = loc_info(ret);
     for (int i = 0; i < int(loci->bel_data.size()); i++) {
         if (std::strcmp(loci->bel_data[i].name.get(), name[2].c_str(this)) == 0) {
             ret.index = i;
@@ -255,7 +255,7 @@ WireId Arch::getBelPinWire(BelId bel, IdString pin) const
 
     NPNR_ASSERT(bel != BelId());
 
-    for (auto &bw : locInfo(bel)->bel_data[bel.index].bel_wires)
+    for (auto &bw : loc_info(bel)->bel_data[bel.index].bel_wires)
         if (bw.port == pin.index) {
             ret.location = bel.location + bw.rel_wire_loc;
             ret.index = bw.wire_index;
@@ -269,7 +269,7 @@ PortType Arch::getBelPinType(BelId bel, IdString pin) const
 {
     NPNR_ASSERT(bel != BelId());
 
-    for (auto &bw : locInfo(bel)->bel_data[bel.index].bel_wires)
+    for (auto &bw : loc_info(bel)->bel_data[bel.index].bel_wires)
         if (bw.port == pin.index)
             return PortType(bw.type);
 
@@ -287,7 +287,7 @@ WireId Arch::getWireByName(IdStringList name) const
     loc.x = id_to_x.at(name[0]);
     loc.y = id_to_y.at(name[1]);
     ret.location = loc;
-    const LocationTypePOD *loci = locInfo(ret);
+    const LocationTypePOD *loci = loc_info(ret);
     for (int i = 0; i < int(loci->wire_data.size()); i++) {
         if (std::strcmp(loci->wire_data[i].name.get(), name[2].c_str(this)) == 0) {
             ret.index = i;
@@ -313,7 +313,7 @@ PipId Arch::getPipByName(IdStringList name) const
     loc.x = id_to_x.at(name[0]);
     loc.y = id_to_y.at(name[1]);
     ret.location = loc;
-    const LocationTypePOD *loci = locInfo(ret);
+    const LocationTypePOD *loci = loc_info(ret);
     for (int i = 0; i < int(loci->pip_data.size()); i++) {
         PipId curr;
         curr.location = loc;
@@ -330,11 +330,11 @@ IdStringList Arch::getPipName(PipId pip) const
     NPNR_ASSERT(pip != PipId());
 
     // TODO: can we improve how pip names are stored/built?
-    auto &pip_data = locInfo(pip)->pip_data[pip.index];
+    auto &pip_data = loc_info(pip)->pip_data[pip.index];
     WireId src = getPipSrcWire(pip), dst = getPipDstWire(pip);
     std::string pip_name = stringf("%d_%d_%s->%d_%d_%s", pip_data.rel_src_loc.x, pip_data.rel_src_loc.y,
-                                   getWireBasename(src).c_str(this), pip_data.rel_dst_loc.x, pip_data.rel_dst_loc.y,
-                                   getWireBasename(dst).c_str(this));
+                                   get_wire_basename(src).c_str(this), pip_data.rel_dst_loc.x, pip_data.rel_dst_loc.y,
+                                   get_wire_basename(dst).c_str(this));
 
     std::array<IdString, 3> ids{x_ids.at(pip.location.x), y_ids.at(pip.location.y), id(pip_name)};
     return IdStringList(ids);
@@ -342,7 +342,7 @@ IdStringList Arch::getPipName(PipId pip) const
 
 // -----------------------------------------------------------------------
 
-BelId Arch::getPackagePinBel(const std::string &pin) const
+BelId Arch::get_package_pin_bel(const std::string &pin) const
 {
     for (auto &ppin : package_info->pin_data) {
         if (ppin.name.get() == pin) {
@@ -355,7 +355,7 @@ BelId Arch::getPackagePinBel(const std::string &pin) const
     return BelId();
 }
 
-std::string Arch::getBelPackagePin(BelId bel) const
+std::string Arch::get_bel_package_pin(BelId bel) const
 {
     for (auto &ppin : package_info->pin_data) {
         if (Location(ppin.abs_loc) == bel.location && ppin.bel_index == bel.index) {
@@ -365,7 +365,7 @@ std::string Arch::getBelPackagePin(BelId bel) const
     return "";
 }
 
-int Arch::getPioBelBank(BelId bel) const
+int Arch::get_pio_bel_bank(BelId bel) const
 {
     for (auto &pio : chip_info->pio_info) {
         if (Location(pio.abs_loc) == bel.location && pio.bel_index == bel.index) {
@@ -375,7 +375,7 @@ int Arch::getPioBelBank(BelId bel) const
     NPNR_ASSERT_FALSE("failed to find PIO");
 }
 
-std::string Arch::getPioFunctionName(BelId bel) const
+std::string Arch::get_pio_function_name(BelId bel) const
 {
     for (auto &pio : chip_info->pio_info) {
         if (Location(pio.abs_loc) == bel.location && pio.bel_index == bel.index) {
@@ -389,7 +389,7 @@ std::string Arch::getPioFunctionName(BelId bel) const
     NPNR_ASSERT_FALSE("failed to find PIO");
 }
 
-BelId Arch::getPioByFunctionName(const std::string &name) const
+BelId Arch::get_pio_by_function_name(const std::string &name) const
 {
     for (auto &pio : chip_info->pio_info) {
         const char *func = pio.function_name.get();
@@ -408,7 +408,7 @@ std::vector<IdString> Arch::getBelPins(BelId bel) const
     std::vector<IdString> ret;
     NPNR_ASSERT(bel != BelId());
 
-    for (auto &bw : locInfo(bel)->bel_data[bel.index].bel_wires) {
+    for (auto &bw : loc_info(bel)->bel_data[bel.index].bel_wires) {
         IdString id;
         id.index = bw.port;
         ret.push_back(id);
@@ -438,7 +438,7 @@ BelId Arch::getBelByLocation(Loc loc) const
 
 delay_t Arch::estimateDelay(WireId src, WireId dst) const
 {
-    int num_uh = locInfo(dst)->wire_data[dst.index].pips_uphill.size();
+    int num_uh = loc_info(dst)->wire_data[dst.index].pips_uphill.size();
     if (num_uh < 6) {
         for (auto uh : getPipsUphill(dst)) {
             if (getPipSrcWire(uh) == src)
@@ -447,7 +447,7 @@ delay_t Arch::estimateDelay(WireId src, WireId dst) const
     }
 
     auto est_location = [&](WireId w) -> std::pair<int, int> {
-        const auto &wire = locInfo(w)->wire_data[w.index];
+        const auto &wire = loc_info(w)->wire_data[w.index];
         if (w == gsrclk_wire) {
             auto phys_wire = getPipSrcWire(*(getPipsUphill(w).begin()));
             return std::make_pair(int(phys_wire.location.x), int(phys_wire.location.y));
@@ -496,7 +496,7 @@ ArcBounds Arch::getRouteBoundingBox(WireId src, WireId dst) const
     };
 
     auto est_location = [&](WireId w) -> std::pair<int, int> {
-        const auto &wire = locInfo(w)->wire_data[w.index];
+        const auto &wire = loc_info(w)->wire_data[w.index];
         if (w == gsrclk_wire) {
             auto phys_wire = getPipSrcWire(*(getPipsUphill(w).begin()));
             return std::make_pair(int(phys_wire.location.x), int(phys_wire.location.y));
@@ -609,7 +609,7 @@ bool Arch::route()
 {
     std::string router = str_or_default(settings, id("router"), defaultRouter);
 
-    setupWireLocations();
+    setup_wire_locations();
     route_ecp5_globals(getCtx());
     assignArchInfo();
     assign_budget(getCtx(), true);
@@ -659,7 +659,7 @@ std::vector<GraphicElement> Arch::getDecalGraphics(DecalId decal) const
         int x = decal.location.x;
         int y = decal.location.y;
         GraphicElement::style_t style = decal.active ? GraphicElement::STYLE_ACTIVE : GraphicElement::STYLE_INACTIVE;
-        GfxTileWireId tilewire = GfxTileWireId(locInfo(wire)->wire_data[wire.index].tile_wire);
+        GfxTileWireId tilewire = GfxTileWireId(loc_info(wire)->wire_data[wire.index].tile_wire);
         gfxTileWire(ret, x, y, chip_info->width, chip_info->height, wire_type, tilewire, style);
     } else if (decal.type == DecalId::TYPE_PIP) {
         PipId pip;
@@ -669,8 +669,8 @@ std::vector<GraphicElement> Arch::getDecalGraphics(DecalId decal) const
         WireId dst_wire = getPipDstWire(pip);
         int x = decal.location.x;
         int y = decal.location.y;
-        GfxTileWireId src_id = GfxTileWireId(locInfo(src_wire)->wire_data[src_wire.index].tile_wire);
-        GfxTileWireId dst_id = GfxTileWireId(locInfo(dst_wire)->wire_data[dst_wire.index].tile_wire);
+        GfxTileWireId src_id = GfxTileWireId(loc_info(src_wire)->wire_data[src_wire.index].tile_wire);
+        GfxTileWireId dst_id = GfxTileWireId(loc_info(dst_wire)->wire_data[dst_wire.index].tile_wire);
         GraphicElement::style_t style = decal.active ? GraphicElement::STYLE_ACTIVE : GraphicElement::STYLE_HIDDEN;
         gfxTilePip(ret, x, y, chip_info->width, chip_info->height, src_wire, getWireType(src_wire), src_id, dst_wire,
                    getWireType(dst_wire), dst_id, style);
@@ -681,7 +681,7 @@ std::vector<GraphicElement> Arch::getDecalGraphics(DecalId decal) const
         auto bel_type = getBelType(bel);
         int x = decal.location.x;
         int y = decal.location.y;
-        int z = locInfo(bel)->bel_data[bel.index].z;
+        int z = loc_info(bel)->bel_data[bel.index].z;
         GraphicElement::style_t style = decal.active ? GraphicElement::STYLE_ACTIVE : GraphicElement::STYLE_INACTIVE;
         gfxTileBel(ret, x, y, z, chip_info->width, chip_info->height, bel_type, style);
     }
@@ -695,7 +695,7 @@ DecalXY Arch::getBelDecal(BelId bel) const
     decalxy.decal.type = DecalId::TYPE_BEL;
     decalxy.decal.location = bel.location;
     decalxy.decal.z = bel.index;
-    decalxy.decal.active = (bel_to_cell.at(getBelFlatIndex(bel)) != nullptr);
+    decalxy.decal.active = (bel_to_cell.at(get_bel_flat_index(bel)) != nullptr);
     return decalxy;
 }
 
@@ -731,7 +731,7 @@ DecalXY Arch::getGroupDecal(GroupId group) const
 
 // -----------------------------------------------------------------------
 
-bool Arch::getDelayFromTimingDatabase(IdString tctype, IdString from, IdString to, DelayInfo &delay) const
+bool Arch::get_delay_from_tmg_db(IdString tctype, IdString from, IdString to, DelayInfo &delay) const
 {
     auto fnd_dk = celldelay_cache.find({tctype, from, to});
     if (fnd_dk != celldelay_cache.end()) {
@@ -755,8 +755,8 @@ bool Arch::getDelayFromTimingDatabase(IdString tctype, IdString from, IdString t
     NPNR_ASSERT_FALSE("failed to find timing cell in db");
 }
 
-void Arch::getSetupHoldFromTimingDatabase(IdString tctype, IdString clock, IdString port, DelayInfo &setup,
-                                          DelayInfo &hold) const
+void Arch::get_setuphold_from_tmg_db(IdString tctype, IdString clock, IdString port, DelayInfo &setup,
+                                     DelayInfo &hold) const
 {
     for (auto &tc : speed_grade->cell_timings) {
         if (tc.cell_type == tctype.index) {
@@ -782,7 +782,7 @@ bool Arch::getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort
         if (fromPort == id_A0 || fromPort == id_B0 || fromPort == id_C0 || fromPort == id_D0 || fromPort == id_A1 ||
             fromPort == id_B1 || fromPort == id_C1 || fromPort == id_D1 || fromPort == id_M0 || fromPort == id_M1 ||
             fromPort == id_FXA || fromPort == id_FXB || fromPort == id_FCI) {
-            return getDelayFromTimingDatabase(has_carry ? id_SCCU2C : id_SLOGICB, fromPort, toPort, delay);
+            return get_delay_from_tmg_db(has_carry ? id_SCCU2C : id_SLOGICB, fromPort, toPort, delay);
         }
 
         if ((fromPort == id_A0 && toPort == id_WADO3) || (fromPort == id_A1 && toPort == id_WDO1) ||
@@ -809,8 +809,7 @@ bool Arch::getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort
         std::string fn = fromPort.str(this), tn = toPort.str(this);
         if (fn.size() > 1 && (fn.front() == 'A' || fn.front() == 'B') && std::isdigit(fn.at(1))) {
             if (tn.size() > 1 && tn.front() == 'P' && std::isdigit(tn.at(1)))
-                return getDelayFromTimingDatabase(cell->multInfo.timing_id, id(std::string("") + fn.front()), id_P,
-                                                  delay);
+                return get_delay_from_tmg_db(cell->multInfo.timing_id, id(std::string("") + fn.front()), id_P, delay);
         }
         return false;
     } else if (cell->type == id_IOLOGIC || cell->type == id_SIOLOGIC) {
@@ -1007,17 +1006,17 @@ TimingClockingInfo Arch::getPortClockingInfo(const CellInfo *cell, IdString port
             port == id_WAD3 || port == id_WRE) {
             info.edge = RISING_EDGE;
             info.clock_port = id_WCK;
-            getSetupHoldFromTimingDatabase(id_SDPRAME, id_WCK, port, info.setup, info.hold);
+            get_setuphold_from_tmg_db(id_SDPRAME, id_WCK, port, info.setup, info.hold);
         } else if (port == id_DI0 || port == id_DI1 || port == id_CE || port == id_LSR || (sd0 == 0 && port == id_M0) ||
                    (sd1 == 0 && port == id_M1)) {
             info.edge = cell->sliceInfo.clkmux == id("INV") ? FALLING_EDGE : RISING_EDGE;
             info.clock_port = id_CLK;
-            getSetupHoldFromTimingDatabase(id_SLOGICB, id_CLK, port, info.setup, info.hold);
+            get_setuphold_from_tmg_db(id_SLOGICB, id_CLK, port, info.setup, info.hold);
 
         } else {
             info.edge = cell->sliceInfo.clkmux == id("INV") ? FALLING_EDGE : RISING_EDGE;
             info.clock_port = id_CLK;
-            bool is_path = getDelayFromTimingDatabase(id_SLOGICB, id_CLK, port, info.clockToQ);
+            bool is_path = get_delay_from_tmg_db(id_SLOGICB, id_CLK, port, info.clockToQ);
             NPNR_ASSERT(is_path);
         }
     } else if (cell->type == id_DP16KD) {
@@ -1052,10 +1051,10 @@ TimingClockingInfo Arch::getPortClockingInfo(const CellInfo *cell, IdString port
                             ? FALLING_EDGE
                             : RISING_EDGE;
         if (cell->ports.at(port).type == PORT_OUT) {
-            bool is_path = getDelayFromTimingDatabase(cell->ramInfo.regmode_timing_id, half_clock, port, info.clockToQ);
+            bool is_path = get_delay_from_tmg_db(cell->ramInfo.regmode_timing_id, half_clock, port, info.clockToQ);
             NPNR_ASSERT(is_path);
         } else {
-            getSetupHoldFromTimingDatabase(cell->ramInfo.regmode_timing_id, half_clock, port, info.setup, info.hold);
+            get_setuphold_from_tmg_db(cell->ramInfo.regmode_timing_id, half_clock, port, info.setup, info.hold);
         }
     } else if (cell->type == id_DCUA) {
         std::string prefix = port.str(this).substr(0, 9);
@@ -1123,16 +1122,16 @@ TimingClockingInfo Arch::getPortClockingInfo(const CellInfo *cell, IdString port
         info.clock_port = clock_id;
         info.edge = RISING_EDGE;
         if (cell->ports.at(port).type == PORT_OUT) {
-            bool is_path = getDelayFromTimingDatabase(cell->multInfo.timing_id, clock_id, port_group, info.clockToQ);
+            bool is_path = get_delay_from_tmg_db(cell->multInfo.timing_id, clock_id, port_group, info.clockToQ);
             NPNR_ASSERT(is_path);
         } else {
-            getSetupHoldFromTimingDatabase(cell->multInfo.timing_id, clock_id, port_group, info.setup, info.hold);
+            get_setuphold_from_tmg_db(cell->multInfo.timing_id, clock_id, port_group, info.setup, info.hold);
         }
     }
     return info;
 }
 
-std::vector<std::pair<std::string, std::string>> Arch::getTilesAtLocation(int row, int col)
+std::vector<std::pair<std::string, std::string>> Arch::get_tiles_at_loc(int row, int col)
 {
     std::vector<std::pair<std::string, std::string>> ret;
     auto &tileloc = chip_info->tile_info[row * chip_info->width + col];
@@ -1142,13 +1141,13 @@ std::vector<std::pair<std::string, std::string>> Arch::getTilesAtLocation(int ro
     return ret;
 }
 
-GlobalInfoPOD Arch::globalInfoAtLoc(Location loc)
+GlobalInfoPOD Arch::global_info_at_loc(Location loc)
 {
     int locidx = loc.y * chip_info->width + loc.x;
     return chip_info->location_glbinfo[locidx];
 }
 
-bool Arch::getPIODQSGroup(BelId pio, bool &dqsright, int &dqsrow)
+bool Arch::get_pio_dqs_group(BelId pio, bool &dqsright, int &dqsrow)
 {
     for (auto &ppio : chip_info->pio_info) {
         if (Location(ppio.abs_loc) == pio.location && ppio.bel_index == pio.index) {
@@ -1165,13 +1164,13 @@ bool Arch::getPIODQSGroup(BelId pio, bool &dqsright, int &dqsrow)
     NPNR_ASSERT_FALSE("failed to find PIO");
 }
 
-BelId Arch::getDQSBUF(bool dqsright, int dqsrow)
+BelId Arch::get_dqsbuf(bool dqsright, int dqsrow)
 {
     BelId bel;
     bel.location.y = dqsrow;
     bel.location.x = (dqsright ? (chip_info->width - 1) : 0);
-    for (int i = 0; i < int(locInfo(bel)->bel_data.size()); i++) {
-        auto &bd = locInfo(bel)->bel_data[i];
+    for (int i = 0; i < int(loc_info(bel)->bel_data.size()); i++) {
+        auto &bd = loc_info(bel)->bel_data[i];
         if (bd.type == id_DQSBUFM.index) {
             bel.index = i;
             return bel;
@@ -1180,9 +1179,9 @@ BelId Arch::getDQSBUF(bool dqsright, int dqsrow)
     NPNR_ASSERT_FALSE("failed to find DQSBUF");
 }
 
-WireId Arch::getBankECLK(int bank, int eclk)
+WireId Arch::get_bank_eclk(int bank, int eclk)
 {
-    return getWireByLocAndBasename(Location(0, 0), "G_BANK" + std::to_string(bank) + "ECLK" + std::to_string(eclk));
+    return get_wire_by_loc_basename(Location(0, 0), "G_BANK" + std::to_string(bank) + "ECLK" + std::to_string(eclk));
 }
 
 #ifdef WITH_HEAP
@@ -1271,7 +1270,7 @@ std::vector<GroupId> Arch::getGroupGroups(GroupId group) const
 std::vector<std::pair<IdString, std::string>> Arch::getWireAttrs(WireId wire) const
 {
     std::vector<std::pair<IdString, std::string>> ret;
-    auto &wi = locInfo(wire)->wire_data[wire.index];
+    auto &wi = loc_info(wire)->wire_data[wire.index];
 
     ret.push_back(std::make_pair(id("TILE_WIRE_ID"), stringf("%d", wi.tile_wire)));
 

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -456,11 +456,11 @@ struct Arch : BaseCtx
     ArchArgs args;
     Arch(ArchArgs args);
 
-    static bool isAvailable(ArchArgs::ArchArgsTypes chip);
-    static std::vector<std::string> getSupportedPackages(ArchArgs::ArchArgsTypes chip);
+    static bool is_available(ArchArgs::ArchArgsTypes chip);
+    static std::vector<std::string> get_supported_packages(ArchArgs::ArchArgsTypes chip);
 
     std::string getChipName() const;
-    std::string getFullChipName() const;
+    std::string get_full_chip_name() const;
 
     IdString archId() const { return id("ecp5"); }
     ArchArgs archArgs() const { return args; }
@@ -480,7 +480,7 @@ struct Arch : BaseCtx
 
     BelId getBelByName(IdStringList name) const;
 
-    template <typename Id> const LocationTypePOD *locInfo(Id &id) const
+    template <typename Id> const LocationTypePOD *loc_info(Id &id) const
     {
         return &(chip_info->locations[chip_info->location_type[id.location.y * chip_info->width + id.location.x]]);
     }
@@ -489,13 +489,13 @@ struct Arch : BaseCtx
     {
         NPNR_ASSERT(bel != BelId());
         std::array<IdString, 3> ids{x_ids.at(bel.location.x), y_ids.at(bel.location.y),
-                                    id(locInfo(bel)->bel_data[bel.index].name.get())};
+                                    id(loc_info(bel)->bel_data[bel.index].name.get())};
         return IdStringList(ids);
     }
 
     uint32_t getBelChecksum(BelId bel) const { return bel.index; }
 
-    int getBelFlatIndex(BelId bel) const
+    int get_bel_flat_index(BelId bel) const
     {
         return (bel.location.y * chip_info->width + bel.location.x) * max_loc_bels + bel.index;
     }
@@ -503,7 +503,7 @@ struct Arch : BaseCtx
     void bindBel(BelId bel, CellInfo *cell, PlaceStrength strength)
     {
         NPNR_ASSERT(bel != BelId());
-        int idx = getBelFlatIndex(bel);
+        int idx = get_bel_flat_index(bel);
         NPNR_ASSERT(bel_to_cell.at(idx) == nullptr);
         bel_to_cell[idx] = cell;
         cell->bel = bel;
@@ -514,7 +514,7 @@ struct Arch : BaseCtx
     void unbindBel(BelId bel)
     {
         NPNR_ASSERT(bel != BelId());
-        int idx = getBelFlatIndex(bel);
+        int idx = get_bel_flat_index(bel);
         NPNR_ASSERT(bel_to_cell.at(idx) != nullptr);
         bel_to_cell[idx]->bel = BelId();
         bel_to_cell[idx]->belStrength = STRENGTH_NONE;
@@ -527,7 +527,7 @@ struct Arch : BaseCtx
         Loc loc;
         loc.x = bel.location.x;
         loc.y = bel.location.y;
-        loc.z = locInfo(bel)->bel_data[bel.index].z;
+        loc.z = loc_info(bel)->bel_data[bel.index].z;
         return loc;
     }
 
@@ -539,19 +539,19 @@ struct Arch : BaseCtx
     bool checkBelAvail(BelId bel) const
     {
         NPNR_ASSERT(bel != BelId());
-        return bel_to_cell[getBelFlatIndex(bel)] == nullptr;
+        return bel_to_cell[get_bel_flat_index(bel)] == nullptr;
     }
 
     CellInfo *getBoundBelCell(BelId bel) const
     {
         NPNR_ASSERT(bel != BelId());
-        return bel_to_cell[getBelFlatIndex(bel)];
+        return bel_to_cell[get_bel_flat_index(bel)];
     }
 
     CellInfo *getConflictingBelCell(BelId bel) const
     {
         NPNR_ASSERT(bel != BelId());
-        return bel_to_cell[getBelFlatIndex(bel)];
+        return bel_to_cell[get_bel_flat_index(bel)];
     }
 
     BelRange getBels() const
@@ -571,7 +571,7 @@ struct Arch : BaseCtx
     {
         NPNR_ASSERT(bel != BelId());
         IdString id;
-        id.index = locInfo(bel)->bel_data[bel.index].type;
+        id.index = loc_info(bel)->bel_data[bel.index].type;
         return id;
     }
 
@@ -587,9 +587,9 @@ struct Arch : BaseCtx
     {
         BelPinRange range;
         NPNR_ASSERT(wire != WireId());
-        range.b.ptr = locInfo(wire)->wire_data[wire.index].bel_pins.begin();
+        range.b.ptr = loc_info(wire)->wire_data[wire.index].bel_pins.begin();
         range.b.wire_loc = wire.location;
-        range.e.ptr = locInfo(wire)->wire_data[wire.index].bel_pins.end();
+        range.e.ptr = loc_info(wire)->wire_data[wire.index].bel_pins.end();
         range.e.wire_loc = wire.location;
         return range;
     }
@@ -604,7 +604,7 @@ struct Arch : BaseCtx
     {
         NPNR_ASSERT(wire != WireId());
         std::array<IdString, 3> ids{x_ids.at(wire.location.x), y_ids.at(wire.location.y),
-                                    id(locInfo(wire)->wire_data[wire.index].name.get())};
+                                    id(loc_info(wire)->wire_data[wire.index].name.get())};
         return IdStringList(ids);
     }
 
@@ -612,7 +612,7 @@ struct Arch : BaseCtx
     {
         NPNR_ASSERT(wire != WireId());
         IdString id;
-        id.index = locInfo(wire)->wire_data[wire.index].type;
+        id.index = loc_info(wire)->wire_data[wire.index].type;
         return id;
     }
 
@@ -697,14 +697,14 @@ struct Arch : BaseCtx
         return range;
     }
 
-    IdString getWireBasename(WireId wire) const { return id(locInfo(wire)->wire_data[wire.index].name.get()); }
+    IdString get_wire_basename(WireId wire) const { return id(loc_info(wire)->wire_data[wire.index].name.get()); }
 
-    WireId getWireByLocAndBasename(Location loc, std::string basename) const
+    WireId get_wire_by_loc_basename(Location loc, std::string basename) const
     {
         WireId wireId;
         wireId.location = loc;
-        for (int i = 0; i < int(locInfo(wireId)->wire_data.size()); i++) {
-            if (locInfo(wireId)->wire_data[i].name.get() == basename) {
+        for (int i = 0; i < int(loc_info(wireId)->wire_data.size()); i++) {
+            if (loc_info(wireId)->wire_data[i].name.get() == basename) {
                 wireId.index = i;
                 return wireId;
             }
@@ -736,8 +736,8 @@ struct Arch : BaseCtx
         wire_fanout[getPipSrcWire(pip)]++;
 
         WireId dst;
-        dst.index = locInfo(pip)->pip_data[pip.index].dst_idx;
-        dst.location = pip.location + locInfo(pip)->pip_data[pip.index].rel_dst_loc;
+        dst.index = loc_info(pip)->pip_data[pip.index].dst_idx;
+        dst.location = pip.location + loc_info(pip)->pip_data[pip.index].rel_dst_loc;
         NPNR_ASSERT(wire_to_net[dst] == nullptr);
         wire_to_net[dst] = net;
         net->wires[dst].pip = pip;
@@ -751,8 +751,8 @@ struct Arch : BaseCtx
         wire_fanout[getPipSrcWire(pip)]--;
 
         WireId dst;
-        dst.index = locInfo(pip)->pip_data[pip.index].dst_idx;
-        dst.location = pip.location + locInfo(pip)->pip_data[pip.index].rel_dst_loc;
+        dst.index = loc_info(pip)->pip_data[pip.index].dst_idx;
+        dst.location = pip.location + loc_info(pip)->pip_data[pip.index].rel_dst_loc;
         NPNR_ASSERT(wire_to_net[dst] != nullptr);
         wire_to_net[dst] = nullptr;
         pip_to_net[pip]->wires.erase(dst);
@@ -803,8 +803,8 @@ struct Arch : BaseCtx
     {
         WireId wire;
         NPNR_ASSERT(pip != PipId());
-        wire.index = locInfo(pip)->pip_data[pip.index].src_idx;
-        wire.location = pip.location + locInfo(pip)->pip_data[pip.index].rel_src_loc;
+        wire.index = loc_info(pip)->pip_data[pip.index].src_idx;
+        wire.location = pip.location + loc_info(pip)->pip_data[pip.index].rel_src_loc;
         return wire;
     }
 
@@ -812,8 +812,8 @@ struct Arch : BaseCtx
     {
         WireId wire;
         NPNR_ASSERT(pip != PipId());
-        wire.index = locInfo(pip)->pip_data[pip.index].dst_idx;
-        wire.location = pip.location + locInfo(pip)->pip_data[pip.index].rel_dst_loc;
+        wire.index = loc_info(pip)->pip_data[pip.index].dst_idx;
+        wire.location = pip.location + loc_info(pip)->pip_data[pip.index].rel_dst_loc;
         return wire;
     }
 
@@ -826,11 +826,11 @@ struct Arch : BaseCtx
         if (fnd_fanout != wire_fanout.end())
             fanout = fnd_fanout->second;
         delay.min_delay =
-                speed_grade->pip_classes[locInfo(pip)->pip_data[pip.index].timing_class].min_base_delay +
-                fanout * speed_grade->pip_classes[locInfo(pip)->pip_data[pip.index].timing_class].min_fanout_adder;
+                speed_grade->pip_classes[loc_info(pip)->pip_data[pip.index].timing_class].min_base_delay +
+                fanout * speed_grade->pip_classes[loc_info(pip)->pip_data[pip.index].timing_class].min_fanout_adder;
         delay.max_delay =
-                speed_grade->pip_classes[locInfo(pip)->pip_data[pip.index].timing_class].max_base_delay +
-                fanout * speed_grade->pip_classes[locInfo(pip)->pip_data[pip.index].timing_class].max_fanout_adder;
+                speed_grade->pip_classes[loc_info(pip)->pip_data[pip.index].timing_class].max_base_delay +
+                fanout * speed_grade->pip_classes[loc_info(pip)->pip_data[pip.index].timing_class].max_fanout_adder;
         return delay;
     }
 
@@ -838,9 +838,9 @@ struct Arch : BaseCtx
     {
         PipRange range;
         NPNR_ASSERT(wire != WireId());
-        range.b.cursor = locInfo(wire)->wire_data[wire.index].pips_downhill.get();
+        range.b.cursor = loc_info(wire)->wire_data[wire.index].pips_downhill.get();
         range.b.wire_loc = wire.location;
-        range.e.cursor = range.b.cursor + locInfo(wire)->wire_data[wire.index].pips_downhill.size();
+        range.e.cursor = range.b.cursor + loc_info(wire)->wire_data[wire.index].pips_downhill.size();
         range.e.wire_loc = wire.location;
         return range;
     }
@@ -849,26 +849,26 @@ struct Arch : BaseCtx
     {
         PipRange range;
         NPNR_ASSERT(wire != WireId());
-        range.b.cursor = locInfo(wire)->wire_data[wire.index].pips_uphill.get();
+        range.b.cursor = loc_info(wire)->wire_data[wire.index].pips_uphill.get();
         range.b.wire_loc = wire.location;
-        range.e.cursor = range.b.cursor + locInfo(wire)->wire_data[wire.index].pips_uphill.size();
+        range.e.cursor = range.b.cursor + loc_info(wire)->wire_data[wire.index].pips_uphill.size();
         range.e.wire_loc = wire.location;
         return range;
     }
 
-    std::string getPipTilename(PipId pip) const
+    std::string get_pip_tilename(PipId pip) const
     {
         auto &tileloc = chip_info->tile_info[pip.location.y * chip_info->width + pip.location.x];
         for (auto &tn : tileloc.tile_names) {
-            if (tn.type_idx == locInfo(pip)->pip_data[pip.index].tile_type)
+            if (tn.type_idx == loc_info(pip)->pip_data[pip.index].tile_type)
                 return tn.name.get();
         }
         NPNR_ASSERT_FALSE("failed to find Pip tile");
     }
 
-    std::string getPipTiletype(PipId pip) const
+    std::string get_pip_tiletype(PipId pip) const
     {
-        return chip_info->tiletype_names[locInfo(pip)->pip_data[pip.index].tile_type].get();
+        return chip_info->tiletype_names[loc_info(pip)->pip_data[pip.index].tile_type].get();
     }
 
     Loc getPipLocation(PipId pip) const
@@ -880,14 +880,14 @@ struct Arch : BaseCtx
         return loc;
     }
 
-    int8_t getPipClass(PipId pip) const { return locInfo(pip)->pip_data[pip.index].pip_type; }
+    int8_t get_pip_class(PipId pip) const { return loc_info(pip)->pip_data[pip.index].pip_type; }
 
-    BelId getPackagePinBel(const std::string &pin) const;
-    std::string getBelPackagePin(BelId bel) const;
-    int getPioBelBank(BelId bel) const;
+    BelId get_package_pin_bel(const std::string &pin) const;
+    std::string get_bel_package_pin(BelId bel) const;
+    int get_pio_bel_bank(BelId bel) const;
     // For getting GCLK, PLL, Vref, etc, pins
-    std::string getPioFunctionName(BelId bel) const;
-    BelId getPioByFunctionName(const std::string &name) const;
+    std::string get_pio_function_name(BelId bel) const;
+    BelId get_pio_by_function_name(const std::string &name) const;
 
     PortType getBelPinType(BelId bel, IdString pin) const;
 
@@ -944,11 +944,11 @@ struct Arch : BaseCtx
     // Get the TimingClockingInfo of a port
     TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const;
     // Return true if a port is a net
-    bool isGlobalNet(const NetInfo *net) const;
+    bool is_global_net(const NetInfo *net) const;
 
-    bool getDelayFromTimingDatabase(IdString tctype, IdString from, IdString to, DelayInfo &delay) const;
-    void getSetupHoldFromTimingDatabase(IdString tctype, IdString clock, IdString port, DelayInfo &setup,
-                                        DelayInfo &hold) const;
+    bool get_delay_from_tmg_db(IdString tctype, IdString from, IdString to, DelayInfo &delay) const;
+    void get_setuphold_from_tmg_db(IdString tctype, IdString clock, IdString port, DelayInfo &setup,
+                                   DelayInfo &hold) const;
 
     // -------------------------------------------------
     // Placement validity checks
@@ -996,14 +996,14 @@ struct Arch : BaseCtx
     bool isBelLocationValid(BelId bel) const;
 
     // Helper function for above
-    bool slicesCompatible(const std::vector<const CellInfo *> &cells) const;
+    bool slices_compatible(const std::vector<const CellInfo *> &cells) const;
 
     void assignArchInfo();
 
     void permute_luts();
 
-    std::vector<std::pair<std::string, std::string>> getTilesAtLocation(int row, int col);
-    std::string getTileByTypeAndLocation(int row, int col, std::string type) const
+    std::vector<std::pair<std::string, std::string>> get_tiles_at_loc(int row, int col);
+    std::string get_tile_by_type_loc(int row, int col, std::string type) const
     {
         auto &tileloc = chip_info->tile_info[row * chip_info->width + col];
         for (auto &tn : tileloc.tile_names) {
@@ -1014,7 +1014,7 @@ struct Arch : BaseCtx
                               type);
     }
 
-    std::string getTileByTypeAndLocation(int row, int col, const std::set<std::string> &type) const
+    std::string get_tile_by_type_loc(int row, int col, const std::set<std::string> &type) const
     {
         auto &tileloc = chip_info->tile_info[row * chip_info->width + col];
         for (auto &tn : tileloc.tile_names) {
@@ -1024,7 +1024,7 @@ struct Arch : BaseCtx
         NPNR_ASSERT_FALSE_STR("no tile at (" + std::to_string(col) + ", " + std::to_string(row) + ") with type in set");
     }
 
-    std::string getTileByType(std::string type) const
+    std::string get_tile_by_type(std::string type) const
     {
         for (int i = 0; i < chip_info->height * chip_info->width; i++) {
             auto &tileloc = chip_info->tile_info[i];
@@ -1035,14 +1035,14 @@ struct Arch : BaseCtx
         NPNR_ASSERT_FALSE_STR("no tile with type " + type);
     }
 
-    GlobalInfoPOD globalInfoAtLoc(Location loc);
+    GlobalInfoPOD global_info_at_loc(Location loc);
 
-    bool getPIODQSGroup(BelId pio, bool &dqsright, int &dqsrow);
-    BelId getDQSBUF(bool dqsright, int dqsrow);
-    WireId getBankECLK(int bank, int eclk);
+    bool get_pio_dqs_group(BelId pio, bool &dqsright, int &dqsrow);
+    BelId get_dqsbuf(bool dqsright, int dqsrow);
+    WireId get_bank_eclk(int bank, int eclk);
 
     // Apply LPF constraints to the context
-    bool applyLPF(std::string filename, std::istream &in);
+    bool apply_lpf(std::string filename, std::istream &in);
 
     IdString id_trellis_slice;
     IdString id_clk, id_lsr;
@@ -1056,7 +1056,7 @@ struct Arch : BaseCtx
     // with different routes to the same physical reset wire causing
     // conflicts and slow routing
     std::unordered_map<WireId, std::pair<int, int>> wire_loc_overrides;
-    void setupWireLocations();
+    void setup_wire_locations();
 
     mutable std::unordered_map<DelayKey, std::pair<bool, DelayInfo>> celldelay_cache;
 

--- a/ecp5/arch_place.cc
+++ b/ecp5/arch_place.cc
@@ -33,7 +33,7 @@ inline NetInfo *port_or_nullptr(const CellInfo *cell, IdString name)
     return found->second.net;
 }
 
-bool Arch::slicesCompatible(const std::vector<const CellInfo *> &cells) const
+bool Arch::slices_compatible(const std::vector<const CellInfo *> &cells) const
 {
     // TODO: allow different LSR/CLK and MUX/SRMODE settings once
     // routing details are worked out
@@ -79,7 +79,7 @@ bool Arch::isBelLocationValid(BelId bel) const
         }
         if (getBoundBelCell(bel) != nullptr && getBoundBelCell(bel)->sliceInfo.has_l6mux && ((bel_loc.z % 2) == 1))
             return false;
-        return slicesCompatible(bel_cells);
+        return slices_compatible(bel_cells);
     } else {
         CellInfo *cell = getBoundBelCell(bel);
         if (cell == nullptr)
@@ -108,7 +108,7 @@ bool Arch::isValidBelForCell(CellInfo *cell, BelId bel) const
         }
 
         bel_cells.push_back(cell);
-        return slicesCompatible(bel_cells);
+        return slices_compatible(bel_cells);
     } else if (cell->type == id_DCUA || cell->type == id_EXTREFB || cell->type == id_PCSCLKDIV) {
         return args.type != ArchArgs::LFE5U_25F && args.type != ArchArgs::LFE5U_45F && args.type != ArchArgs::LFE5U_85F;
     } else {
@@ -196,7 +196,7 @@ void Arch::permute_luts()
     }
 }
 
-void Arch::setupWireLocations()
+void Arch::setup_wire_locations()
 {
     wire_loc_overrides.clear();
     for (auto cell : sorted(cells)) {

--- a/ecp5/bitstream.cc
+++ b/ecp5/bitstream.cc
@@ -49,7 +49,7 @@ void config_empty_lfe5um5g_85f(ChipConfig &cc);
 // Convert an absolute wire name to a relative Trellis one
 static std::string get_trellis_wirename(Context *ctx, Location loc, WireId wire)
 {
-    std::string basename = ctx->locInfo(wire)->wire_data[wire.index].name.get();
+    std::string basename = ctx->loc_info(wire)->wire_data[wire.index].name.get();
     std::string prefix2 = basename.substr(0, 2);
     if (prefix2 == "G_" || prefix2 == "L_" || prefix2 == "R_")
         return basename;
@@ -102,7 +102,7 @@ static void tie_cib_signal(Context *ctx, ChipConfig &cc, WireId wire, bool value
         NPNR_ASSERT(!signals.empty());
         NPNR_ASSERT(signals.size() < 100);
         cibsig = signals.front();
-        basename = ctx->getWireBasename(cibsig).str(ctx);
+        basename = ctx->get_wire_basename(cibsig).str(ctx);
         signals.pop();
         if (std::regex_match(basename, cib_re))
             break;
@@ -118,7 +118,7 @@ static void tie_cib_signal(Context *ctx, ChipConfig &cc, WireId wire, bool value
         out_value = 0;
     }
 
-    for (const auto &tile : ctx->getTilesAtLocation(cibsig.location.y, cibsig.location.x)) {
+    for (const auto &tile : ctx->get_tiles_at_loc(cibsig.location.y, cibsig.location.x)) {
         if (tile.second.substr(0, 3) == "CIB" || tile.second.substr(0, 4) == "VCIB") {
 
             cc.tiles[tile.first].add_enum("CIB." + basename + "MUX", out_value ? "1" : "0");
@@ -181,27 +181,27 @@ static std::string get_pio_tile(Context *ctx, BelId bel)
     static const std::set<std::string> pioa_b = {"PICB0", "EFB0_PICB0", "EFB2_PICB0", "SPICB0"};
     static const std::set<std::string> piob_b = {"PICB1", "EFB1_PICB1", "EFB3_PICB1"};
 
-    std::string pio_name = ctx->locInfo(bel)->bel_data[bel.index].name.get();
+    std::string pio_name = ctx->loc_info(bel)->bel_data[bel.index].name.get();
     if (bel.location.y == 0) {
         if (pio_name == "PIOA") {
-            return ctx->getTileByTypeAndLocation(0, bel.location.x, "PIOT0");
+            return ctx->get_tile_by_type_loc(0, bel.location.x, "PIOT0");
         } else if (pio_name == "PIOB") {
-            return ctx->getTileByTypeAndLocation(0, bel.location.x + 1, "PIOT1");
+            return ctx->get_tile_by_type_loc(0, bel.location.x + 1, "PIOT1");
         } else {
             NPNR_ASSERT_FALSE("bad PIO location");
         }
     } else if (bel.location.y == ctx->chip_info->height - 1) {
         if (pio_name == "PIOA") {
-            return ctx->getTileByTypeAndLocation(bel.location.y, bel.location.x, pioa_b);
+            return ctx->get_tile_by_type_loc(bel.location.y, bel.location.x, pioa_b);
         } else if (pio_name == "PIOB") {
-            return ctx->getTileByTypeAndLocation(bel.location.y, bel.location.x + 1, piob_b);
+            return ctx->get_tile_by_type_loc(bel.location.y, bel.location.x + 1, piob_b);
         } else {
             NPNR_ASSERT_FALSE("bad PIO location");
         }
     } else if (bel.location.x == 0) {
-        return ctx->getTileByTypeAndLocation(bel.location.y + 1, bel.location.x, pioabcd_l);
+        return ctx->get_tile_by_type_loc(bel.location.y + 1, bel.location.x, pioabcd_l);
     } else if (bel.location.x == ctx->chip_info->width - 1) {
-        return ctx->getTileByTypeAndLocation(bel.location.y + 1, bel.location.x, pioabcd_r);
+        return ctx->get_tile_by_type_loc(bel.location.y + 1, bel.location.x, pioabcd_r);
     } else {
         NPNR_ASSERT_FALSE("bad PIO location");
     }
@@ -218,36 +218,36 @@ static std::string get_pic_tile(Context *ctx, BelId bel)
     static const std::set<std::string> pica_b = {"PICB0", "EFB0_PICB0", "EFB2_PICB0", "SPICB0"};
     static const std::set<std::string> picb_b = {"PICB1", "EFB1_PICB1", "EFB3_PICB1"};
 
-    std::string pio_name = ctx->locInfo(bel)->bel_data[bel.index].name.get();
+    std::string pio_name = ctx->loc_info(bel)->bel_data[bel.index].name.get();
     if (bel.location.y == 0) {
         if (pio_name == "PIOA") {
-            return ctx->getTileByTypeAndLocation(1, bel.location.x, "PICT0");
+            return ctx->get_tile_by_type_loc(1, bel.location.x, "PICT0");
         } else if (pio_name == "PIOB") {
-            return ctx->getTileByTypeAndLocation(1, bel.location.x + 1, "PICT1");
+            return ctx->get_tile_by_type_loc(1, bel.location.x + 1, "PICT1");
         } else {
             NPNR_ASSERT_FALSE("bad PIO location");
         }
     } else if (bel.location.y == ctx->chip_info->height - 1) {
         if (pio_name == "PIOA") {
-            return ctx->getTileByTypeAndLocation(bel.location.y, bel.location.x, pica_b);
+            return ctx->get_tile_by_type_loc(bel.location.y, bel.location.x, pica_b);
         } else if (pio_name == "PIOB") {
-            return ctx->getTileByTypeAndLocation(bel.location.y, bel.location.x + 1, picb_b);
+            return ctx->get_tile_by_type_loc(bel.location.y, bel.location.x + 1, picb_b);
         } else {
             NPNR_ASSERT_FALSE("bad PIO location");
         }
     } else if (bel.location.x == 0) {
         if (pio_name == "PIOA" || pio_name == "PIOB") {
-            return ctx->getTileByTypeAndLocation(bel.location.y, bel.location.x, picab_l);
+            return ctx->get_tile_by_type_loc(bel.location.y, bel.location.x, picab_l);
         } else if (pio_name == "PIOC" || pio_name == "PIOD") {
-            return ctx->getTileByTypeAndLocation(bel.location.y + 2, bel.location.x, piccd_l);
+            return ctx->get_tile_by_type_loc(bel.location.y + 2, bel.location.x, piccd_l);
         } else {
             NPNR_ASSERT_FALSE("bad PIO location");
         }
     } else if (bel.location.x == ctx->chip_info->width - 1) {
         if (pio_name == "PIOA" || pio_name == "PIOB") {
-            return ctx->getTileByTypeAndLocation(bel.location.y, bel.location.x, picab_r);
+            return ctx->get_tile_by_type_loc(bel.location.y, bel.location.x, picab_r);
         } else if (pio_name == "PIOC" || pio_name == "PIOD") {
-            return ctx->getTileByTypeAndLocation(bel.location.y + 2, bel.location.x, piccd_r);
+            return ctx->get_tile_by_type_loc(bel.location.y + 2, bel.location.x, piccd_r);
         } else {
             NPNR_ASSERT_FALSE("bad PIO location");
         }
@@ -260,12 +260,12 @@ static std::string get_pic_tile(Context *ctx, BelId bel)
 static std::string get_comp_pio_tile(Context *ctx, BelId bel)
 {
     NPNR_ASSERT(bel.location.y == 0);
-    return ctx->getTileByTypeAndLocation(0, bel.location.x + 1, "PIOT1");
+    return ctx->get_tile_by_type_loc(0, bel.location.x + 1, "PIOT1");
 }
 static std::string get_comp_pic_tile(Context *ctx, BelId bel)
 {
     NPNR_ASSERT(bel.location.y == 0);
-    return ctx->getTileByTypeAndLocation(1, bel.location.x + 1, "PICT1");
+    return ctx->get_tile_by_type_loc(1, bel.location.x + 1, "PICT1");
 }
 
 // Get the list of tiles corresponding to a blockram
@@ -282,23 +282,23 @@ std::vector<std::string> get_bram_tiles(Context *ctx, BelId bel)
 
     switch (loc.z) {
     case 0:
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, ebr0));
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, "MIB_EBR1"));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, ebr0));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, "MIB_EBR1"));
         break;
     case 1:
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "MIB_EBR2"));
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, "MIB_EBR3"));
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 2, "MIB_EBR4"));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "MIB_EBR2"));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, "MIB_EBR3"));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 2, "MIB_EBR4"));
         break;
     case 2:
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "MIB_EBR4"));
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, "MIB_EBR5"));
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 2, "MIB_EBR6"));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "MIB_EBR4"));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, "MIB_EBR5"));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 2, "MIB_EBR6"));
         break;
     case 3:
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "MIB_EBR6"));
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, "MIB_EBR7"));
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 2, ebr8));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "MIB_EBR6"));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, "MIB_EBR7"));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 2, ebr8));
         break;
     default:
         NPNR_ASSERT_FALSE("bad EBR z loc");
@@ -316,52 +316,52 @@ std::vector<std::string> get_dsp_tiles(Context *ctx, BelId bel)
     if (ctx->getBelType(bel) == id_MULT18X18D) {
         switch (loc.z) {
         case 0:
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "MIB_DSP0"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "MIB2_DSP0"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, "MIB_DSP1"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, "MIB2_DSP1"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 2, "MIB_DSP2"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 2, "MIB2_DSP2"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 3, "MIB_DSP3"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 3, "MIB2_DSP3"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 4, "MIB_DSP4"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 4, "MIB2_DSP4"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "MIB_DSP0"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "MIB2_DSP0"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, "MIB_DSP1"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, "MIB2_DSP1"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 2, "MIB_DSP2"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 2, "MIB2_DSP2"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 3, "MIB_DSP3"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 3, "MIB2_DSP3"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 4, "MIB_DSP4"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 4, "MIB2_DSP4"));
             break;
         case 1:
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x - 1, "MIB_DSP0"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x - 1, "MIB2_DSP0"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "MIB_DSP1"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "MIB2_DSP1"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, "MIB_DSP2"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, "MIB2_DSP2"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 2, "MIB_DSP3"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 2, "MIB2_DSP3"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 3, "MIB_DSP4"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 3, "MIB2_DSP4"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x - 1, "MIB_DSP0"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x - 1, "MIB2_DSP0"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "MIB_DSP1"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "MIB2_DSP1"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, "MIB_DSP2"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, "MIB2_DSP2"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 2, "MIB_DSP3"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 2, "MIB2_DSP3"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 3, "MIB_DSP4"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 3, "MIB2_DSP4"));
             break;
         case 4:
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "MIB_DSP4"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "MIB2_DSP4"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, "MIB_DSP5"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, "MIB2_DSP5"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 2, "MIB_DSP6"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 2, "MIB2_DSP6"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 3, "MIB_DSP7"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 3, "MIB2_DSP7"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 4, dsp8));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 4, "MIB2_DSP8"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "MIB_DSP4"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "MIB2_DSP4"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, "MIB_DSP5"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, "MIB2_DSP5"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 2, "MIB_DSP6"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 2, "MIB2_DSP6"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 3, "MIB_DSP7"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 3, "MIB2_DSP7"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 4, dsp8));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 4, "MIB2_DSP8"));
             break;
         case 5:
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x - 1, "MIB_DSP4"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x - 1, "MIB2_DSP4"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "MIB_DSP5"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "MIB2_DSP5"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, "MIB_DSP6"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, "MIB2_DSP6"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 2, "MIB_DSP7"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 2, "MIB2_DSP7"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 3, dsp8));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 3, "MIB2_DSP8"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x - 1, "MIB_DSP4"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x - 1, "MIB2_DSP4"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "MIB_DSP5"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "MIB2_DSP5"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, "MIB_DSP6"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, "MIB2_DSP6"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 2, "MIB_DSP7"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 2, "MIB2_DSP7"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 3, dsp8));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 3, "MIB2_DSP8"));
             break;
         default:
             NPNR_ASSERT_FALSE("bad MULT z loc");
@@ -369,28 +369,28 @@ std::vector<std::string> get_dsp_tiles(Context *ctx, BelId bel)
     } else if (ctx->getBelType(bel) == id_ALU54B) {
         switch (loc.z) {
         case 3:
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x - 3, "MIB_DSP0"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x - 3, "MIB2_DSP0"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x - 2, "MIB_DSP1"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x - 2, "MIB2_DSP1"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x - 1, "MIB_DSP2"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x - 1, "MIB2_DSP2"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "MIB_DSP3"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "MIB2_DSP3"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, "MIB_DSP4"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, "MIB2_DSP4"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x - 3, "MIB_DSP0"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x - 3, "MIB2_DSP0"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x - 2, "MIB_DSP1"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x - 2, "MIB2_DSP1"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x - 1, "MIB_DSP2"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x - 1, "MIB2_DSP2"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "MIB_DSP3"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "MIB2_DSP3"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, "MIB_DSP4"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, "MIB2_DSP4"));
             break;
         case 7:
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x - 3, "MIB_DSP4"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x - 3, "MIB2_DSP4"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x - 2, "MIB_DSP5"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x - 2, "MIB2_DSP5"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x - 1, "MIB_DSP6"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x - 1, "MIB2_DSP6"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "MIB_DSP7"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "MIB2_DSP7"));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, dsp8));
-            tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, "MIB2_DSP8"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x - 3, "MIB_DSP4"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x - 3, "MIB2_DSP4"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x - 2, "MIB_DSP5"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x - 2, "MIB2_DSP5"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x - 1, "MIB_DSP6"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x - 1, "MIB2_DSP6"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "MIB_DSP7"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "MIB2_DSP7"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, dsp8));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, "MIB2_DSP8"));
             break;
         default:
             NPNR_ASSERT_FALSE("bad ALU z loc");
@@ -405,30 +405,30 @@ std::vector<std::string> get_dcu_tiles(Context *ctx, BelId bel)
     std::vector<std::string> tiles;
     Loc loc = ctx->getBelLocation(bel);
     for (int i = 0; i < 9; i++)
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + i, "DCU" + std::to_string(i)));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + i, "DCU" + std::to_string(i)));
     return tiles;
 }
 
 // Get the list of tiles corresponding to a PLL
 std::vector<std::string> get_pll_tiles(Context *ctx, BelId bel)
 {
-    std::string name = ctx->locInfo(bel)->bel_data[bel.index].name.get();
+    std::string name = ctx->loc_info(bel)->bel_data[bel.index].name.get();
     std::vector<std::string> tiles;
     Loc loc = ctx->getBelLocation(bel);
     static const std::set<std::string> pll1_lr = {"PLL1_LR", "BANKREF4"};
 
     if (name == "EHXPLL_UL") {
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x - 1, "PLL0_UL"));
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y + 1, loc.x - 1, "PLL1_UL"));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x - 1, "PLL0_UL"));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y + 1, loc.x - 1, "PLL1_UL"));
     } else if (name == "EHXPLL_LL") {
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y + 1, loc.x, "PLL0_LL"));
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y + 1, loc.x + 1, "BANKREF8"));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y + 1, loc.x, "PLL0_LL"));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y + 1, loc.x + 1, "BANKREF8"));
     } else if (name == "EHXPLL_LR") {
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y + 1, loc.x, "PLL0_LR"));
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y + 1, loc.x - 1, pll1_lr));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y + 1, loc.x, "PLL0_LR"));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y + 1, loc.x - 1, pll1_lr));
     } else if (name == "EHXPLL_UR") {
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, "PLL0_UR"));
-        tiles.push_back(ctx->getTileByTypeAndLocation(loc.y + 1, loc.x + 1, "PLL1_UR"));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, "PLL0_UR"));
+        tiles.push_back(ctx->get_tile_by_type_loc(loc.y + 1, loc.x + 1, "PLL1_UR"));
     } else {
         NPNR_ASSERT_FALSE_STR("bad PLL loc " + name);
     }
@@ -516,7 +516,7 @@ void tieoff_dcu_ports(Context *ctx, ChipConfig &cc, CellInfo *ci)
 
 static void set_pip(Context *ctx, ChipConfig &cc, PipId pip)
 {
-    std::string tile = ctx->getPipTilename(pip);
+    std::string tile = ctx->get_pip_tilename(pip);
     std::string source = get_trellis_wirename(ctx, pip.location, ctx->getPipSrcWire(pip));
     std::string sink = get_trellis_wirename(ctx, pip.location, ctx->getPipDstWire(pip));
     cc.tiles[tile].add_arc(sink, source);
@@ -633,7 +633,7 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
         }
     }
 
-    cc.metadata.push_back("Part: " + ctx->getFullChipName());
+    cc.metadata.push_back("Part: " + ctx->get_full_chip_name());
 
     // Clear out DCU tieoffs in base config if DCU used
     for (auto &cell : ctx->cells) {
@@ -641,7 +641,7 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
         if (ci->type == id_DCUA) {
             Loc loc = ctx->getBelLocation(ci->bel);
             for (int i = 0; i < 12; i++) {
-                auto tiles = ctx->getTilesAtLocation(loc.y - 1, loc.x + i);
+                auto tiles = ctx->get_tiles_at_loc(loc.y - 1, loc.x + i);
                 for (const auto &tile : tiles) {
                     auto cc_tile = cc.tiles.find(tile.first);
                     if (cc_tile != cc.tiles.end()) {
@@ -655,7 +655,7 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
     // Add all set, configurable pips to the config
     for (auto pip : ctx->getPips()) {
         if (ctx->getBoundPipNet(pip) != nullptr) {
-            if (ctx->getPipClass(pip) == 0) { // ignore fixed pips
+            if (ctx->get_pip_class(pip) == 0) { // ignore fixed pips
                 std::string source = get_trellis_wirename(ctx, pip.location, ctx->getPipSrcWire(pip));
                 if (source.find("CLKI_PLL") != std::string::npos) {
                     // Special case - must set pip in all relevant tiles
@@ -676,7 +676,7 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
     for (auto &cell : ctx->cells) {
         CellInfo *ci = cell.second.get();
         if (ci->bel != BelId() && ci->type == ctx->id("TRELLIS_IO")) {
-            int bank = ctx->getPioBelBank(ci->bel);
+            int bank = ctx->get_pio_bel_bank(ci->bel);
             std::string dir = str_or_default(ci->params, ctx->id("DIR"), "INPUT");
             std::string iotype = str_or_default(ci->attrs, ctx->id("IO_TYPE"), "LVCMOS33");
 
@@ -706,7 +706,7 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
     // Set all bankref tiles to appropriate VccIO
     for (int y = 0; y < ctx->getGridDimY(); y++) {
         for (int x = 0; x < ctx->getGridDimX(); x++) {
-            auto tiles = ctx->getTilesAtLocation(y, x);
+            auto tiles = ctx->get_tiles_at_loc(y, x);
             for (auto tile : tiles) {
                 std::string type = tile.second;
                 if (type.find("BANKREF") != std::string::npos) {
@@ -741,18 +741,19 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
     for (auto bv : bankVref) {
         if (!bv.second)
             continue;
-        BelId vrefIO = ctx->getPioByFunctionName(fmt_str("VREF1_" << bv.first));
+        BelId vrefIO = ctx->get_pio_by_function_name(fmt_str("VREF1_" << bv.first));
         if (vrefIO == BelId())
             log_error("unable to find VREF input for bank %d\n", bv.first);
         if (!ctx->checkBelAvail(vrefIO)) {
             CellInfo *bound = ctx->getBoundBelCell(vrefIO);
             if (bound != nullptr)
-                log_error("VREF pin %s of bank %d is occupied by IO '%s'\n", ctx->getBelPackagePin(vrefIO).c_str(),
+                log_error("VREF pin %s of bank %d is occupied by IO '%s'\n", ctx->get_bel_package_pin(vrefIO).c_str(),
                           bv.first, bound->name.c_str(ctx));
             else
-                log_error("VREF pin %s of bank %d is unavailable\n", ctx->getBelPackagePin(vrefIO).c_str(), bv.first);
+                log_error("VREF pin %s of bank %d is unavailable\n", ctx->get_bel_package_pin(vrefIO).c_str(),
+                          bv.first);
         }
-        log_info("Using pin %s as VREF for bank %d\n", ctx->getBelPackagePin(vrefIO).c_str(), bv.first);
+        log_info("Using pin %s as VREF for bank %d\n", ctx->get_bel_package_pin(vrefIO).c_str(), bv.first);
         std::string pio_tile = get_pio_tile(ctx, vrefIO);
 
         std::string iotype;
@@ -774,7 +775,7 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
                       iovoltage_to_str(bankVcc[bv.first]).c_str());
         }
 
-        std::string pio = ctx->locInfo(vrefIO)->bel_data[vrefIO.index].name.get();
+        std::string pio = ctx->loc_info(vrefIO)->bel_data[vrefIO.index].name.get();
         cc.tiles[pio_tile].add_enum(pio + ".BASE_TYPE", "OUTPUT_" + iotype);
         cc.tiles[pio_tile].add_enum(pio + ".PULLMODE", "NONE");
     }
@@ -787,8 +788,8 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
         }
         BelId bel = ci->bel;
         if (ci->type == ctx->id("TRELLIS_SLICE")) {
-            std::string tname = ctx->getTileByTypeAndLocation(bel.location.y, bel.location.x, "PLC2");
-            std::string slice = ctx->locInfo(bel)->bel_data[bel.index].name.get();
+            std::string tname = ctx->get_tile_by_type_loc(bel.location.y, bel.location.x, "PLC2");
+            std::string slice = ctx->loc_info(bel)->bel_data[bel.index].name.get();
             int lut0_init = int_or_default(ci->params, ctx->id("LUT0_INITVAL"));
             int lut1_init = int_or_default(ci->params, ctx->id("LUT1_INITVAL"));
             cc.tiles[tname].add_word(slice + ".K0.INIT", int_to_bitvector(lut0_init, 16));
@@ -811,12 +812,12 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
                 NetInfo *lsrnet = nullptr;
                 if (ci->ports.find(ctx->id("LSR")) != ci->ports.end() && ci->ports.at(ctx->id("LSR")).net != nullptr)
                     lsrnet = ci->ports.at(ctx->id("LSR")).net;
-                if (ctx->getBoundWireNet(ctx->getWireByLocAndBasename(bel.location, "LSR0")) == lsrnet) {
+                if (ctx->getBoundWireNet(ctx->get_wire_by_loc_basename(bel.location, "LSR0")) == lsrnet) {
                     cc.tiles[tname].add_enum("LSR0.SRMODE",
                                              str_or_default(ci->params, ctx->id("SRMODE"), "LSR_OVER_CE"));
                     cc.tiles[tname].add_enum("LSR0.LSRMUX", str_or_default(ci->params, ctx->id("LSRMUX"), "LSR"));
                 }
-                if (ctx->getBoundWireNet(ctx->getWireByLocAndBasename(bel.location, "LSR1")) == lsrnet) {
+                if (ctx->getBoundWireNet(ctx->get_wire_by_loc_basename(bel.location, "LSR1")) == lsrnet) {
                     cc.tiles[tname].add_enum("LSR1.SRMODE",
                                              str_or_default(ci->params, ctx->id("SRMODE"), "LSR_OVER_CE"));
                     cc.tiles[tname].add_enum("LSR1.LSRMUX", str_or_default(ci->params, ctx->id("LSRMUX"), "LSR"));
@@ -825,10 +826,10 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
                 NetInfo *clknet = nullptr;
                 if (ci->ports.find(ctx->id("CLK")) != ci->ports.end() && ci->ports.at(ctx->id("CLK")).net != nullptr)
                     clknet = ci->ports.at(ctx->id("CLK")).net;
-                if (ctx->getBoundWireNet(ctx->getWireByLocAndBasename(bel.location, "CLK0")) == clknet) {
+                if (ctx->getBoundWireNet(ctx->get_wire_by_loc_basename(bel.location, "CLK0")) == clknet) {
                     cc.tiles[tname].add_enum("CLK0.CLKMUX", str_or_default(ci->params, ctx->id("CLKMUX"), "CLK"));
                 }
-                if (ctx->getBoundWireNet(ctx->getWireByLocAndBasename(bel.location, "CLK1")) == clknet) {
+                if (ctx->getBoundWireNet(ctx->get_wire_by_loc_basename(bel.location, "CLK1")) == clknet) {
                     cc.tiles[tname].add_enum("CLK1.CLKMUX", str_or_default(ci->params, ctx->id("CLKMUX"), "CLK"));
                 }
             }
@@ -861,7 +862,7 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
 
             // TODO: CLKMUX
         } else if (ci->type == ctx->id("TRELLIS_IO")) {
-            std::string pio = ctx->locInfo(bel)->bel_data[bel.index].name.get();
+            std::string pio = ctx->loc_info(bel)->bel_data[bel.index].name.get();
             std::string iotype = str_or_default(ci->attrs, ctx->id("IO_TYPE"), "LVCMOS33");
             std::string dir = str_or_default(ci->params, ctx->id("DIR"), "INPUT");
             std::string pio_tile = get_pio_tile(ctx, bel);
@@ -903,12 +904,11 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
                 (ci->ports.find(ctx->id("IOLTO")) == ci->ports.end() ||
                  ci->ports.at(ctx->id("IOLTO")).net == nullptr)) {
                 // Tie tristate low if unconnected for outputs or bidir
-                WireId jpt_wire = ctx->getWireByLocAndBasename(bel.location, fmt_str("JPADDT" << pio.back()));
+                WireId jpt_wire = ctx->get_wire_by_loc_basename(bel.location, fmt_str("JPADDT" << pio.back()));
                 PipId jpt_pip = *ctx->getPipsUphill(jpt_wire).begin();
                 WireId cib_wire = ctx->getPipSrcWire(jpt_pip);
-                std::string cib_tile =
-                        ctx->getTileByTypeAndLocation(cib_wire.location.y, cib_wire.location.x, cib_tiles);
-                std::string cib_wirename = ctx->locInfo(cib_wire)->wire_data[cib_wire.index].name.get();
+                std::string cib_tile = ctx->get_tile_by_type_loc(cib_wire.location.y, cib_wire.location.x, cib_tiles);
+                std::string cib_wirename = ctx->loc_info(cib_wire)->wire_data[cib_wire.index].name.get();
                 cc.tiles[cib_tile].add_enum("CIB." + cib_wirename + "MUX", "0");
             }
             if ((dir == "INPUT" || dir == "BIDIR") && !is_differential(ioType_from_str(iotype)) &&
@@ -993,25 +993,25 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
         } else if (ci->type == ctx->id("DCCA")) {
             const NetInfo *cen = get_net_or_empty(ci, ctx->id("CE"));
             if (cen != nullptr) {
-                std::string belname = ctx->locInfo(bel)->bel_data[bel.index].name.get();
+                std::string belname = ctx->loc_info(bel)->bel_data[bel.index].name.get();
                 Loc loc = ctx->getBelLocation(bel);
                 TileGroup tg;
                 switch (belname[0]) {
                 case 'B':
                     tg.tiles.push_back(
-                            ctx->getTileByTypeAndLocation(loc.y, loc.x, std::set<std::string>{"BMID_0H", "BMID_0V"}));
-                    tg.tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1,
-                                                                     std::set<std::string>{"BMID_2", "BMID_2V"}));
+                            ctx->get_tile_by_type_loc(loc.y, loc.x, std::set<std::string>{"BMID_0H", "BMID_0V"}));
+                    tg.tiles.push_back(
+                            ctx->get_tile_by_type_loc(loc.y, loc.x + 1, std::set<std::string>{"BMID_2", "BMID_2V"}));
                     break;
                 case 'T':
-                    tg.tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "TMID_0"));
-                    tg.tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x + 1, "TMID_1"));
+                    tg.tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "TMID_0"));
+                    tg.tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x + 1, "TMID_1"));
                     break;
                 case 'L':
-                    tg.tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "LMID_0"));
+                    tg.tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "LMID_0"));
                     break;
                 case 'R':
-                    tg.tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, "RMID_0"));
+                    tg.tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, "RMID_0"));
                     break;
                 default:
                     NPNR_ASSERT_FALSE("bad DCC for gating");
@@ -1405,38 +1405,38 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
             cc.tilegroups.push_back(tg);
         } else if (ci->type == id_PCSCLKDIV) {
             Loc loc = ctx->getBelLocation(ci->bel);
-            std::string tname = ctx->getTileByTypeAndLocation(loc.y + 1, loc.x, "BMID_0H");
+            std::string tname = ctx->get_tile_by_type_loc(loc.y + 1, loc.x, "BMID_0H");
             cc.tiles[tname].add_enum("PCSCLKDIV" + std::to_string(loc.z),
                                      str_or_default(ci->params, ctx->id("GSR"), "ENABLED"));
         } else if (ci->type == id_DTR) {
-            cc.tiles[ctx->getTileByType("DTR")].add_enum("DTR.MODE", "DTR");
+            cc.tiles[ctx->get_tile_by_type("DTR")].add_enum("DTR.MODE", "DTR");
         } else if (ci->type == id_OSCG) {
             int div = int_or_default(ci->params, ctx->id("DIV"), 128);
             if (div == 128)
                 div = 127;
-            cc.tiles[ctx->getTileByType("EFB0_PICB0")].add_enum("OSC.DIV", std::to_string(div));
-            cc.tiles[ctx->getTileByType("EFB1_PICB1")].add_enum("OSC.DIV", std::to_string(div));
-            cc.tiles[ctx->getTileByType("EFB1_PICB1")].add_enum("OSC.MODE", "OSCG");
-            cc.tiles[ctx->getTileByType("EFB1_PICB1")].add_enum("CCLK.MODE", "_NONE_");
+            cc.tiles[ctx->get_tile_by_type("EFB0_PICB0")].add_enum("OSC.DIV", std::to_string(div));
+            cc.tiles[ctx->get_tile_by_type("EFB1_PICB1")].add_enum("OSC.DIV", std::to_string(div));
+            cc.tiles[ctx->get_tile_by_type("EFB1_PICB1")].add_enum("OSC.MODE", "OSCG");
+            cc.tiles[ctx->get_tile_by_type("EFB1_PICB1")].add_enum("CCLK.MODE", "_NONE_");
         } else if (ci->type == id_USRMCLK) {
             if (str_or_default(ctx->settings, ctx->id("arch.sysconfig.MASTER_SPI_PORT"), "") == "ENABLE")
                 log_warning("USRMCLK will not function correctly when MASTER_SPI_PORT is set to ENABLE.\n");
-            cc.tiles[ctx->getTileByType("EFB3_PICB1")].add_enum("CCLK.MODE", "USRMCLK");
+            cc.tiles[ctx->get_tile_by_type("EFB3_PICB1")].add_enum("CCLK.MODE", "USRMCLK");
         } else if (ci->type == id_GSR) {
-            cc.tiles[ctx->getTileByType("EFB0_PICB0")].add_enum(
+            cc.tiles[ctx->get_tile_by_type("EFB0_PICB0")].add_enum(
                     "GSR.GSRMODE", str_or_default(ci->params, ctx->id("MODE"), "ACTIVE_LOW"));
-            cc.tiles[ctx->getTileByType("VIQ_BUF")].add_enum("GSR.SYNCMODE",
-                                                             str_or_default(ci->params, ctx->id("SYNCMODE"), "ASYNC"));
+            cc.tiles[ctx->get_tile_by_type("VIQ_BUF")].add_enum(
+                    "GSR.SYNCMODE", str_or_default(ci->params, ctx->id("SYNCMODE"), "ASYNC"));
         } else if (ci->type == id_JTAGG) {
-            cc.tiles[ctx->getTileByType("EFB0_PICB0")].add_enum("JTAG.ER1",
-                                                                str_or_default(ci->params, ctx->id("ER1"), "ENABLED"));
-            cc.tiles[ctx->getTileByType("EFB0_PICB0")].add_enum("JTAG.ER2",
-                                                                str_or_default(ci->params, ctx->id("ER2"), "ENABLED"));
+            cc.tiles[ctx->get_tile_by_type("EFB0_PICB0")].add_enum(
+                    "JTAG.ER1", str_or_default(ci->params, ctx->id("ER1"), "ENABLED"));
+            cc.tiles[ctx->get_tile_by_type("EFB0_PICB0")].add_enum(
+                    "JTAG.ER2", str_or_default(ci->params, ctx->id("ER2"), "ENABLED"));
         } else if (ci->type == id_CLKDIVF) {
             Loc loc = ctx->getBelLocation(ci->bel);
             bool r = loc.x > 5;
             std::string clkdiv = std::string("CLKDIV_") + (r ? "R" : "L") + std::to_string(loc.z);
-            std::string tile = ctx->getTileByType(std::string("ECLK_") + (r ? "R" : "L"));
+            std::string tile = ctx->get_tile_by_type(std::string("ECLK_") + (r ? "R" : "L"));
             cc.tiles[tile].add_enum(clkdiv + ".DIV", str_or_default(ci->params, ctx->id("DIV"), "2.0"));
             cc.tiles[tile].add_enum(clkdiv + ".GSR", str_or_default(ci->params, ctx->id("GSR"), "DISABLED"));
         } else if (ci->type == id_TRELLIS_ECLKBUF) {
@@ -1445,10 +1445,10 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
             bool l = loc.x < 10;
             std::string pic = l ? "PICL" : "PICR";
             TileGroup tg;
-            tg.tiles.push_back(ctx->getTileByTypeAndLocation(loc.y - 2, loc.x, pic + "1_DQS0"));
-            tg.tiles.push_back(ctx->getTileByTypeAndLocation(loc.y - 1, loc.x, pic + "2_DQS1"));
-            tg.tiles.push_back(ctx->getTileByTypeAndLocation(loc.y, loc.x, pic + "0_DQS2"));
-            tg.tiles.push_back(ctx->getTileByTypeAndLocation(loc.y + 1, loc.x, pic + "1_DQS3"));
+            tg.tiles.push_back(ctx->get_tile_by_type_loc(loc.y - 2, loc.x, pic + "1_DQS0"));
+            tg.tiles.push_back(ctx->get_tile_by_type_loc(loc.y - 1, loc.x, pic + "2_DQS1"));
+            tg.tiles.push_back(ctx->get_tile_by_type_loc(loc.y, loc.x, pic + "0_DQS2"));
+            tg.tiles.push_back(ctx->get_tile_by_type_loc(loc.y + 1, loc.x, pic + "1_DQS3"));
             tg.config.add_enum("DQS.MODE", "DQSBUFM");
             tg.config.add_enum("DQS.DQS_LI_DEL_ADJ", str_or_default(ci->params, ctx->id("DQS_LI_DEL_ADJ"), "PLUS"));
             tg.config.add_enum("DQS.DQS_LO_DEL_ADJ", str_or_default(ci->params, ctx->id("DQS_LO_DEL_ADJ"), "PLUS"));
@@ -1473,15 +1473,15 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
         } else if (ci->type == id_ECLKSYNCB) {
             Loc loc = ctx->getBelLocation(ci->bel);
             bool r = loc.x > 5;
-            std::string eclksync = ctx->locInfo(bel)->bel_data[bel.index].name.get();
-            std::string tile = ctx->getTileByType(std::string("ECLK_") + (r ? "R" : "L"));
+            std::string eclksync = ctx->loc_info(bel)->bel_data[bel.index].name.get();
+            std::string tile = ctx->get_tile_by_type(std::string("ECLK_") + (r ? "R" : "L"));
             if (get_net_or_empty(ci, id_STOP) != nullptr)
                 cc.tiles[tile].add_enum(eclksync + ".MODE", "ECLKSYNCB");
         } else if (ci->type == id_ECLKBRIDGECS) {
             Loc loc = ctx->getBelLocation(ci->bel);
             bool r = loc.x > 5;
-            std::string eclkb = ctx->locInfo(bel)->bel_data[bel.index].name.get();
-            std::string tile = ctx->getTileByType(std::string("ECLK_") + (r ? "R" : "L"));
+            std::string eclkb = ctx->loc_info(bel)->bel_data[bel.index].name.get();
+            std::string tile = ctx->get_tile_by_type(std::string("ECLK_") + (r ? "R" : "L"));
             if (get_net_or_empty(ci, id_STOP) != nullptr)
                 cc.tiles[tile].add_enum(eclkb + ".MODE", "ECLKBRIDGECS");
         } else if (ci->type == id_DDRDLL) {
@@ -1492,7 +1492,7 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
                  ctx->args.type == ArchArgs::LFE5UM_25F || ctx->args.type == ArchArgs::LFE5UM5G_25F) &&
                 u)
                 tiletype += "A";
-            std::string tile = ctx->getTileByType(tiletype);
+            std::string tile = ctx->get_tile_by_type(tiletype);
             cc.tiles[tile].add_enum("DDRDLL.MODE", "DDRDLLA");
             cc.tiles[tile].add_enum("DDRDLL.GSR", str_or_default(ci->params, ctx->id("GSR"), "DISABLED"));
             cc.tiles[tile].add_enum("DDRDLL.FORCE_MAX_DELAY",
@@ -1511,15 +1511,15 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
         key = key.substr(prefix.length());
         std::string value = setting.second.as_string();
         if (key == "SLAVE_SPI_PORT" || key == "DONE_EX") {
-            cc.tiles[ctx->getTileByType("EFB0_PICB0")].add_enum("SYSCONFIG." + key, value);
-            cc.tiles[ctx->getTileByType("EFB2_PICB0")].add_enum("SYSCONFIG." + key, value);
+            cc.tiles[ctx->get_tile_by_type("EFB0_PICB0")].add_enum("SYSCONFIG." + key, value);
+            cc.tiles[ctx->get_tile_by_type("EFB2_PICB0")].add_enum("SYSCONFIG." + key, value);
         } else if (key == "SLAVE_PARALLEL_PORT" || key == "BACKGROUND_RECONFIG" || key == "WAKE_UP") {
-            cc.tiles[ctx->getTileByType("EFB0_PICB0")].add_enum("SYSCONFIG." + key, value);
+            cc.tiles[ctx->get_tile_by_type("EFB0_PICB0")].add_enum("SYSCONFIG." + key, value);
         } else if (key == "MASTER_SPI_PORT") {
-            cc.tiles[ctx->getTileByType("EFB1_PICB1")].add_enum("SYSCONFIG." + key, value);
+            cc.tiles[ctx->get_tile_by_type("EFB1_PICB1")].add_enum("SYSCONFIG." + key, value);
         } else if (key == "TRANSFR") {
-            cc.tiles[ctx->getTileByType("EFB0_PICB0")].add_enum("SYSCONFIG." + key, value);
-            cc.tiles[ctx->getTileByType("EFB1_PICB1")].add_enum("SYSCONFIG." + key, value);
+            cc.tiles[ctx->get_tile_by_type("EFB0_PICB0")].add_enum("SYSCONFIG." + key, value);
+            cc.tiles[ctx->get_tile_by_type("EFB1_PICB1")].add_enum("SYSCONFIG." + key, value);
         } else {
             cc.sysconfig[key] = value;
         }

--- a/ecp5/globals.cc
+++ b/ecp5/globals.cc
@@ -115,17 +115,17 @@ class Ecp5GlobalRouter
 
     PipId find_tap_pip(WireId tile_glb)
     {
-        std::string wireName = ctx->getWireBasename(tile_glb).str(ctx);
+        std::string wireName = ctx->get_wire_basename(tile_glb).str(ctx);
         std::string glbName = wireName.substr(2);
-        TapDirection td = ctx->globalInfoAtLoc(tile_glb.location).tap_dir;
+        TapDirection td = ctx->global_info_at_loc(tile_glb.location).tap_dir;
         WireId tap_wire;
         Location tap_loc;
-        tap_loc.x = ctx->globalInfoAtLoc(tile_glb.location).tap_col;
+        tap_loc.x = ctx->global_info_at_loc(tile_glb.location).tap_col;
         tap_loc.y = tile_glb.location.y;
         if (td == TAP_DIR_LEFT) {
-            tap_wire = ctx->getWireByLocAndBasename(tap_loc, "L_" + glbName);
+            tap_wire = ctx->get_wire_by_loc_basename(tap_loc, "L_" + glbName);
         } else {
-            tap_wire = ctx->getWireByLocAndBasename(tap_loc, "R_" + glbName);
+            tap_wire = ctx->get_wire_by_loc_basename(tap_loc, "R_" + glbName);
         }
         NPNR_ASSERT(tap_wire != WireId());
         return *(ctx->getPipsUphill(tap_wire).begin());
@@ -133,11 +133,11 @@ class Ecp5GlobalRouter
 
     PipId find_spine_pip(WireId tap_wire)
     {
-        std::string wireName = ctx->getWireBasename(tap_wire).str(ctx);
+        std::string wireName = ctx->get_wire_basename(tap_wire).str(ctx);
         Location spine_loc;
-        spine_loc.x = ctx->globalInfoAtLoc(tap_wire.location).spine_col;
-        spine_loc.y = ctx->globalInfoAtLoc(tap_wire.location).spine_row;
-        WireId spine_wire = ctx->getWireByLocAndBasename(spine_loc, wireName);
+        spine_loc.x = ctx->global_info_at_loc(tap_wire.location).spine_col;
+        spine_loc.y = ctx->global_info_at_loc(tap_wire.location).spine_row;
+        WireId spine_wire = ctx->get_wire_by_loc_basename(spine_loc, wireName);
         return *(ctx->getPipsUphill(spine_wire).begin());
     }
 
@@ -162,7 +162,7 @@ class Ecp5GlobalRouter
                 break;
             }
 
-            if (ctx->getWireBasename(next) == global_name) {
+            if (ctx->get_wire_basename(next) == global_name) {
                 globalWire = next;
                 break;
             }
@@ -212,7 +212,7 @@ class Ecp5GlobalRouter
 
     bool is_global_io(CellInfo *io, std::string &glb_name)
     {
-        std::string func_name = ctx->getPioFunctionName(io->bel);
+        std::string func_name = ctx->get_pio_function_name(io->bel);
         if (func_name.substr(0, 5) == "PCLKT") {
             func_name.erase(func_name.find('_'), 1);
             glb_name = "G_" + func_name;
@@ -223,8 +223,8 @@ class Ecp5GlobalRouter
 
     WireId get_global_wire(GlobalQuadrant quad, int network)
     {
-        return ctx->getWireByLocAndBasename(Location(0, 0),
-                                            "G_" + get_quad_name(quad) + "PCLK" + std::to_string(network));
+        return ctx->get_wire_by_loc_basename(Location(0, 0),
+                                             "G_" + get_quad_name(quad) + "PCLK" + std::to_string(network));
     }
 
     bool simple_router(NetInfo *net, WireId src, WireId dst, bool allow_fail = false)
@@ -385,7 +385,7 @@ class Ecp5GlobalRouter
         WireId dcc_mux = ctx->getPipSrcWire(*(ctx->getPipsUphill(dcc_i).begin()));
         for (auto pip : ctx->getPipsUphill(dcc_mux)) {
             WireId src = ctx->getPipSrcWire(pip);
-            std::string basename = ctx->nameOf(ctx->getWireBasename(src));
+            std::string basename = ctx->nameOf(ctx->get_wire_basename(src));
             if (basename.find("QPCLKCIB") == std::string::npos)
                 continue;
             candidates.insert(src);
@@ -404,7 +404,7 @@ class Ecp5GlobalRouter
         for (auto bel : ctx->getBels()) {
             if (ctx->getBelType(bel) == id_DCCA && ctx->checkBelAvail(bel)) {
                 if (ctx->isValidBelForCell(dcc, bel)) {
-                    std::string belname = ctx->locInfo(bel)->bel_data[bel.index].name.get();
+                    std::string belname = ctx->loc_info(bel)->bel_data[bel.index].name.get();
                     if (belname.at(0) == 'D' && using_ce)
                         continue; // don't allow DCCs with CE at center
                     ctx->bindBel(bel, dcc, STRENGTH_LOCKED);
@@ -624,7 +624,7 @@ class Ecp5GlobalRouter
                             WireId src = ctx->getPipSrcWire(uh);
                             if (backtrace.count(src))
                                 continue;
-                            IdString basename = ctx->getWireBasename(src);
+                            IdString basename = ctx->get_wire_basename(src);
                             // "ECLKCIB" wires are the junction with general routing
                             if (basename.str(ctx).find("ECLKCIB") != std::string::npos)
                                 continue;

--- a/ecp5/lpf.cc
+++ b/ecp5/lpf.cc
@@ -36,7 +36,7 @@ static const std::unordered_set<std::string> iobuf_keys = {
         "CLAMP",   "OPENDRAIN", "DIFFRESISTOR", "DIFFDRIVE", "HYSTERESIS", "TERMINATION",
 };
 
-bool Arch::applyLPF(std::string filename, std::istream &in)
+bool Arch::apply_lpf(std::string filename, std::istream &in)
 {
     auto isempty = [](const std::string &str) {
         return std::all_of(str.begin(), str.end(), [](char c) { return isblank(c) || c == '\r' || c == '\n'; });

--- a/ecp5/main.cc
+++ b/ecp5/main.cc
@@ -49,25 +49,25 @@ ECP5CommandHandler::ECP5CommandHandler(int argc, char **argv) : CommandHandler(a
 po::options_description ECP5CommandHandler::getArchOptions()
 {
     po::options_description specific("Architecture specific options");
-    if (Arch::isAvailable(ArchArgs::LFE5U_12F))
+    if (Arch::is_available(ArchArgs::LFE5U_12F))
         specific.add_options()("12k", "set device type to LFE5U-12F");
-    if (Arch::isAvailable(ArchArgs::LFE5U_25F))
+    if (Arch::is_available(ArchArgs::LFE5U_25F))
         specific.add_options()("25k", "set device type to LFE5U-25F");
-    if (Arch::isAvailable(ArchArgs::LFE5U_45F))
+    if (Arch::is_available(ArchArgs::LFE5U_45F))
         specific.add_options()("45k", "set device type to LFE5U-45F");
-    if (Arch::isAvailable(ArchArgs::LFE5U_85F))
+    if (Arch::is_available(ArchArgs::LFE5U_85F))
         specific.add_options()("85k", "set device type to LFE5U-85F");
-    if (Arch::isAvailable(ArchArgs::LFE5UM_25F))
+    if (Arch::is_available(ArchArgs::LFE5UM_25F))
         specific.add_options()("um-25k", "set device type to LFE5UM-25F");
-    if (Arch::isAvailable(ArchArgs::LFE5UM_45F))
+    if (Arch::is_available(ArchArgs::LFE5UM_45F))
         specific.add_options()("um-45k", "set device type to LFE5UM-45F");
-    if (Arch::isAvailable(ArchArgs::LFE5UM_85F))
+    if (Arch::is_available(ArchArgs::LFE5UM_85F))
         specific.add_options()("um-85k", "set device type to LFE5UM-85F");
-    if (Arch::isAvailable(ArchArgs::LFE5UM5G_25F))
+    if (Arch::is_available(ArchArgs::LFE5UM5G_25F))
         specific.add_options()("um5g-25k", "set device type to LFE5UM5G-25F");
-    if (Arch::isAvailable(ArchArgs::LFE5UM5G_45F))
+    if (Arch::is_available(ArchArgs::LFE5UM5G_45F))
         specific.add_options()("um5g-45k", "set device type to LFE5UM5G-45F");
-    if (Arch::isAvailable(ArchArgs::LFE5UM5G_85F))
+    if (Arch::is_available(ArchArgs::LFE5UM5G_85F))
         specific.add_options()("um5g-85k", "set device type to LFE5UM5G-85F");
 
     specific.add_options()("package", po::value<std::string>(), "select device package (defaults to CABGA381)");
@@ -266,7 +266,7 @@ void ECP5CommandHandler::customAfterLoad(Context *ctx)
             std::ifstream in(filename);
             if (!in)
                 log_error("failed to open LPF file '%s'\n", filename.c_str());
-            if (!ctx->applyLPF(filename, in))
+            if (!ctx->apply_lpf(filename, in))
                 log_error("failed to parse LPF file '%s'\n", filename.c_str());
         }
 

--- a/ecp5/pack.cc
+++ b/ecp5/pack.cc
@@ -516,7 +516,7 @@ class Ecp5Packer
                     auto loc_attr = trio->attrs.find(ctx->id("LOC"));
                     if (loc_attr != trio->attrs.end()) {
                         std::string pin = loc_attr->second.as_string();
-                        BelId pinBel = ctx->getPackagePinBel(pin);
+                        BelId pinBel = ctx->get_package_pin_bel(pin);
                         if (pinBel == BelId()) {
                             log_error("IO pin '%s' constrained to pin '%s', which does not exist for package '%s'.\n",
                                       trio->name.c_str(ctx), pin.c_str(), ctx->args.package.c_str());
@@ -1815,7 +1815,7 @@ class Ecp5Packer
                 for (auto bel : ctx->getBels()) {
                     if (ctx->getBelType(bel) != id_TRELLIS_ECLKBUF)
                         continue;
-                    if (ctx->getWireBasename(ctx->getBelPinWire(bel, id_ECLKO)) != eclkname)
+                    if (ctx->get_wire_basename(ctx->getBelPinWire(bel, id_ECLKO)) != eclkname)
                         continue;
                     target_bel = bel;
                     break;
@@ -1854,7 +1854,7 @@ class Ecp5Packer
             upstream.pop();
             if (ctx->debug)
                 log_info("    visited %s\n", ctx->nameOfWire(next));
-            IdString basename = ctx->getWireBasename(next);
+            IdString basename = ctx->get_wire_basename(next);
             if (basename == bnke_name || basename == global_name) {
                 break;
             }
@@ -1925,7 +1925,8 @@ class Ecp5Packer
                     log_error("PIO '%s' does not appear to be a DQS site (didn't find a DQSBUFM).\n",
                               ctx->nameOfBel(pio_bel));
                 ci->attrs[ctx->id("BEL")] = ctx->getBelName(dqsbuf).str(ctx);
-                bool got_dqsg = ctx->getPIODQSGroup(pio_bel, dqsbuf_dqsg[ci->name].first, dqsbuf_dqsg[ci->name].second);
+                bool got_dqsg =
+                        ctx->get_pio_dqs_group(pio_bel, dqsbuf_dqsg[ci->name].first, dqsbuf_dqsg[ci->name].second);
                 NPNR_ASSERT(got_dqsg);
                 log_info("Constrained DQSBUFM '%s' to %cDQS%d\n", ci->name.c_str(ctx),
                          dqsbuf_dqsg[ci->name].first ? 'R' : 'L', dqsbuf_dqsg[ci->name].second);
@@ -2118,7 +2119,7 @@ class Ecp5Packer
             } else {
                 bool dqsr;
                 int dqsgroup;
-                bool has_dqs = ctx->getPIODQSGroup(get_pio_bel(pio, prim), dqsr, dqsgroup);
+                bool has_dqs = ctx->get_pio_dqs_group(get_pio_bel(pio, prim), dqsr, dqsgroup);
                 if (!has_dqs)
                     log_error("Primitive '%s' cannot be connected to top level port '%s' as the associated pin is not "
                               "in any DQS group",
@@ -2645,7 +2646,7 @@ class Ecp5Packer
                     pioLoc.z -= 4;
                 BelId pioBel = ctx->getBelByLocation(pioLoc);
                 NPNR_ASSERT(pioBel != BelId());
-                int bank = ctx->getPioBelBank(pioBel);
+                int bank = ctx->get_pio_bel_bank(pioBel);
                 make_eclk(ci->ports.at(id_ECLK), ci, bel, bank);
             }
         }

--- a/gui/ecp5/mainwindow.cc
+++ b/gui/ecp5/mainwindow.cc
@@ -79,23 +79,23 @@ void MainWindow::createMenu()
 void MainWindow::new_proj()
 {
     QMap<QString, int> arch;
-    if (Arch::isAvailable(ArchArgs::LFE5U_25F))
+    if (Arch::is_available(ArchArgs::LFE5U_25F))
         arch.insert("Lattice ECP5 LFE5U-25F", ArchArgs::LFE5U_25F);
-    if (Arch::isAvailable(ArchArgs::LFE5U_45F))
+    if (Arch::is_available(ArchArgs::LFE5U_45F))
         arch.insert("Lattice ECP5 LFE5U-45F", ArchArgs::LFE5U_45F);
-    if (Arch::isAvailable(ArchArgs::LFE5U_85F))
+    if (Arch::is_available(ArchArgs::LFE5U_85F))
         arch.insert("Lattice ECP5 LFE5U-85F", ArchArgs::LFE5U_85F);
-    if (Arch::isAvailable(ArchArgs::LFE5UM_25F))
+    if (Arch::is_available(ArchArgs::LFE5UM_25F))
         arch.insert("Lattice ECP5 LFE5UM-25F", ArchArgs::LFE5UM_25F);
-    if (Arch::isAvailable(ArchArgs::LFE5UM_45F))
+    if (Arch::is_available(ArchArgs::LFE5UM_45F))
         arch.insert("Lattice ECP5 LFE5UM-45F", ArchArgs::LFE5UM_45F);
-    if (Arch::isAvailable(ArchArgs::LFE5UM_85F))
+    if (Arch::is_available(ArchArgs::LFE5UM_85F))
         arch.insert("Lattice ECP5 LFE5UM-85F", ArchArgs::LFE5UM_85F);
-    if (Arch::isAvailable(ArchArgs::LFE5UM5G_25F))
+    if (Arch::is_available(ArchArgs::LFE5UM5G_25F))
         arch.insert("Lattice ECP5 LFE5UM5G-25F", ArchArgs::LFE5UM5G_25F);
-    if (Arch::isAvailable(ArchArgs::LFE5UM5G_45F))
+    if (Arch::is_available(ArchArgs::LFE5UM5G_45F))
         arch.insert("Lattice ECP5 LFE5UM5G-45F", ArchArgs::LFE5UM5G_45F);
-    if (Arch::isAvailable(ArchArgs::LFE5UM5G_85F))
+    if (Arch::is_available(ArchArgs::LFE5UM5G_85F))
         arch.insert("Lattice ECP5 LFE5UM5G-85F", ArchArgs::LFE5UM5G_85F);
 
     bool ok;
@@ -105,7 +105,7 @@ void MainWindow::new_proj()
         chipArgs.type = (ArchArgs::ArchArgsTypes)arch.value(item);
 
         QStringList packages;
-        for (auto package : Arch::getSupportedPackages(chipArgs.type))
+        for (auto package : Arch::get_supported_packages(chipArgs.type))
             packages.append(QLatin1String(package.data(), package.size()));
         QString package = QInputDialog::getItem(this, "Select package", "Package:", packages, 0, false, &ok);
 
@@ -127,7 +127,7 @@ void MainWindow::open_lpf()
     QString fileName = QFileDialog::getOpenFileName(this, QString("Open LPF"), QString(), QString("*.lpf"));
     if (!fileName.isEmpty()) {
         std::ifstream in(fileName.toStdString());
-        if (ctx->applyLPF(fileName.toStdString(), in)) {
+        if (ctx->apply_lpf(fileName.toStdString(), in)) {
             log("Loading LPF successful.\n");
             actionPack->setEnabled(true);
             actionLoadLPF->setEnabled(false);

--- a/gui/ice40/mainwindow.cc
+++ b/gui/ice40/mainwindow.cc
@@ -77,29 +77,29 @@ void MainWindow::createMenu()
 void MainWindow::new_proj()
 {
     QMap<QString, int> arch;
-    if (Arch::isAvailable(ArchArgs::LP384))
+    if (Arch::is_available(ArchArgs::LP384))
         arch.insert("Lattice iCE40LP384", ArchArgs::LP384);
-    if (Arch::isAvailable(ArchArgs::LP1K))
+    if (Arch::is_available(ArchArgs::LP1K))
         arch.insert("Lattice iCE40LP1K", ArchArgs::LP1K);
-    if (Arch::isAvailable(ArchArgs::HX1K))
+    if (Arch::is_available(ArchArgs::HX1K))
         arch.insert("Lattice iCE40HX1K", ArchArgs::HX1K);
-    if (Arch::isAvailable(ArchArgs::U1K))
+    if (Arch::is_available(ArchArgs::U1K))
         arch.insert("Lattice iCE5LP1K", ArchArgs::U1K);
-    if (Arch::isAvailable(ArchArgs::U2K))
+    if (Arch::is_available(ArchArgs::U2K))
         arch.insert("Lattice iCE5LP2K", ArchArgs::U2K);
-    if (Arch::isAvailable(ArchArgs::U4K))
+    if (Arch::is_available(ArchArgs::U4K))
         arch.insert("Lattice iCE5LP4K", ArchArgs::U4K);
-    if (Arch::isAvailable(ArchArgs::UP3K))
+    if (Arch::is_available(ArchArgs::UP3K))
         arch.insert("Lattice iCE40UP3K", ArchArgs::UP3K);
-    if (Arch::isAvailable(ArchArgs::UP5K))
+    if (Arch::is_available(ArchArgs::UP5K))
         arch.insert("Lattice iCE40UP5K", ArchArgs::UP5K);
-    if (Arch::isAvailable(ArchArgs::LP4K))
+    if (Arch::is_available(ArchArgs::LP4K))
         arch.insert("Lattice iCE40LP4K", ArchArgs::LP4K);
-    if (Arch::isAvailable(ArchArgs::LP8K))
+    if (Arch::is_available(ArchArgs::LP8K))
         arch.insert("Lattice iCE40LP8K", ArchArgs::LP8K);
-    if (Arch::isAvailable(ArchArgs::HX4K))
+    if (Arch::is_available(ArchArgs::HX4K))
         arch.insert("Lattice iCE40HX4K", ArchArgs::HX4K);
-    if (Arch::isAvailable(ArchArgs::HX8K))
+    if (Arch::is_available(ArchArgs::HX8K))
         arch.insert("Lattice iCE40HX8K", ArchArgs::HX8K);
 
     bool ok;
@@ -109,7 +109,7 @@ void MainWindow::new_proj()
         chipArgs.type = (ArchArgs::ArchArgsTypes)arch.value(item);
 
         QStringList packages;
-        for (auto package : Arch::getSupportedPackages(chipArgs.type))
+        for (auto package : Arch::get_supported_packages(chipArgs.type))
             packages.append(QLatin1String(package.data(), package.size()));
         QString package = QInputDialog::getItem(this, "Select package", "Package:", packages, 0, false, &ok);
 

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -67,9 +67,9 @@ static const ChipInfoPOD *get_chip_info(ArchArgs::ArchArgsTypes chip)
     return ptr->get();
 }
 
-bool Arch::isAvailable(ArchArgs::ArchArgsTypes chip) { return get_chip_info(chip) != nullptr; }
+bool Arch::is_available(ArchArgs::ArchArgsTypes chip) { return get_chip_info(chip) != nullptr; }
 
-std::vector<std::string> Arch::getSupportedPackages(ArchArgs::ArchArgsTypes chip)
+std::vector<std::string> Arch::get_supported_packages(ArchArgs::ArchArgsTypes chip)
 {
     const ChipInfoPOD *chip_info = get_chip_info(chip);
     std::vector<std::string> packages;
@@ -350,7 +350,7 @@ std::vector<IdString> Arch::getBelPins(BelId bel) const
     return ret;
 }
 
-bool Arch::isBelLocked(BelId bel) const
+bool Arch::is_bel_locked(BelId bel) const
 {
     const BelConfigPOD *bel_config = nullptr;
     for (auto &bel_cfg : chip_info->bel_config) {
@@ -493,7 +493,7 @@ std::vector<std::pair<IdString, std::string>> Arch::getPipAttrs(PipId pip) const
 
 // -----------------------------------------------------------------------
 
-BelId Arch::getPackagePinBel(const std::string &pin) const
+BelId Arch::get_package_pin_bel(const std::string &pin) const
 {
     for (auto &ppin : package_info->pins) {
         if (ppin.name.get() == pin) {
@@ -505,7 +505,7 @@ BelId Arch::getPackagePinBel(const std::string &pin) const
     return BelId();
 }
 
-std::string Arch::getBelPackagePin(BelId bel) const
+std::string Arch::get_bel_package_pin(BelId bel) const
 {
     for (auto &ppin : package_info->pins) {
         if (ppin.bel_index == bel.index) {
@@ -939,10 +939,10 @@ bool Arch::getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort
     } else if (cell->type == id_ICESTORM_RAM || cell->type == id_ICESTORM_SPRAM) {
         return false;
     }
-    return getCellDelayInternal(cell, fromPort, toPort, delay);
+    return get_cell_delay_internal(cell, fromPort, toPort, delay);
 }
 
-bool Arch::getCellDelayInternal(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const
+bool Arch::get_cell_delay_internal(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const
 {
     for (auto &tc : chip_info->cell_timing) {
         if (tc.type == cell->type.index) {
@@ -1094,12 +1094,12 @@ TimingClockingInfo Arch::getPortClockingInfo(const CellInfo *cell, IdString port
         info.clock_port = id_CLK;
         info.edge = cell->lcInfo.negClk ? FALLING_EDGE : RISING_EDGE;
         if (port == id_O) {
-            bool has_clktoq = getCellDelayInternal(cell, id_CLK, id_O, info.clockToQ);
+            bool has_clktoq = get_cell_delay_internal(cell, id_CLK, id_O, info.clockToQ);
             NPNR_ASSERT(has_clktoq);
         } else {
             if (port == id_I0 || port == id_I1 || port == id_I2 || port == id_I3) {
                 DelayInfo dlut;
-                bool has_ld = getCellDelayInternal(cell, port, id_O, dlut);
+                bool has_ld = get_cell_delay_internal(cell, port, id_O, dlut);
                 NPNR_ASSERT(has_ld);
                 if (args.type == ArchArgs::LP1K || args.type == ArchArgs::LP4K || args.type == ArchArgs::LP8K ||
                     args.type == ArchArgs::LP384) {
@@ -1124,7 +1124,7 @@ TimingClockingInfo Arch::getPortClockingInfo(const CellInfo *cell, IdString port
             info.edge = bool_or_default(cell->params, id("NEG_CLK_W")) ? FALLING_EDGE : RISING_EDGE;
         }
         if (cell->ports.at(port).type == PORT_OUT) {
-            bool has_clktoq = getCellDelayInternal(cell, info.clock_port, port, info.clockToQ);
+            bool has_clktoq = get_cell_delay_internal(cell, info.clock_port, port, info.clockToQ);
             NPNR_ASSERT(has_clktoq);
         } else {
             info.setup.delay = 100;
@@ -1170,7 +1170,7 @@ TimingClockingInfo Arch::getPortClockingInfo(const CellInfo *cell, IdString port
         info.clock_port = cell->type == id_ICESTORM_SPRAM ? id_CLOCK : id_CLK;
         info.edge = RISING_EDGE;
         if (cell->ports.at(port).type == PORT_OUT) {
-            bool has_clktoq = getCellDelayInternal(cell, info.clock_port, port, info.clockToQ);
+            bool has_clktoq = get_cell_delay_internal(cell, info.clock_port, port, info.clockToQ);
             if (!has_clktoq)
                 info.clockToQ.delay = 100;
         } else {
@@ -1194,7 +1194,7 @@ TimingClockingInfo Arch::getPortClockingInfo(const CellInfo *cell, IdString port
     return info;
 }
 
-bool Arch::isGlobalNet(const NetInfo *net) const
+bool Arch::is_global_net(const NetInfo *net) const
 {
     if (net == nullptr)
         return false;
@@ -1206,7 +1206,7 @@ void Arch::assignArchInfo()
 {
     for (auto &net : getCtx()->nets) {
         NetInfo *ni = net.second.get();
-        if (isGlobalNet(ni))
+        if (is_global_net(ni))
             ni->is_global = true;
         ni->is_enable = false;
         ni->is_reset = false;

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -399,8 +399,8 @@ struct Arch : BaseCtx
     ArchArgs args;
     Arch(ArchArgs args);
 
-    static bool isAvailable(ArchArgs::ArchArgsTypes chip);
-    static std::vector<std::string> getSupportedPackages(ArchArgs::ArchArgsTypes chip);
+    static bool is_available(ArchArgs::ArchArgsTypes chip);
+    static std::vector<std::string> get_supported_packages(ArchArgs::ArchArgsTypes chip);
 
     std::string getChipName() const;
 
@@ -506,7 +506,7 @@ struct Arch : BaseCtx
     PortType getBelPinType(BelId bel, IdString pin) const;
     std::vector<IdString> getBelPins(BelId bel) const;
 
-    bool isBelLocked(BelId bel) const;
+    bool is_bel_locked(BelId bel) const;
 
     // -------------------------------------------------
 
@@ -767,8 +767,8 @@ struct Arch : BaseCtx
         return range;
     }
 
-    BelId getPackagePinBel(const std::string &pin) const;
-    std::string getBelPackagePin(BelId bel) const;
+    BelId get_package_pin_bel(const std::string &pin) const;
+    std::string get_bel_package_pin(BelId bel) const;
 
     // -------------------------------------------------
 
@@ -818,15 +818,15 @@ struct Arch : BaseCtx
     // Get the delay through a cell from one port to another, returning false
     // if no path exists. This only considers combinational delays, as required by the Arch API
     bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const;
-    // getCellDelayInternal is similar to the above, but without false path checks and including clock to out delays
+    // get_cell_delay_internal is similar to the above, but without false path checks and including clock to out delays
     // for internal arch use only
-    bool getCellDelayInternal(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const;
+    bool get_cell_delay_internal(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const;
     // Get the port class, also setting clockInfoCount to the number of TimingClockingInfos associated with a port
     TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const;
     // Get the TimingClockingInfo of a port
     TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const;
     // Return true if a port is a net
-    bool isGlobalNet(const NetInfo *net) const;
+    bool is_global_net(const NetInfo *net) const;
 
     // -------------------------------------------------
 
@@ -883,7 +883,7 @@ struct Arch : BaseCtx
     bool isBelLocationValid(BelId bel) const;
 
     // Helper function for above
-    bool logicCellsCompatible(const CellInfo **it, const size_t size) const;
+    bool logic_cells_compatible(const CellInfo **it, const size_t size) const;
 
     // -------------------------------------------------
     // Assign architecture-specific arguments to nets and cells, which must be
@@ -893,7 +893,7 @@ struct Arch : BaseCtx
     void assignCellInfo(CellInfo *cell);
 
     // -------------------------------------------------
-    BelPin getIOBSharingPLLPin(BelId pll, IdString pll_pin) const
+    BelPin get_iob_sharing_pll_pin(BelId pll, IdString pll_pin) const
     {
         auto wire = getBelPinWire(pll, pll_pin);
         for (auto src_bel : getWireBelPins(wire)) {
@@ -904,7 +904,7 @@ struct Arch : BaseCtx
         NPNR_ASSERT_FALSE("Expected PLL pin to share an output with an SB_IO D_IN_{0,1}");
     }
 
-    int getDrivenGlobalNetwork(BelId bel) const
+    int get_driven_glb_netwk(BelId bel) const
     {
         NPNR_ASSERT(getBelType(bel) == id_SB_GB);
         IdString glb_net = getWireName(getBelPinWire(bel, id_GLOBAL_BUFFER_OUTPUT))[2];

--- a/ice40/arch_place.cc
+++ b/ice40/arch_place.cc
@@ -27,7 +27,7 @@
 
 NEXTPNR_NAMESPACE_BEGIN
 
-bool Arch::logicCellsCompatible(const CellInfo **it, const size_t size) const
+bool Arch::logic_cells_compatible(const CellInfo **it, const size_t size) const
 {
     bool dffs_exist = false, dffs_neg = false;
     const NetInfo *cen = nullptr, *clk = nullptr, *sr = nullptr;
@@ -81,7 +81,7 @@ bool Arch::isBelLocationValid(BelId bel) const
             if (ci_other != nullptr)
                 bel_cells[num_cells++] = ci_other;
         }
-        return logicCellsCompatible(bel_cells.data(), num_cells);
+        return logic_cells_compatible(bel_cells.data(), num_cells);
     } else {
         CellInfo *ci = getBoundBelCell(bel);
         if (ci == nullptr)
@@ -119,7 +119,7 @@ bool Arch::isValidBelForCell(CellInfo *cell, BelId bel) const
         }
 
         bel_cells[num_cells++] = cell;
-        return logicCellsCompatible(bel_cells.data(), num_cells);
+        return logic_cells_compatible(bel_cells.data(), num_cells);
     } else if (cell->type == id_SB_IO) {
         // Do not allow placement of input SB_IOs on blocks where there a PLL is outputting to.
 
@@ -195,13 +195,13 @@ bool Arch::isValidBelForCell(CellInfo *cell, BelId bel) const
             }
         }
 
-        return getBelPackagePin(bel) != "";
+        return get_bel_package_pin(bel) != "";
     } else if (cell->type == id_SB_GB) {
         if (cell->gbInfo.forPadIn)
             return true;
         NPNR_ASSERT(cell->ports.at(id_GLOBAL_BUFFER_OUTPUT).net != nullptr);
         const NetInfo *net = cell->ports.at(id_GLOBAL_BUFFER_OUTPUT).net;
-        int glb_id = getDrivenGlobalNetwork(bel);
+        int glb_id = get_driven_glb_netwk(bel);
         if (net->is_reset && net->is_enable)
             return false;
         else if (net->is_reset)

--- a/ice40/chains.cc
+++ b/ice40/chains.cc
@@ -63,7 +63,7 @@ class ChainConstrainer
             }
             tile.push_back(cell);
             chains.back().cells.push_back(cell);
-            bool split_chain = (!ctx->logicCellsCompatible(tile.data(), tile.size())) ||
+            bool split_chain = (!ctx->logic_cells_compatible(tile.data(), tile.size())) ||
                                (int(chains.back().cells.size()) > max_length);
             if (split_chain) {
                 CellInfo *passout = make_carry_pass_out((*(curr_cell - 1))->ports.at(ctx->id("COUT")));
@@ -84,7 +84,7 @@ class ChainConstrainer
                         if (!at_end) {
                             // See if we need to split chain anyway
                             tile.push_back(*(curr_cell + 1));
-                            bool split_chain_next = (!ctx->logicCellsCompatible(tile.data(), tile.size())) ||
+                            bool split_chain_next = (!ctx->logic_cells_compatible(tile.data(), tile.size())) ||
                                                     (int(chains.back().cells.size()) > max_length);
                             tile.pop_back();
                             if (split_chain_next)

--- a/ice40/main.cc
+++ b/ice40/main.cc
@@ -50,29 +50,29 @@ Ice40CommandHandler::Ice40CommandHandler(int argc, char **argv) : CommandHandler
 po::options_description Ice40CommandHandler::getArchOptions()
 {
     po::options_description specific("Architecture specific options");
-    if (Arch::isAvailable(ArchArgs::LP384))
+    if (Arch::is_available(ArchArgs::LP384))
         specific.add_options()("lp384", "set device type to iCE40LP384");
-    if (Arch::isAvailable(ArchArgs::LP1K))
+    if (Arch::is_available(ArchArgs::LP1K))
         specific.add_options()("lp1k", "set device type to iCE40LP1K");
-    if (Arch::isAvailable(ArchArgs::LP4K))
+    if (Arch::is_available(ArchArgs::LP4K))
         specific.add_options()("lp4k", "set device type to iCE40LP4K");
-    if (Arch::isAvailable(ArchArgs::LP8K))
+    if (Arch::is_available(ArchArgs::LP8K))
         specific.add_options()("lp8k", "set device type to iCE40LP8K");
-    if (Arch::isAvailable(ArchArgs::HX1K))
+    if (Arch::is_available(ArchArgs::HX1K))
         specific.add_options()("hx1k", "set device type to iCE40HX1K");
-    if (Arch::isAvailable(ArchArgs::HX8K))
+    if (Arch::is_available(ArchArgs::HX8K))
         specific.add_options()("hx4k", "set device type to iCE40HX4K");
-    if (Arch::isAvailable(ArchArgs::HX4K))
+    if (Arch::is_available(ArchArgs::HX4K))
         specific.add_options()("hx8k", "set device type to iCE40HX8K");
-    if (Arch::isAvailable(ArchArgs::UP3K))
+    if (Arch::is_available(ArchArgs::UP3K))
         specific.add_options()("up3k", "set device type to iCE40UP3K");
-    if (Arch::isAvailable(ArchArgs::UP5K))
+    if (Arch::is_available(ArchArgs::UP5K))
         specific.add_options()("up5k", "set device type to iCE40UP5K");
-    if (Arch::isAvailable(ArchArgs::U1K))
+    if (Arch::is_available(ArchArgs::U1K))
         specific.add_options()("u1k", "set device type to iCE5LP1K");
-    if (Arch::isAvailable(ArchArgs::U2K))
+    if (Arch::is_available(ArchArgs::U2K))
         specific.add_options()("u2k", "set device type to iCE5LP2K");
-    if (Arch::isAvailable(ArchArgs::U4K))
+    if (Arch::is_available(ArchArgs::U4K))
         specific.add_options()("u4k", "set device type to iCE5LP4K");
     specific.add_options()("package", po::value<std::string>(), "set device package");
     specific.add_options()("pcf", po::value<std::string>(), "PCF constraints file to ingest");

--- a/ice40/pack.cc
+++ b/ice40/pack.cc
@@ -639,7 +639,7 @@ static void promote_globals(Context *ctx)
     std::map<IdString, int> clock_count, reset_count, cen_count, logic_count;
     for (auto net : sorted(ctx->nets)) {
         NetInfo *ni = net.second;
-        if (ni->driver.cell != nullptr && !ctx->isGlobalNet(ni)) {
+        if (ni->driver.cell != nullptr && !ctx->is_global_net(ni)) {
             clock_count[net.first] = 0;
             reset_count[net.first] = 0;
             cen_count[net.first] = 0;
@@ -667,7 +667,7 @@ static void promote_globals(Context *ctx)
             if (cell.second->attrs.find(ctx->id("BEL")) != cell.second->attrs.end()) {
                 /* If the SB_GB is locked, doesn't matter what it drives */
                 BelId bel = ctx->getBelByNameStr(cell.second->attrs[ctx->id("BEL")].as_string());
-                int glb_id = ctx->getDrivenGlobalNetwork(bel);
+                int glb_id = ctx->get_driven_glb_netwk(bel);
                 if ((glb_id % 2) == 0)
                     resets_available--;
                 else if ((glb_id % 2) == 1)
@@ -766,11 +766,11 @@ static void place_plls(Context *ctx)
     for (auto bel : ctx->getBels()) {
         if (ctx->getBelType(bel) != id_ICESTORM_PLL)
             continue;
-        if (ctx->isBelLocked(bel))
+        if (ctx->is_bel_locked(bel))
             continue;
 
-        auto io_a_pin = ctx->getIOBSharingPLLPin(bel, id_PLLOUT_A);
-        auto io_b_pin = ctx->getIOBSharingPLLPin(bel, id_PLLOUT_B);
+        auto io_a_pin = ctx->get_iob_sharing_pll_pin(bel, id_PLLOUT_A);
+        auto io_b_pin = ctx->get_iob_sharing_pll_pin(bel, id_PLLOUT_B);
         auto gb_a = find_padin_gbuf(ctx, bel, id_PLLOUT_A_GLOBAL);
         auto gb_b = find_padin_gbuf(ctx, bel, id_PLLOUT_B_GLOBAL);
 
@@ -1064,7 +1064,7 @@ static BelId cell_place_unique(Context *ctx, CellInfo *ci)
     for (auto bel : ctx->getBels()) {
         if (ctx->getBelType(bel) != ci->type)
             continue;
-        if (ctx->isBelLocked(bel))
+        if (ctx->is_bel_locked(bel))
             continue;
         IdStringList bel_name = ctx->getBelName(bel);
         ci->attrs[ctx->id("BEL")] = bel_name.str(ctx);

--- a/ice40/pcf.cc
+++ b/ice40/pcf.cc
@@ -89,7 +89,7 @@ bool apply_pcf(Context *ctx, std::string filename, std::istream &in)
                     if (!nowarn)
                         log_warning("unmatched constraint '%s' (on line %d)\n", cell.c_str(), lineno);
                 } else {
-                    BelId pin_bel = ctx->getPackagePinBel(pin);
+                    BelId pin_bel = ctx->get_package_pin_bel(pin);
                     if (pin_bel == BelId())
                         log_error("package does not have a pin named '%s' (on line %d)\n", pin.c_str(), lineno);
                     if (fnd_cell->second->attrs.count(ctx->id("BEL")))


### PR DESCRIPTION
This improves the ability to distinguish between what is part of the official Arch API and what is arch-specific.

Longer term, there are potentially better ways to do this like https://github.com/SymbiFlow/nextpnr/pull/195#discussion_r566203422 (potentially with their own complexities) but this is a first step in that direction to improve the clarity.

An annoying exception here is the nextpnr-generic `add*` functions; which can't be renamed without a breaking change to downstream users of the Python API, which I try and keep stable without very good reasons for change.