### PR TITLE
Create a new BaseArch that formally specifies the Arch API and provides some base implementations 

### DIFF
--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -1006,6 +1006,114 @@ struct BaseCtx
 
     void archInfoToAttributes();
     void attributesToArchInfo();
+
+    // --------------------------------------------------------------
+    // Arch API base
+
+    // Basic config
+    virtual int getGridDimX() const = 0;
+    virtual int getGridDimY() const = 0;
+    virtual int getTileBelDimZ(int x, int y) const = 0;
+    virtual int getTilePipDimZ(int x, int y) const { return 1; }
+    virtual char getNameDelimiter() const { return ' '; }
+
+    // Bel methods
+    virtual BelId getBelByName(IdStringList name) const = 0;
+    virtual IdStringList getBelName(BelId bel) const = 0;
+    virtual uint32_t getBelChecksum(BelId bel) const { return uint32_t(std::hash<BelId>()(bel)); }
+    virtual void bindBel(BelId bel, CellInfo *cell, PlaceStrength strength) = 0;
+    virtual void unbindBel(BelId bel) = 0;
+    virtual Loc getBelLocation(BelId bel) const = 0;
+    virtual BelId getBelByLocation(Loc loc) const = 0;
+    virtual bool getBelGlobalBuf(BelId bel) const { return false; }
+    virtual bool checkBelAvail(BelId bel) const = 0;
+    virtual CellInfo *getBoundBelCell(BelId bel) const = 0;
+    virtual CellInfo *getConflictingBelCell(BelId bel) const = 0;
+    virtual IdString getBelType(BelId bel) const = 0;
+    virtual WireId getBelPinWire(BelId bel, IdString pin) const = 0;
+    virtual PortType getBelPinType(BelId bel, IdString pin) const = 0;
+
+    // Wire methods
+    virtual WireId getWireByName(IdStringList name) const = 0;
+    virtual IdStringList getWireName(WireId wire) const = 0;
+    virtual IdString getWireType(WireId wire) const { return IdString(); }
+    virtual uint32_t getWireChecksum(WireId wire) const { return uint32_t(std::hash<WireId>()(wire)); }
+    virtual void bindWire(WireId wire, NetInfo *net, PlaceStrength strength) = 0;
+    virtual void unbindWire(WireId wire) = 0;
+    virtual bool checkWireAvail(WireId wire) const = 0;
+    virtual NetInfo *getBoundWireNet(WireId wire) const = 0;
+    virtual WireId getConflictingWireWire(WireId wire) const { return wire; };
+    virtual NetInfo *getConflictingWireNet(WireId wire) const { return getBoundWireNet(wire); }
+    virtual DelayInfo getWireDelay(WireId wire) const = 0;
+
+    // Pip methods
+    virtual PipId getPipByName(IdStringList name) const = 0;
+    virtual IdStringList getPipName(PipId pip) const = 0;
+    virtual IdString getPipType(PipId pip) const { return IdString(); }
+    virtual uint32_t getPipChecksum(PipId pip) const { return uint32_t(std::hash<PipId>()(pip)); }
+    virtual void bindPip(PipId pip, NetInfo *net, PlaceStrength strength) = 0;
+    virtual void unbindPip(PipId pip) = 0;
+    virtual bool checkPipAvail(PipId pip) const = 0;
+    virtual NetInfo *getBoundPipNet(PipId pip) const = 0;
+    virtual WireId getConflictingPipWire(PipId pip) const { return WireId(); }
+    virtual NetInfo *getConflictingPipNet(PipId pip) const { return nullptr; }
+    virtual WireId getPipSrcWire(PipId pip) const = 0;
+    virtual WireId getPipDstWire(PipId pip) const = 0;
+    virtual DelayInfo getPipDelay(PipId pip) const = 0;
+    virtual Loc getPipLocation(PipId pip) const = 0;
+
+    // Group methods
+    virtual GroupId getGroupByName(IdStringList name) const = 0;
+    virtual IdStringList getGroupName(GroupId group) const = 0;
+    virtual delay_t estimateDelay(WireId src, WireId dst) const = 0;
+    virtual ArcBounds getRouteBoundingBox(WireId src, WireId dst) const = 0;
+
+    // Delay methods
+    virtual delay_t predictDelay(const NetInfo *net_info, const PortRef &sink) const = 0;
+    virtual delay_t getDelayEpsilon() const = 0;
+    virtual delay_t getRipupDelayPenalty() const = 0;
+    virtual float getDelayNS(delay_t v) const = 0;
+    virtual DelayInfo getDelayFromNS(float ns) const = 0;
+    virtual uint32_t getDelayChecksum(delay_t v) const = 0;
+    virtual bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const
+    {
+        return false;
+    }
+
+    // Decal methods
+    virtual DecalXY getBelDecal(BelId bel) const { return DecalXY(); }
+    virtual DecalXY getWireDecal(WireId wire) const { return DecalXY(); }
+    virtual DecalXY getPipDecal(PipId pip) const { return DecalXY(); }
+    virtual DecalXY getGroupDecal(GroupId group) const { return DecalXY(); }
+
+    // Cell timing methods
+    virtual bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const
+    {
+        return false;
+    }
+    virtual TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const
+    {
+        return TMG_IGNORE;
+    }
+    virtual TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const
+    {
+        NPNR_ASSERT_FALSE("unreachable");
+    }
+
+    // Placement validity checks
+    virtual bool isValidBelForCellType(IdString cell_type, BelId bel) const { return cell_type == getBelType(bel); }
+    virtual IdString getBelBucketName(BelBucketId bucket) const = 0;
+    virtual BelBucketId getBelBucketByName(IdString name) const = 0;
+    virtual BelBucketId getBelBucketForBel(BelId bel) const = 0;
+    virtual BelBucketId getBelBucketForCellType(IdString cell_type) const = 0;
+    virtual bool isValidBelForCell(CellInfo *cell, BelId bel) const { return true; }
+    virtual bool isBelLocationValid(BelId bel) const { return true; }
+
+    // Flow methods
+    virtual bool pack() = 0;
+    virtual bool place() = 0;
+    virtual bool route() = 0;
+    virtual void assignArchInfo(){};
 };
 
 NEXTPNR_NAMESPACE_END

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -841,6 +841,8 @@ struct BaseCtx
     // Context meta data
     std::unordered_map<IdString, Property> attrs;
 
+    Context *as_ctx = nullptr;
+
     BaseCtx()
     {
         idstring_str_to_idx = new std::unordered_map<std::string, int>;
@@ -914,9 +916,9 @@ struct BaseCtx
 
     IdString id(const char *s) const { return IdString(this, s); }
 
-    Context *getCtx() { return reinterpret_cast<Context *>(this); }
+    Context *getCtx() { return as_ctx; }
 
-    const Context *getCtx() const { return reinterpret_cast<const Context *>(this); }
+    const Context *getCtx() const { return as_ctx; }
 
     const char *nameOf(IdString name) const { return name.c_str(this); }
 
@@ -1245,7 +1247,7 @@ struct Context : Arch, DeterministicRNG
     // Should we disable printing of the location of nets in the critical path?
     bool disable_critical_path_source_print = false;
 
-    Context(ArchArgs args) : Arch(args) {}
+    Context(ArchArgs args) : Arch(args) { BaseCtx::as_ctx = this; }
 
     // --------------------------------------------------------------
 

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -1093,6 +1093,7 @@ template <typename R> struct ArchAPI : BaseCtx
     virtual typename R::BelAttrsRange getBelAttrs(BelId bel) const = 0;
     virtual WireId getBelPinWire(BelId bel, IdString pin) const = 0;
     virtual PortType getBelPinType(BelId bel, IdString pin) const = 0;
+    virtual typename R::BelPinsRange getBelPins(BelId bel) const = 0;
     // Wire methods
     virtual typename R::AllWiresRange getWires() const = 0;
     virtual WireId getWireByName(IdStringList name) const = 0;

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -1064,7 +1064,7 @@ typename std::enable_if<!std::is_same<Tret, Tc>::value, Tret>::type return_if_ma
 
 } // namespace
 
-template <typename R> struct ArchBase : BaseCtx
+template <typename R> struct BaseArch : BaseCtx
 {
     // --------------------------------------------------------------
     // Arch API base

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -1006,7 +1006,10 @@ struct BaseCtx
 
     void archInfoToAttributes();
     void attributesToArchInfo();
+};
 
+template <typename R> struct ArchBase : BaseCtx
+{
     // --------------------------------------------------------------
     // Arch API base
 
@@ -1018,6 +1021,7 @@ struct BaseCtx
     virtual char getNameDelimiter() const { return ' '; }
 
     // Bel methods
+    virtual typename R::AllBelsRange getBels() const = 0;
     virtual BelId getBelByName(IdStringList name) const = 0;
     virtual IdStringList getBelName(BelId bel) const = 0;
     virtual uint32_t getBelChecksum(BelId bel) const { return uint32_t(std::hash<BelId>()(bel)); }
@@ -1025,19 +1029,26 @@ struct BaseCtx
     virtual void unbindBel(BelId bel) = 0;
     virtual Loc getBelLocation(BelId bel) const = 0;
     virtual BelId getBelByLocation(Loc loc) const = 0;
+    virtual typename R::TileBelsRange getBelsByTile(int x, int y) const = 0;
     virtual bool getBelGlobalBuf(BelId bel) const { return false; }
     virtual bool checkBelAvail(BelId bel) const = 0;
     virtual CellInfo *getBoundBelCell(BelId bel) const = 0;
     virtual CellInfo *getConflictingBelCell(BelId bel) const = 0;
     virtual IdString getBelType(BelId bel) const = 0;
+    virtual typename R::BelAttrsRange getBelAttrs(BelId bel) const = 0;
     virtual WireId getBelPinWire(BelId bel, IdString pin) const = 0;
     virtual PortType getBelPinType(BelId bel, IdString pin) const = 0;
 
     // Wire methods
+    virtual typename R::AllWiresRange getWires() const = 0;
     virtual WireId getWireByName(IdStringList name) const = 0;
     virtual IdStringList getWireName(WireId wire) const = 0;
     virtual IdString getWireType(WireId wire) const { return IdString(); }
+    virtual typename R::WireAttrsRange getWireAttrs(WireId) const = 0;
     virtual uint32_t getWireChecksum(WireId wire) const { return uint32_t(std::hash<WireId>()(wire)); }
+    virtual typename R::DownhillPipRange getPipsDownhill(WireId wire) const = 0;
+    virtual typename R::UphillPipRange getPipsUphill(WireId wire) const = 0;
+    virtual typename R::WireBelPinRange getWireBelPins(WireId wire) const = 0;
     virtual void bindWire(WireId wire, NetInfo *net, PlaceStrength strength) = 0;
     virtual void unbindWire(WireId wire) = 0;
     virtual bool checkWireAvail(WireId wire) const = 0;
@@ -1047,9 +1058,11 @@ struct BaseCtx
     virtual DelayInfo getWireDelay(WireId wire) const = 0;
 
     // Pip methods
+    virtual typename R::AllPipsRange getPips() const = 0;
     virtual PipId getPipByName(IdStringList name) const = 0;
     virtual IdStringList getPipName(PipId pip) const = 0;
     virtual IdString getPipType(PipId pip) const { return IdString(); }
+    virtual typename R::PipAttrsRange getPipAttrs(PipId) const = 0;
     virtual uint32_t getPipChecksum(PipId pip) const { return uint32_t(std::hash<PipId>()(pip)); }
     virtual void bindPip(PipId pip, NetInfo *net, PlaceStrength strength) = 0;
     virtual void unbindPip(PipId pip) = 0;
@@ -1067,6 +1080,11 @@ struct BaseCtx
     virtual IdStringList getGroupName(GroupId group) const = 0;
     virtual delay_t estimateDelay(WireId src, WireId dst) const = 0;
     virtual ArcBounds getRouteBoundingBox(WireId src, WireId dst) const = 0;
+    virtual typename R::AllGroupsRange getGroups() const = 0;
+    virtual typename R::GroupBelsRange getGroupBels(GroupId group) const = 0;
+    virtual typename R::GroupWiresRange getGroupWires(GroupId group) const = 0;
+    virtual typename R::GroupPipsRange getGroupPips(GroupId group) const = 0;
+    virtual typename R::GroupGroupsRange getGroupGroups(GroupId group) const = 0;
 
     // Delay methods
     virtual delay_t predictDelay(const NetInfo *net_info, const PortRef &sink) const = 0;
@@ -1108,6 +1126,9 @@ struct BaseCtx
     virtual BelBucketId getBelBucketForCellType(IdString cell_type) const = 0;
     virtual bool isValidBelForCell(CellInfo *cell, BelId bel) const { return true; }
     virtual bool isBelLocationValid(BelId bel) const { return true; }
+    virtual typename R::CellTypeRange getCellTypes() const = 0;
+    virtual typename R::BelBucketRange getBelBuckets() const = 0;
+    virtual typename R::BucketBelRange getBelsInBucket(BelBucketId bucket) const = 0;
 
     // Flow methods
     virtual bool pack() = 0;

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -1156,7 +1156,7 @@ template <typename R> struct ArchBase : BaseCtx
         return fnd == base_pip2net.end() ? nullptr : fnd->second;
     }
     virtual WireId getConflictingPipWire(PipId pip) const { return WireId(); }
-    virtual NetInfo *getConflictingPipNet(PipId pip) const { return nullptr; }
+    virtual NetInfo *getConflictingPipNet(PipId pip) const { return getBoundPipNet(pip); }
     virtual WireId getPipSrcWire(PipId pip) const = 0;
     virtual WireId getPipDstWire(PipId pip) const = 0;
     virtual DelayInfo getPipDelay(PipId pip) const = 0;

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -1070,6 +1070,8 @@ template <typename R> struct ArchAPI : BaseCtx
     // Basic config
     virtual IdString archId() const = 0;
     virtual std::string getChipName() const = 0;
+    virtual typename R::ArchArgsType archArgs() const = 0;
+    virtual IdString archArgsToId(typename R::ArchArgsType args) const = 0;
     virtual int getGridDimX() const = 0;
     virtual int getGridDimY() const = 0;
     virtual int getTileBelDimZ(int x, int y) const = 0;
@@ -1181,6 +1183,7 @@ template <typename R> struct BaseArch : ArchAPI<R>
 
     // Basic config
     virtual IdString archId() const override { return this->id(STRINGIFY(ARCHNAME)); }
+    virtual IdString archArgsToId(typename R::ArchArgsType args) const { return IdString(); }
     virtual int getTilePipDimZ(int x, int y) const override { return 1; }
     virtual char getNameDelimiter() const override { return ' '; }
 

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -858,7 +858,7 @@ struct BaseCtx
         constraintObjects.push_back(wildcard);
     }
 
-    ~BaseCtx()
+    virtual ~BaseCtx()
     {
         delete idstring_str_to_idx;
         delete idstring_idx_to_str;

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -1070,15 +1070,15 @@ template <typename R> struct ArchAPI : BaseCtx
     // Basic config
     virtual IdString archId() const = 0;
     virtual std::string getChipName() const = 0;
-    virtual typename R::ArchArgsType archArgs() const = 0;
-    virtual IdString archArgsToId(typename R::ArchArgsType args) const = 0;
+    virtual typename R::ArchArgsT archArgs() const = 0;
+    virtual IdString archArgsToId(typename R::ArchArgsT args) const = 0;
     virtual int getGridDimX() const = 0;
     virtual int getGridDimY() const = 0;
     virtual int getTileBelDimZ(int x, int y) const = 0;
     virtual int getTilePipDimZ(int x, int y) const = 0;
     virtual char getNameDelimiter() const = 0;
     // Bel methods
-    virtual typename R::AllBelsRange getBels() const = 0;
+    virtual typename R::AllBelsRangeT getBels() const = 0;
     virtual IdStringList getBelName(BelId bel) const = 0;
     virtual BelId getBelByName(IdStringList name) const = 0;
     virtual uint32_t getBelChecksum(BelId bel) const = 0;
@@ -1086,25 +1086,25 @@ template <typename R> struct ArchAPI : BaseCtx
     virtual void unbindBel(BelId bel) = 0;
     virtual Loc getBelLocation(BelId bel) const = 0;
     virtual BelId getBelByLocation(Loc loc) const = 0;
-    virtual typename R::TileBelsRange getBelsByTile(int x, int y) const = 0;
+    virtual typename R::TileBelsRangeT getBelsByTile(int x, int y) const = 0;
     virtual bool getBelGlobalBuf(BelId bel) const = 0;
     virtual bool checkBelAvail(BelId bel) const = 0;
     virtual CellInfo *getBoundBelCell(BelId bel) const = 0;
     virtual CellInfo *getConflictingBelCell(BelId bel) const = 0;
     virtual IdString getBelType(BelId bel) const = 0;
-    virtual typename R::BelAttrsRange getBelAttrs(BelId bel) const = 0;
+    virtual typename R::BelAttrsRangeT getBelAttrs(BelId bel) const = 0;
     virtual WireId getBelPinWire(BelId bel, IdString pin) const = 0;
     virtual PortType getBelPinType(BelId bel, IdString pin) const = 0;
-    virtual typename R::BelPinsRange getBelPins(BelId bel) const = 0;
+    virtual typename R::BelPinsRangeT getBelPins(BelId bel) const = 0;
     // Wire methods
-    virtual typename R::AllWiresRange getWires() const = 0;
+    virtual typename R::AllWiresRangeT getWires() const = 0;
     virtual WireId getWireByName(IdStringList name) const = 0;
     virtual IdStringList getWireName(WireId wire) const = 0;
     virtual IdString getWireType(WireId wire) const = 0;
-    virtual typename R::WireAttrsRange getWireAttrs(WireId) const = 0;
-    virtual typename R::DownhillPipRange getPipsDownhill(WireId wire) const = 0;
-    virtual typename R::UphillPipRange getPipsUphill(WireId wire) const = 0;
-    virtual typename R::WireBelPinRange getWireBelPins(WireId wire) const = 0;
+    virtual typename R::WireAttrsRangeT getWireAttrs(WireId) const = 0;
+    virtual typename R::DownhillPipRangeT getPipsDownhill(WireId wire) const = 0;
+    virtual typename R::UphillPipRangeT getPipsUphill(WireId wire) const = 0;
+    virtual typename R::WireBelPinRangeT getWireBelPins(WireId wire) const = 0;
     virtual uint32_t getWireChecksum(WireId wire) const = 0;
     virtual void bindWire(WireId wire, NetInfo *net, PlaceStrength strength) = 0;
     virtual void unbindWire(WireId wire) = 0;
@@ -1114,11 +1114,11 @@ template <typename R> struct ArchAPI : BaseCtx
     virtual NetInfo *getConflictingWireNet(WireId wire) const = 0;
     virtual DelayInfo getWireDelay(WireId wire) const = 0;
     // Pip methods
-    virtual typename R::AllPipsRange getPips() const = 0;
+    virtual typename R::AllPipsRangeT getPips() const = 0;
     virtual PipId getPipByName(IdStringList name) const = 0;
     virtual IdStringList getPipName(PipId pip) const = 0;
     virtual IdString getPipType(PipId pip) const = 0;
-    virtual typename R::PipAttrsRange getPipAttrs(PipId) const = 0;
+    virtual typename R::PipAttrsRangeT getPipAttrs(PipId) const = 0;
     virtual uint32_t getPipChecksum(PipId pip) const = 0;
     virtual void bindPip(PipId pip, NetInfo *net, PlaceStrength strength) = 0;
     virtual void unbindPip(PipId pip) = 0;
@@ -1133,11 +1133,11 @@ template <typename R> struct ArchAPI : BaseCtx
     // Group methods
     virtual GroupId getGroupByName(IdStringList name) const = 0;
     virtual IdStringList getGroupName(GroupId group) const = 0;
-    virtual typename R::AllGroupsRange getGroups() const = 0;
-    virtual typename R::GroupBelsRange getGroupBels(GroupId group) const = 0;
-    virtual typename R::GroupWiresRange getGroupWires(GroupId group) const = 0;
-    virtual typename R::GroupPipsRange getGroupPips(GroupId group) const = 0;
-    virtual typename R::GroupGroupsRange getGroupGroups(GroupId group) const = 0;
+    virtual typename R::AllGroupsRangeT getGroups() const = 0;
+    virtual typename R::GroupBelsRangeT getGroupBels(GroupId group) const = 0;
+    virtual typename R::GroupWiresRangeT getGroupWires(GroupId group) const = 0;
+    virtual typename R::GroupPipsRangeT getGroupPips(GroupId group) const = 0;
+    virtual typename R::GroupGroupsRangeT getGroupGroups(GroupId group) const = 0;
     // Delay Methods
     virtual delay_t predictDelay(const NetInfo *net_info, const PortRef &sink) const = 0;
     virtual delay_t getDelayEpsilon() const = 0;
@@ -1149,7 +1149,7 @@ template <typename R> struct ArchAPI : BaseCtx
     virtual delay_t estimateDelay(WireId src, WireId dst) const = 0;
     virtual ArcBounds getRouteBoundingBox(WireId src, WireId dst) const = 0;
     // Decal methods
-    virtual typename R::DecalGfxRange getDecalGraphics(DecalId decal) const = 0;
+    virtual typename R::DecalGfxRangeT getDecalGraphics(DecalId decal) const = 0;
     virtual DecalXY getBelDecal(BelId bel) const = 0;
     virtual DecalXY getWireDecal(WireId wire) const = 0;
     virtual DecalXY getPipDecal(PipId pip) const = 0;
@@ -1166,9 +1166,9 @@ template <typename R> struct ArchAPI : BaseCtx
     virtual BelBucketId getBelBucketForCellType(IdString cell_type) const = 0;
     virtual bool isValidBelForCell(CellInfo *cell, BelId bel) const = 0;
     virtual bool isBelLocationValid(BelId bel) const = 0;
-    virtual typename R::CellTypeRange getCellTypes() const = 0;
-    virtual typename R::BelBucketRange getBelBuckets() const = 0;
-    virtual typename R::BucketBelRange getBelsInBucket(BelBucketId bucket) const = 0;
+    virtual typename R::CellTypeRangeT getCellTypes() const = 0;
+    virtual typename R::BelBucketRangeT getBelBuckets() const = 0;
+    virtual typename R::BucketBelRangeT getBelsInBucket(BelBucketId bucket) const = 0;
     // Flow methods
     virtual bool pack() = 0;
     virtual bool place() = 0;
@@ -1183,7 +1183,7 @@ template <typename R> struct BaseArch : ArchAPI<R>
 
     // Basic config
     virtual IdString archId() const override { return this->id(STRINGIFY(ARCHNAME)); }
-    virtual IdString archArgsToId(typename R::ArchArgsType args) const { return IdString(); }
+    virtual IdString archArgsToId(typename R::ArchArgsT args) const { return IdString(); }
     virtual int getTilePipDimZ(int x, int y) const override { return 1; }
     virtual char getNameDelimiter() const override { return ' '; }
 
@@ -1218,16 +1218,16 @@ template <typename R> struct BaseArch : ArchAPI<R>
         return fnd == base_bel2cell.end() ? nullptr : fnd->second;
     }
     virtual CellInfo *getConflictingBelCell(BelId bel) const override { return getBoundBelCell(bel); }
-    virtual typename R::BelAttrsRange getBelAttrs(BelId bel) const override
+    virtual typename R::BelAttrsRangeT getBelAttrs(BelId bel) const override
     {
-        return empty_if_possible<typename R::BelAttrsRange>();
+        return empty_if_possible<typename R::BelAttrsRangeT>();
     }
 
     // Wire methods
     virtual IdString getWireType(WireId wire) const override { return IdString(); }
-    virtual typename R::WireAttrsRange getWireAttrs(WireId) const override
+    virtual typename R::WireAttrsRangeT getWireAttrs(WireId) const override
     {
-        return empty_if_possible<typename R::WireAttrsRange>();
+        return empty_if_possible<typename R::WireAttrsRangeT>();
     }
     virtual uint32_t getWireChecksum(WireId wire) const override { return uint32_t(std::hash<WireId>()(wire)); }
 
@@ -1273,9 +1273,9 @@ template <typename R> struct BaseArch : ArchAPI<R>
 
     // Pip methods
     virtual IdString getPipType(PipId pip) const { return IdString(); }
-    virtual typename R::PipAttrsRange getPipAttrs(PipId) const override
+    virtual typename R::PipAttrsRangeT getPipAttrs(PipId) const override
     {
-        return empty_if_possible<typename R::PipAttrsRange>();
+        return empty_if_possible<typename R::PipAttrsRangeT>();
     }
     virtual uint32_t getPipChecksum(PipId pip) const override { return uint32_t(std::hash<PipId>()(pip)); }
     virtual void bindPip(PipId pip, NetInfo *net, PlaceStrength strength) override
@@ -1318,18 +1318,24 @@ template <typename R> struct BaseArch : ArchAPI<R>
     // Group methods
     virtual GroupId getGroupByName(IdStringList name) const override { return GroupId(); };
     virtual IdStringList getGroupName(GroupId group) const override { return IdStringList(); };
-    virtual typename R::AllGroupsRange getGroups() const override
+    virtual typename R::AllGroupsRangeT getGroups() const override
     {
-        return empty_if_possible<typename R::AllGroupsRange>();
+        return empty_if_possible<typename R::AllGroupsRangeT>();
     }
     // Default implementation of these assumes no groups so never called
-    virtual typename R::GroupBelsRange getGroupBels(GroupId group) const override { NPNR_ASSERT_FALSE("unreachable"); };
-    virtual typename R::GroupWiresRange getGroupWires(GroupId group) const override
+    virtual typename R::GroupBelsRangeT getGroupBels(GroupId group) const override
     {
         NPNR_ASSERT_FALSE("unreachable");
     };
-    virtual typename R::GroupPipsRange getGroupPips(GroupId group) const override { NPNR_ASSERT_FALSE("unreachable"); };
-    virtual typename R::GroupGroupsRange getGroupGroups(GroupId group) const override
+    virtual typename R::GroupWiresRangeT getGroupWires(GroupId group) const override
+    {
+        NPNR_ASSERT_FALSE("unreachable");
+    };
+    virtual typename R::GroupPipsRangeT getGroupPips(GroupId group) const override
+    {
+        NPNR_ASSERT_FALSE("unreachable");
+    };
+    virtual typename R::GroupGroupsRangeT getGroupGroups(GroupId group) const override
     {
         NPNR_ASSERT_FALSE("unreachable");
     };
@@ -1341,7 +1347,7 @@ template <typename R> struct BaseArch : ArchAPI<R>
     }
 
     // Decal methods
-    virtual typename R::DecalGfxRange getDecalGraphics(DecalId decal) const override
+    virtual typename R::DecalGfxRangeT getDecalGraphics(DecalId decal) const override
     {
         NPNR_ASSERT_FALSE("unreachable");
     };
@@ -1381,20 +1387,20 @@ template <typename R> struct BaseArch : ArchAPI<R>
     };
     virtual bool isValidBelForCell(CellInfo *cell, BelId bel) const override { return true; }
     virtual bool isBelLocationValid(BelId bel) const override { return true; }
-    virtual typename R::CellTypeRange getCellTypes() const override
+    virtual typename R::CellTypeRangeT getCellTypes() const override
     {
         NPNR_ASSERT(cell_types_initialised);
-        return return_if_match<const std::vector<IdString> &, typename R::CellTypeRange>(cell_types);
+        return return_if_match<const std::vector<IdString> &, typename R::CellTypeRangeT>(cell_types);
     }
-    virtual typename R::BelBucketRange getBelBuckets() const override
+    virtual typename R::BelBucketRangeT getBelBuckets() const override
     {
         NPNR_ASSERT(bel_buckets_initialised);
-        return return_if_match<const std::vector<BelBucketId> &, typename R::BelBucketRange>(bel_buckets);
+        return return_if_match<const std::vector<BelBucketId> &, typename R::BelBucketRangeT>(bel_buckets);
     }
-    virtual typename R::BucketBelRange getBelsInBucket(BelBucketId bucket) const override
+    virtual typename R::BucketBelRangeT getBelsInBucket(BelBucketId bucket) const override
     {
         NPNR_ASSERT(bel_buckets_initialised);
-        return return_if_match<const std::vector<BelId> &, typename R::BucketBelRange>(bucket_bels.at(bucket));
+        return return_if_match<const std::vector<BelId> &, typename R::BucketBelRangeT>(bucket_bels.at(bucket));
     }
 
     // Flow methods

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -74,7 +74,15 @@ Constructor. ArchArgs is a architecture-specific type (usually a struct also def
 
 ### std::string getChipName() const
 
-Return a string representation of the ArchArgs that was used to construct this object.
+Return a user-friendly string representation of the ArchArgs that was used to construct this object.
+
+### ArchArgs archArgs() const
+
+Return the `ArchArgs` used to construct this object.
+
+### IdString archArgsToId(ArchArgs args) const
+
+Return an internal IdString representation of the ArchArgs that was used to construct this object.
 
 ### int getGridDimX() const
 

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -105,18 +105,8 @@ Arch::Arch(ArchArgs args) : args(args)
 
     bel_to_cell.resize(chip_info->height * chip_info->width * max_loc_bels, nullptr);
 
-    std::unordered_set<IdString> bel_types;
-    for (BelId bel : getBels()) {
-        bel_types.insert(getBelType(bel));
-    }
-
-    for (IdString bel_type : bel_types) {
-        cell_types.push_back(bel_type);
-
-        BelBucketId bucket;
-        bucket.name = bel_type;
-        buckets.push_back(bucket);
-    }
+    ArchBase::init_cell_types();
+    ArchBase::init_bel_buckets();
 
     for (int i = 0; i < chip_info->width; i++)
         x_ids.push_back(id(stringf("X%d", i)));

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -105,8 +105,8 @@ Arch::Arch(ArchArgs args) : args(args)
 
     bel_to_cell.resize(chip_info->height * chip_info->width * max_loc_bels, nullptr);
 
-    ArchBase::init_cell_types();
-    ArchBase::init_bel_buckets();
+    BaseArch::init_cell_types();
+    BaseArch::init_bel_buckets();
 
     for (int i = 0; i < chip_info->width; i++)
         x_ids.push_back(id(stringf("X%d", i)));

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -437,6 +437,7 @@ NEXTPNR_NAMESPACE_BEGIN
 
 struct ArchRanges
 {
+    using ArchArgsType = ArchArgs;
     // Bels
     using AllBelsRange = BelRange;
     using TileBelsRange = BelRange;
@@ -490,8 +491,8 @@ struct Arch : BaseArch<ArchRanges>
     std::string getChipName() const override;
     std::string get_full_chip_name() const;
 
-    ArchArgs archArgs() const { return args; }
-    IdString archArgsToId(ArchArgs args) const;
+    ArchArgs archArgs() const override { return args; }
+    IdString archArgsToId(ArchArgs args) const override;
 
     // -------------------------------------------------
 

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -457,6 +457,8 @@ struct ArchRanges
     using GroupWiresRange = std::vector<WireId>;
     using GroupPipsRange = std::vector<PipId>;
     using GroupGroupsRange = std::vector<GroupId>;
+    // Decals
+    using DecalGfxRange = std::vector<GraphicElement>;
     // Placement validity
     using CellTypeRange = const std::vector<IdString> &;
     using BelBucketRange = std::vector<BelBucketId>;
@@ -485,10 +487,9 @@ struct Arch : ArchBase<ArchRanges>
     static bool is_available(ArchArgs::ArchArgsTypes chip);
     static std::vector<std::string> get_supported_packages(ArchArgs::ArchArgsTypes chip);
 
-    std::string getChipName() const;
+    std::string getChipName() const override;
     std::string get_full_chip_name() const;
 
-    IdString archId() const { return id("ecp5"); }
     ArchArgs archArgs() const { return args; }
     IdString archArgsToId(ArchArgs args) const;
 
@@ -864,7 +865,7 @@ struct Arch : ArchBase<ArchRanges>
 
     // -------------------------------------------------
 
-    std::vector<GraphicElement> getDecalGraphics(DecalId decal) const;
+    std::vector<GraphicElement> getDecalGraphics(DecalId decal) const override;
 
     DecalXY getBelDecal(BelId bel) const override;
     DecalXY getWireDecal(WireId wire) const override;

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -602,12 +602,6 @@ struct Arch : ArchBase<ArchRanges>
         return id;
     }
 
-    std::vector<std::pair<IdString, std::string>> getBelAttrs(BelId) const override
-    {
-        std::vector<std::pair<IdString, std::string>> ret;
-        return ret;
-    }
-
     WireId getBelPinWire(BelId bel, IdString pin) const override;
 
     BelPinRange getWireBelPins(WireId wire) const override
@@ -703,12 +697,6 @@ struct Arch : ArchBase<ArchRanges>
 
     PipId getPipByName(IdStringList name) const override;
     IdStringList getPipName(PipId pip) const override;
-
-    std::vector<std::pair<IdString, std::string>> getPipAttrs(PipId) const
-    {
-        std::vector<std::pair<IdString, std::string>> ret;
-        return ret;
-    }
 
     uint32_t getPipChecksum(PipId pip) const override { return pip.index; }
 

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -470,22 +470,22 @@ struct Arch : BaseCtx
 
     static const int max_loc_bels = 20;
 
-    int getGridDimX() const { return chip_info->width; };
-    int getGridDimY() const { return chip_info->height; };
-    int getTileBelDimZ(int, int) const { return max_loc_bels; };
-    int getTilePipDimZ(int, int) const { return 1; };
-    char getNameDelimiter() const { return '/'; }
+    int getGridDimX() const override { return chip_info->width; };
+    int getGridDimY() const override { return chip_info->height; };
+    int getTileBelDimZ(int, int) const override { return max_loc_bels; };
+    int getTilePipDimZ(int, int) const override { return 1; };
+    char getNameDelimiter() const override { return '/'; }
 
     // -------------------------------------------------
 
-    BelId getBelByName(IdStringList name) const;
+    BelId getBelByName(IdStringList name) const override;
 
     template <typename Id> const LocationTypePOD *loc_info(Id &id) const
     {
         return &(chip_info->locations[chip_info->location_type[id.location.y * chip_info->width + id.location.x]]);
     }
 
-    IdStringList getBelName(BelId bel) const
+    IdStringList getBelName(BelId bel) const override
     {
         NPNR_ASSERT(bel != BelId());
         std::array<IdString, 3> ids{x_ids.at(bel.location.x), y_ids.at(bel.location.y),
@@ -493,14 +493,14 @@ struct Arch : BaseCtx
         return IdStringList(ids);
     }
 
-    uint32_t getBelChecksum(BelId bel) const { return bel.index; }
+    uint32_t getBelChecksum(BelId bel) const override { return bel.index; }
 
     int get_bel_flat_index(BelId bel) const
     {
         return (bel.location.y * chip_info->width + bel.location.x) * max_loc_bels + bel.index;
     }
 
-    void bindBel(BelId bel, CellInfo *cell, PlaceStrength strength)
+    void bindBel(BelId bel, CellInfo *cell, PlaceStrength strength) override
     {
         NPNR_ASSERT(bel != BelId());
         int idx = get_bel_flat_index(bel);
@@ -511,7 +511,7 @@ struct Arch : BaseCtx
         refreshUiBel(bel);
     }
 
-    void unbindBel(BelId bel)
+    void unbindBel(BelId bel) override
     {
         NPNR_ASSERT(bel != BelId());
         int idx = get_bel_flat_index(bel);
@@ -522,7 +522,7 @@ struct Arch : BaseCtx
         refreshUiBel(bel);
     }
 
-    Loc getBelLocation(BelId bel) const
+    Loc getBelLocation(BelId bel) const override
     {
         Loc loc;
         loc.x = bel.location.x;
@@ -531,24 +531,24 @@ struct Arch : BaseCtx
         return loc;
     }
 
-    BelId getBelByLocation(Loc loc) const;
+    BelId getBelByLocation(Loc loc) const override;
     BelRange getBelsByTile(int x, int y) const;
 
-    bool getBelGlobalBuf(BelId bel) const { return getBelType(bel) == id_DCCA; }
+    bool getBelGlobalBuf(BelId bel) const override { return getBelType(bel) == id_DCCA; }
 
-    bool checkBelAvail(BelId bel) const
+    bool checkBelAvail(BelId bel) const override
     {
         NPNR_ASSERT(bel != BelId());
         return bel_to_cell[get_bel_flat_index(bel)] == nullptr;
     }
 
-    CellInfo *getBoundBelCell(BelId bel) const
+    CellInfo *getBoundBelCell(BelId bel) const override
     {
         NPNR_ASSERT(bel != BelId());
         return bel_to_cell[get_bel_flat_index(bel)];
     }
 
-    CellInfo *getConflictingBelCell(BelId bel) const
+    CellInfo *getConflictingBelCell(BelId bel) const override
     {
         NPNR_ASSERT(bel != BelId());
         return bel_to_cell[get_bel_flat_index(bel)];
@@ -567,7 +567,7 @@ struct Arch : BaseCtx
         return range;
     }
 
-    IdString getBelType(BelId bel) const
+    IdString getBelType(BelId bel) const override
     {
         NPNR_ASSERT(bel != BelId());
         IdString id;
@@ -581,7 +581,7 @@ struct Arch : BaseCtx
         return ret;
     }
 
-    WireId getBelPinWire(BelId bel, IdString pin) const;
+    WireId getBelPinWire(BelId bel, IdString pin) const override;
 
     BelPinRange getWireBelPins(WireId wire) const
     {
@@ -598,9 +598,9 @@ struct Arch : BaseCtx
 
     // -------------------------------------------------
 
-    WireId getWireByName(IdStringList name) const;
+    WireId getWireByName(IdStringList name) const override;
 
-    IdStringList getWireName(WireId wire) const
+    IdStringList getWireName(WireId wire) const override
     {
         NPNR_ASSERT(wire != WireId());
         std::array<IdString, 3> ids{x_ids.at(wire.location.x), y_ids.at(wire.location.y),
@@ -608,7 +608,7 @@ struct Arch : BaseCtx
         return IdStringList(ids);
     }
 
-    IdString getWireType(WireId wire) const
+    IdString getWireType(WireId wire) const override
     {
         NPNR_ASSERT(wire != WireId());
         IdString id;
@@ -618,9 +618,9 @@ struct Arch : BaseCtx
 
     std::vector<std::pair<IdString, std::string>> getWireAttrs(WireId) const;
 
-    uint32_t getWireChecksum(WireId wire) const { return wire.index; }
+    uint32_t getWireChecksum(WireId wire) const override { return wire.index; }
 
-    void bindWire(WireId wire, NetInfo *net, PlaceStrength strength)
+    void bindWire(WireId wire, NetInfo *net, PlaceStrength strength) override
     {
         NPNR_ASSERT(wire != WireId());
         NPNR_ASSERT(wire_to_net[wire] == nullptr);
@@ -630,7 +630,7 @@ struct Arch : BaseCtx
         refreshUiWire(wire);
     }
 
-    void unbindWire(WireId wire)
+    void unbindWire(WireId wire) override
     {
         NPNR_ASSERT(wire != WireId());
         NPNR_ASSERT(wire_to_net[wire] != nullptr);
@@ -650,13 +650,13 @@ struct Arch : BaseCtx
         refreshUiWire(wire);
     }
 
-    bool checkWireAvail(WireId wire) const
+    bool checkWireAvail(WireId wire) const override
     {
         NPNR_ASSERT(wire != WireId());
         return wire_to_net.find(wire) == wire_to_net.end() || wire_to_net.at(wire) == nullptr;
     }
 
-    NetInfo *getBoundWireNet(WireId wire) const
+    NetInfo *getBoundWireNet(WireId wire) const override
     {
         NPNR_ASSERT(wire != WireId());
         if (wire_to_net.find(wire) == wire_to_net.end())
@@ -665,18 +665,7 @@ struct Arch : BaseCtx
             return wire_to_net.at(wire);
     }
 
-    WireId getConflictingWireWire(WireId wire) const { return wire; }
-
-    NetInfo *getConflictingWireNet(WireId wire) const
-    {
-        NPNR_ASSERT(wire != WireId());
-        if (wire_to_net.find(wire) == wire_to_net.end())
-            return nullptr;
-        else
-            return wire_to_net.at(wire);
-    }
-
-    DelayInfo getWireDelay(WireId wire) const
+    DelayInfo getWireDelay(WireId wire) const override
     {
         DelayInfo delay;
         delay.min_delay = 0;
@@ -714,10 +703,8 @@ struct Arch : BaseCtx
 
     // -------------------------------------------------
 
-    PipId getPipByName(IdStringList name) const;
-    IdStringList getPipName(PipId pip) const;
-
-    IdString getPipType(PipId pip) const { return IdString(); }
+    PipId getPipByName(IdStringList name) const override;
+    IdStringList getPipName(PipId pip) const override;
 
     std::vector<std::pair<IdString, std::string>> getPipAttrs(PipId) const
     {
@@ -725,9 +712,9 @@ struct Arch : BaseCtx
         return ret;
     }
 
-    uint32_t getPipChecksum(PipId pip) const { return pip.index; }
+    uint32_t getPipChecksum(PipId pip) const override { return pip.index; }
 
-    void bindPip(PipId pip, NetInfo *net, PlaceStrength strength)
+    void bindPip(PipId pip, NetInfo *net, PlaceStrength strength) override
     {
         NPNR_ASSERT(pip != PipId());
         NPNR_ASSERT(pip_to_net[pip] == nullptr);
@@ -744,7 +731,7 @@ struct Arch : BaseCtx
         net->wires[dst].strength = strength;
     }
 
-    void unbindPip(PipId pip)
+    void unbindPip(PipId pip) override
     {
         NPNR_ASSERT(pip != PipId());
         NPNR_ASSERT(pip_to_net[pip] != nullptr);
@@ -760,13 +747,13 @@ struct Arch : BaseCtx
         pip_to_net[pip] = nullptr;
     }
 
-    bool checkPipAvail(PipId pip) const
+    bool checkPipAvail(PipId pip) const override
     {
         NPNR_ASSERT(pip != PipId());
         return pip_to_net.find(pip) == pip_to_net.end() || pip_to_net.at(pip) == nullptr;
     }
 
-    NetInfo *getBoundPipNet(PipId pip) const
+    NetInfo *getBoundPipNet(PipId pip) const override
     {
         NPNR_ASSERT(pip != PipId());
         if (pip_to_net.find(pip) == pip_to_net.end())
@@ -775,9 +762,7 @@ struct Arch : BaseCtx
             return pip_to_net.at(pip);
     }
 
-    WireId getConflictingPipWire(PipId pip) const { return WireId(); }
-
-    NetInfo *getConflictingPipNet(PipId pip) const
+    NetInfo *getConflictingPipNet(PipId pip) const override
     {
         NPNR_ASSERT(pip != PipId());
         if (pip_to_net.find(pip) == pip_to_net.end())
@@ -799,7 +784,7 @@ struct Arch : BaseCtx
         return range;
     }
 
-    WireId getPipSrcWire(PipId pip) const
+    WireId getPipSrcWire(PipId pip) const override
     {
         WireId wire;
         NPNR_ASSERT(pip != PipId());
@@ -808,7 +793,7 @@ struct Arch : BaseCtx
         return wire;
     }
 
-    WireId getPipDstWire(PipId pip) const
+    WireId getPipDstWire(PipId pip) const override
     {
         WireId wire;
         NPNR_ASSERT(pip != PipId());
@@ -817,7 +802,7 @@ struct Arch : BaseCtx
         return wire;
     }
 
-    DelayInfo getPipDelay(PipId pip) const
+    DelayInfo getPipDelay(PipId pip) const override
     {
         DelayInfo delay;
         NPNR_ASSERT(pip != PipId());
@@ -871,7 +856,7 @@ struct Arch : BaseCtx
         return chip_info->tiletype_names[loc_info(pip)->pip_data[pip.index].tile_type].get();
     }
 
-    Loc getPipLocation(PipId pip) const
+    Loc getPipLocation(PipId pip) const override
     {
         Loc loc;
         loc.x = pip.location.x;
@@ -889,12 +874,12 @@ struct Arch : BaseCtx
     std::string get_pio_function_name(BelId bel) const;
     BelId get_pio_by_function_name(const std::string &name) const;
 
-    PortType getBelPinType(BelId bel, IdString pin) const;
+    PortType getBelPinType(BelId bel, IdString pin) const override;
 
     // -------------------------------------------------
 
-    GroupId getGroupByName(IdStringList name) const;
-    IdStringList getGroupName(GroupId group) const;
+    GroupId getGroupByName(IdStringList name) const override;
+    IdStringList getGroupName(GroupId group) const override;
     std::vector<GroupId> getGroups() const;
     std::vector<BelId> getGroupBels(GroupId group) const;
     std::vector<WireId> getGroupWires(GroupId group) const;
@@ -903,46 +888,46 @@ struct Arch : BaseCtx
 
     // -------------------------------------------------
 
-    delay_t estimateDelay(WireId src, WireId dst) const;
-    ArcBounds getRouteBoundingBox(WireId src, WireId dst) const;
-    delay_t predictDelay(const NetInfo *net_info, const PortRef &sink) const;
-    delay_t getDelayEpsilon() const { return 20; }
-    delay_t getRipupDelayPenalty() const;
-    float getDelayNS(delay_t v) const { return v * 0.001; }
-    DelayInfo getDelayFromNS(float ns) const
+    delay_t estimateDelay(WireId src, WireId dst) const override;
+    ArcBounds getRouteBoundingBox(WireId src, WireId dst) const override;
+    delay_t predictDelay(const NetInfo *net_info, const PortRef &sink) const override;
+    delay_t getDelayEpsilon() const override { return 20; }
+    delay_t getRipupDelayPenalty() const override;
+    float getDelayNS(delay_t v) const override { return v * 0.001; }
+    DelayInfo getDelayFromNS(float ns) const override
     {
         DelayInfo del;
         del.min_delay = delay_t(ns * 1000);
         del.max_delay = delay_t(ns * 1000);
         return del;
     }
-    uint32_t getDelayChecksum(delay_t v) const { return v; }
-    bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const;
+    uint32_t getDelayChecksum(delay_t v) const override { return v; }
+    bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const override;
 
     // -------------------------------------------------
 
-    bool pack();
-    bool place();
-    bool route();
+    bool pack() override;
+    bool place() override;
+    bool route() override;
 
     // -------------------------------------------------
 
     std::vector<GraphicElement> getDecalGraphics(DecalId decal) const;
 
-    DecalXY getBelDecal(BelId bel) const;
-    DecalXY getWireDecal(WireId wire) const;
-    DecalXY getPipDecal(PipId pip) const;
-    DecalXY getGroupDecal(GroupId group) const;
+    DecalXY getBelDecal(BelId bel) const override;
+    DecalXY getWireDecal(WireId wire) const override;
+    DecalXY getPipDecal(PipId pip) const override;
+    DecalXY getGroupDecal(GroupId group) const override;
 
     // -------------------------------------------------
 
     // Get the delay through a cell from one port to another, returning false
     // if no path exists
-    bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const;
+    bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const override;
     // Get the port class, also setting clockInfoCount to the number of TimingClockingInfos associated with a port
-    TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const;
+    TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const override;
     // Get the TimingClockingInfo of a port
-    TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const;
+    TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const override;
     // Return true if a port is a net
     bool is_global_net(const NetInfo *net) const;
 
@@ -952,29 +937,28 @@ struct Arch : BaseCtx
 
     // -------------------------------------------------
     // Placement validity checks
-    bool isValidBelForCellType(IdString cell_type, BelId bel) const { return cell_type == getBelType(bel); }
 
     const std::vector<IdString> &getCellTypes() const { return cell_types; }
 
     std::vector<BelBucketId> getBelBuckets() const { return buckets; }
 
-    IdString getBelBucketName(BelBucketId bucket) const { return bucket.name; }
+    IdString getBelBucketName(BelBucketId bucket) const override { return bucket.name; }
 
-    BelBucketId getBelBucketByName(IdString name) const
+    BelBucketId getBelBucketByName(IdString name) const override
     {
         BelBucketId bucket;
         bucket.name = name;
         return bucket;
     }
 
-    BelBucketId getBelBucketForBel(BelId bel) const
+    BelBucketId getBelBucketForBel(BelId bel) const override
     {
         BelBucketId bucket;
         bucket.name = getBelType(bel);
         return bucket;
     }
 
-    BelBucketId getBelBucketForCellType(IdString cell_type) const
+    BelBucketId getBelBucketForCellType(IdString cell_type) const override
     {
         BelBucketId bucket;
         bucket.name = cell_type;
@@ -992,13 +976,13 @@ struct Arch : BaseCtx
         return bels;
     }
 
-    bool isValidBelForCell(CellInfo *cell, BelId bel) const;
-    bool isBelLocationValid(BelId bel) const;
+    bool isValidBelForCell(CellInfo *cell, BelId bel) const override;
+    bool isBelLocationValid(BelId bel) const override;
 
     // Helper function for above
     bool slices_compatible(const std::vector<const CellInfo *> &cells) const;
 
-    void assignArchInfo();
+    void assignArchInfo() override;
 
     void permute_luts();
 

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -435,7 +435,35 @@ template <> struct hash<NEXTPNR_NAMESPACE_PREFIX DelayKey>
 } // namespace std
 NEXTPNR_NAMESPACE_BEGIN
 
-struct Arch : BaseCtx
+struct ArchRanges
+{
+    // Bels
+    using AllBelsRange = BelRange;
+    using TileBelsRange = BelRange;
+    using BelAttrsRange = std::vector<std::pair<IdString, std::string>>;
+    using BelPinsRange = std::vector<IdString>;
+    // Wires
+    using AllWiresRange = WireRange;
+    using DownhillPipRange = PipRange;
+    using UphillPipRange = PipRange;
+    using WireBelPinRange = BelPinRange;
+    using WireAttrsRange = std::vector<std::pair<IdString, std::string>>;
+    // Pips
+    using AllPipsRange = AllPipRange;
+    using PipAttrsRange = std::vector<std::pair<IdString, std::string>>;
+    // Groups
+    using AllGroupsRange = std::vector<GroupId>;
+    using GroupBelsRange = std::vector<BelId>;
+    using GroupWiresRange = std::vector<WireId>;
+    using GroupPipsRange = std::vector<PipId>;
+    using GroupGroupsRange = std::vector<GroupId>;
+    // Placement validity
+    using CellTypeRange = const std::vector<IdString> &;
+    using BelBucketRange = std::vector<BelBucketId>;
+    using BucketBelRange = std::vector<BelId>;
+};
+
+struct Arch : ArchBase<ArchRanges>
 {
     const ChipInfoPOD *chip_info;
     const PackageInfoPOD *package_info;
@@ -532,7 +560,7 @@ struct Arch : BaseCtx
     }
 
     BelId getBelByLocation(Loc loc) const override;
-    BelRange getBelsByTile(int x, int y) const;
+    BelRange getBelsByTile(int x, int y) const override;
 
     bool getBelGlobalBuf(BelId bel) const override { return getBelType(bel) == id_DCCA; }
 
@@ -554,7 +582,7 @@ struct Arch : BaseCtx
         return bel_to_cell[get_bel_flat_index(bel)];
     }
 
-    BelRange getBels() const
+    BelRange getBels() const override
     {
         BelRange range;
         range.b.cursor_tile = 0;
@@ -575,7 +603,7 @@ struct Arch : BaseCtx
         return id;
     }
 
-    std::vector<std::pair<IdString, std::string>> getBelAttrs(BelId) const
+    std::vector<std::pair<IdString, std::string>> getBelAttrs(BelId) const override
     {
         std::vector<std::pair<IdString, std::string>> ret;
         return ret;
@@ -583,7 +611,7 @@ struct Arch : BaseCtx
 
     WireId getBelPinWire(BelId bel, IdString pin) const override;
 
-    BelPinRange getWireBelPins(WireId wire) const
+    BelPinRange getWireBelPins(WireId wire) const override
     {
         BelPinRange range;
         NPNR_ASSERT(wire != WireId());
@@ -616,7 +644,7 @@ struct Arch : BaseCtx
         return id;
     }
 
-    std::vector<std::pair<IdString, std::string>> getWireAttrs(WireId) const;
+    std::vector<std::pair<IdString, std::string>> getWireAttrs(WireId) const override;
 
     uint32_t getWireChecksum(WireId wire) const override { return wire.index; }
 
@@ -673,7 +701,7 @@ struct Arch : BaseCtx
         return delay;
     }
 
-    WireRange getWires() const
+    WireRange getWires() const override
     {
         WireRange range;
         range.b.cursor_tile = 0;
@@ -771,7 +799,7 @@ struct Arch : BaseCtx
             return pip_to_net.at(pip);
     }
 
-    AllPipRange getPips() const
+    AllPipRange getPips() const override
     {
         AllPipRange range;
         range.b.cursor_tile = 0;
@@ -819,7 +847,7 @@ struct Arch : BaseCtx
         return delay;
     }
 
-    PipRange getPipsDownhill(WireId wire) const
+    PipRange getPipsDownhill(WireId wire) const override
     {
         PipRange range;
         NPNR_ASSERT(wire != WireId());
@@ -830,7 +858,7 @@ struct Arch : BaseCtx
         return range;
     }
 
-    PipRange getPipsUphill(WireId wire) const
+    PipRange getPipsUphill(WireId wire) const override
     {
         PipRange range;
         NPNR_ASSERT(wire != WireId());
@@ -880,11 +908,11 @@ struct Arch : BaseCtx
 
     GroupId getGroupByName(IdStringList name) const override;
     IdStringList getGroupName(GroupId group) const override;
-    std::vector<GroupId> getGroups() const;
-    std::vector<BelId> getGroupBels(GroupId group) const;
-    std::vector<WireId> getGroupWires(GroupId group) const;
-    std::vector<PipId> getGroupPips(GroupId group) const;
-    std::vector<GroupId> getGroupGroups(GroupId group) const;
+    std::vector<GroupId> getGroups() const override;
+    std::vector<BelId> getGroupBels(GroupId group) const override;
+    std::vector<WireId> getGroupWires(GroupId group) const override;
+    std::vector<PipId> getGroupPips(GroupId group) const override;
+    std::vector<GroupId> getGroupGroups(GroupId group) const override;
 
     // -------------------------------------------------
 
@@ -938,9 +966,9 @@ struct Arch : BaseCtx
     // -------------------------------------------------
     // Placement validity checks
 
-    const std::vector<IdString> &getCellTypes() const { return cell_types; }
+    const std::vector<IdString> &getCellTypes() const override { return cell_types; }
 
-    std::vector<BelBucketId> getBelBuckets() const { return buckets; }
+    std::vector<BelBucketId> getBelBuckets() const override { return buckets; }
 
     IdString getBelBucketName(BelBucketId bucket) const override { return bucket.name; }
 
@@ -965,7 +993,7 @@ struct Arch : BaseCtx
         return bucket;
     }
 
-    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const
+    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const override
     {
         std::vector<BelId> bels;
         for (BelId bel : getBels()) {

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -465,7 +465,7 @@ struct ArchRanges
     using BucketBelRange = const std::vector<BelId> &;
 };
 
-struct Arch : ArchBase<ArchRanges>
+struct Arch : BaseArch<ArchRanges>
 {
     const ChipInfoPOD *chip_info;
     const PackageInfoPOD *package_info;
@@ -654,7 +654,7 @@ struct Arch : ArchBase<ArchRanges>
         if (pip != PipId()) {
             wire_fanout[getPipSrcWire(pip)]--;
         }
-        ArchBase::unbindWire(wire);
+        BaseArch::unbindWire(wire);
     }
 
     DelayInfo getWireDelay(WireId wire) const override
@@ -703,13 +703,13 @@ struct Arch : ArchBase<ArchRanges>
     void bindPip(PipId pip, NetInfo *net, PlaceStrength strength) override
     {
         wire_fanout[getPipSrcWire(pip)]++;
-        ArchBase::bindPip(pip, net, strength);
+        BaseArch::bindPip(pip, net, strength);
     }
 
     void unbindPip(PipId pip) override
     {
         wire_fanout[getPipSrcWire(pip)]--;
-        ArchBase::unbindPip(pip);
+        BaseArch::unbindPip(pip);
     }
 
     AllPipRange getPips() const override

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -461,8 +461,8 @@ struct ArchRanges
     using DecalGfxRange = std::vector<GraphicElement>;
     // Placement validity
     using CellTypeRange = const std::vector<IdString> &;
-    using BelBucketRange = std::vector<BelBucketId>;
-    using BucketBelRange = std::vector<BelId>;
+    using BelBucketRange = const std::vector<BelBucketId> &;
+    using BucketBelRange = const std::vector<BelId> &;
 };
 
 struct Arch : ArchBase<ArchRanges>
@@ -878,45 +878,6 @@ struct Arch : ArchBase<ArchRanges>
 
     // -------------------------------------------------
     // Placement validity checks
-
-    const std::vector<IdString> &getCellTypes() const override { return cell_types; }
-
-    std::vector<BelBucketId> getBelBuckets() const override { return buckets; }
-
-    IdString getBelBucketName(BelBucketId bucket) const override { return bucket.name; }
-
-    BelBucketId getBelBucketByName(IdString name) const override
-    {
-        BelBucketId bucket;
-        bucket.name = name;
-        return bucket;
-    }
-
-    BelBucketId getBelBucketForBel(BelId bel) const override
-    {
-        BelBucketId bucket;
-        bucket.name = getBelType(bel);
-        return bucket;
-    }
-
-    BelBucketId getBelBucketForCellType(IdString cell_type) const override
-    {
-        BelBucketId bucket;
-        bucket.name = cell_type;
-        return bucket;
-    }
-
-    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const override
-    {
-        std::vector<BelId> bels;
-        for (BelId bel : getBels()) {
-            if (getBelType(bel) == bucket.name) {
-                bels.push_back(bel);
-            }
-        }
-        return bels;
-    }
-
     bool isValidBelForCell(CellInfo *cell, BelId bel) const override;
     bool isBelLocationValid(BelId bel) const override;
 

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -437,33 +437,33 @@ NEXTPNR_NAMESPACE_BEGIN
 
 struct ArchRanges
 {
-    using ArchArgsType = ArchArgs;
+    using ArchArgsT = ArchArgs;
     // Bels
-    using AllBelsRange = BelRange;
-    using TileBelsRange = BelRange;
-    using BelAttrsRange = std::vector<std::pair<IdString, std::string>>;
-    using BelPinsRange = std::vector<IdString>;
+    using AllBelsRangeT = BelRange;
+    using TileBelsRangeT = BelRange;
+    using BelAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
+    using BelPinsRangeT = std::vector<IdString>;
     // Wires
-    using AllWiresRange = WireRange;
-    using DownhillPipRange = PipRange;
-    using UphillPipRange = PipRange;
-    using WireBelPinRange = BelPinRange;
-    using WireAttrsRange = std::vector<std::pair<IdString, std::string>>;
+    using AllWiresRangeT = WireRange;
+    using DownhillPipRangeT = PipRange;
+    using UphillPipRangeT = PipRange;
+    using WireBelPinRangeT = BelPinRange;
+    using WireAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
     // Pips
-    using AllPipsRange = AllPipRange;
-    using PipAttrsRange = std::vector<std::pair<IdString, std::string>>;
+    using AllPipsRangeT = AllPipRange;
+    using PipAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
     // Groups
-    using AllGroupsRange = std::vector<GroupId>;
-    using GroupBelsRange = std::vector<BelId>;
-    using GroupWiresRange = std::vector<WireId>;
-    using GroupPipsRange = std::vector<PipId>;
-    using GroupGroupsRange = std::vector<GroupId>;
+    using AllGroupsRangeT = std::vector<GroupId>;
+    using GroupBelsRangeT = std::vector<BelId>;
+    using GroupWiresRangeT = std::vector<WireId>;
+    using GroupPipsRangeT = std::vector<PipId>;
+    using GroupGroupsRangeT = std::vector<GroupId>;
     // Decals
-    using DecalGfxRange = std::vector<GraphicElement>;
+    using DecalGfxRangeT = std::vector<GraphicElement>;
     // Placement validity
-    using CellTypeRange = const std::vector<IdString> &;
-    using BelBucketRange = const std::vector<BelBucketId> &;
-    using BucketBelRange = const std::vector<BelId> &;
+    using CellTypeRangeT = const std::vector<IdString> &;
+    using BelBucketRangeT = const std::vector<BelBucketId> &;
+    using BucketBelRangeT = const std::vector<BelId> &;
 };
 
 struct Arch : BaseArch<ArchRanges>

--- a/ecp5/arch_pybindings.h
+++ b/ecp5/arch_pybindings.h
@@ -76,18 +76,6 @@ template <> struct string_converter<PipId>
     }
 };
 
-template <> struct string_converter<BelBucketId>
-{
-    BelBucketId from_str(Context *ctx, std::string name) { return ctx->getBelBucketByName(ctx->id(name)); }
-
-    std::string to_str(Context *ctx, BelBucketId id)
-    {
-        if (id == BelBucketId())
-            throw bad_wrap();
-        return ctx->getBelBucketName(id).str(ctx);
-    }
-};
-
 template <> struct string_converter<BelPin>
 {
     BelPin from_str(Context *ctx, std::string name)

--- a/ecp5/archdefs.h
+++ b/ecp5/archdefs.h
@@ -126,14 +126,7 @@ struct PipId
     }
 };
 
-struct BelBucketId
-{
-    IdString name;
-
-    bool operator==(const BelBucketId &other) const { return (name == other.name); }
-    bool operator!=(const BelBucketId &other) const { return (name != other.name); }
-    bool operator<(const BelBucketId &other) const { return name < other.name; }
-};
+typedef IdString BelBucketId;
 
 struct GroupId
 {
@@ -267,16 +260,6 @@ template <> struct hash<NEXTPNR_NAMESPACE_PREFIX DecalId>
         boost::hash_combine(seed, hash<NEXTPNR_NAMESPACE_PREFIX Location>()(decal.location));
         boost::hash_combine(seed, hash<int>()(decal.z));
         boost::hash_combine(seed, hash<bool>()(decal.active));
-        return seed;
-    }
-};
-
-template <> struct hash<NEXTPNR_NAMESPACE_PREFIX BelBucketId>
-{
-    std::size_t operator()(const NEXTPNR_NAMESPACE_PREFIX BelBucketId &partition) const noexcept
-    {
-        std::size_t seed = 0;
-        boost::hash_combine(seed, hash<NEXTPNR_NAMESPACE_PREFIX IdString>()(partition.name));
         return seed;
     }
 };

--- a/fpga_interchange/arch.cc
+++ b/fpga_interchange/arch.cc
@@ -483,8 +483,6 @@ ArcBounds Arch::getRouteBoundingBox(WireId src, WireId dst) const
     return {x0, y0, x1, y1};
 }
 
-delay_t Arch::getWireRipupDelayPenalty(WireId wire) const { return getRipupDelayPenalty(); }
-
 bool Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const { return false; }
 
 // -----------------------------------------------------------------------
@@ -529,7 +527,7 @@ DecalXY Arch::getGroupDecal(GroupId pip) const { return {}; };
 
 // -----------------------------------------------------------------------
 
-delay_t Arch::estimateDelay(WireId src, WireId dst, bool debug) const
+delay_t Arch::estimateDelay(WireId src, WireId dst) const
 {
     // FIXME: Implement something to push the A* router in the right direction.
     return 0;

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -118,6 +118,7 @@ struct CellTiming
 
 struct ArchRanges
 {
+    using ArchArgsType = ArchArgs;
     // Bels
     using AllBelsRange = const std::vector<BelId> &;
     using TileBelsRange = const std::vector<BelId> &;
@@ -213,8 +214,8 @@ struct Arch : ArchAPI<ArchRanges>
     std::string getChipName() const override { return chipName; }
 
     IdString archId() const override { return id("generic"); }
-    ArchArgs archArgs() const { return args; }
-    IdString archArgsToId(ArchArgs args) const { return id("none"); }
+    ArchArgs archArgs() const override { return args; }
+    IdString archArgsToId(ArchArgs args) const override { return id("none"); }
 
     int getGridDimX() const override { return gridDimX; }
     int getGridDimY() const override { return gridDimY; }

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -116,7 +116,37 @@ struct CellTiming
     std::unordered_map<IdString, std::vector<TimingClockingInfo>> clockingInfo;
 };
 
-struct Arch : BaseCtx
+struct ArchRanges
+{
+    // Bels
+    using AllBelsRange = const std::vector<BelId> &;
+    using TileBelsRange = const std::vector<BelId> &;
+    using BelAttrsRange = const std::map<IdString, std::string> &;
+    using BelPinsRange = std::vector<IdString>;
+    // Wires
+    using AllWiresRange = const std::vector<WireId> &;
+    using DownhillPipRange = const std::vector<PipId> &;
+    using UphillPipRange = const std::vector<PipId> &;
+    using WireBelPinRange = const std::vector<BelPin> &;
+    using WireAttrsRange = const std::map<IdString, std::string> &;
+    // Pips
+    using AllPipsRange = const std::vector<PipId> &;
+    using PipAttrsRange = const std::map<IdString, std::string> &;
+    // Groups
+    using AllGroupsRange = std::vector<GroupId>;
+    using GroupBelsRange = const std::vector<BelId> &;
+    using GroupWiresRange = const std::vector<WireId> &;
+    using GroupPipsRange = const std::vector<PipId> &;
+    using GroupGroupsRange = const std::vector<GroupId> &;
+    // Decals
+    using DecalGfxRange = const std::vector<GraphicElement> &;
+    // Placement validity
+    using CellTypeRange = std::vector<IdString>;
+    using BelBucketRange = std::vector<BelBucketId>;
+    using BucketBelRange = std::vector<BelId>;
+};
+
+struct Arch : ArchAPI<ArchRanges>
 {
     std::string chipName;
 
@@ -180,102 +210,102 @@ struct Arch : BaseCtx
     ArchArgs args;
     Arch(ArchArgs args);
 
-    std::string getChipName() const { return chipName; }
+    std::string getChipName() const override { return chipName; }
 
-    IdString archId() const { return id("generic"); }
+    IdString archId() const override { return id("generic"); }
     ArchArgs archArgs() const { return args; }
     IdString archArgsToId(ArchArgs args) const { return id("none"); }
 
-    int getGridDimX() const { return gridDimX; }
-    int getGridDimY() const { return gridDimY; }
-    int getTileBelDimZ(int x, int y) const { return tileBelDimZ[x][y]; }
-    int getTilePipDimZ(int x, int y) const { return tilePipDimZ[x][y]; }
-    char getNameDelimiter() const { return '/'; }
+    int getGridDimX() const override { return gridDimX; }
+    int getGridDimY() const override { return gridDimY; }
+    int getTileBelDimZ(int x, int y) const override { return tileBelDimZ[x][y]; }
+    int getTilePipDimZ(int x, int y) const override { return tilePipDimZ[x][y]; }
+    char getNameDelimiter() const override { return '/'; }
 
-    BelId getBelByName(IdStringList name) const;
-    IdStringList getBelName(BelId bel) const;
-    Loc getBelLocation(BelId bel) const;
-    BelId getBelByLocation(Loc loc) const;
-    const std::vector<BelId> &getBelsByTile(int x, int y) const;
-    bool getBelGlobalBuf(BelId bel) const;
-    uint32_t getBelChecksum(BelId bel) const;
-    void bindBel(BelId bel, CellInfo *cell, PlaceStrength strength);
-    void unbindBel(BelId bel);
-    bool checkBelAvail(BelId bel) const;
-    CellInfo *getBoundBelCell(BelId bel) const;
-    CellInfo *getConflictingBelCell(BelId bel) const;
-    const std::vector<BelId> &getBels() const;
-    IdString getBelType(BelId bel) const;
-    const std::map<IdString, std::string> &getBelAttrs(BelId bel) const;
-    WireId getBelPinWire(BelId bel, IdString pin) const;
-    PortType getBelPinType(BelId bel, IdString pin) const;
-    std::vector<IdString> getBelPins(BelId bel) const;
+    BelId getBelByName(IdStringList name) const override;
+    IdStringList getBelName(BelId bel) const override;
+    Loc getBelLocation(BelId bel) const override;
+    BelId getBelByLocation(Loc loc) const override;
+    const std::vector<BelId> &getBelsByTile(int x, int y) const override;
+    bool getBelGlobalBuf(BelId bel) const override;
+    uint32_t getBelChecksum(BelId bel) const override;
+    void bindBel(BelId bel, CellInfo *cell, PlaceStrength strength) override;
+    void unbindBel(BelId bel) override;
+    bool checkBelAvail(BelId bel) const override;
+    CellInfo *getBoundBelCell(BelId bel) const override;
+    CellInfo *getConflictingBelCell(BelId bel) const override;
+    const std::vector<BelId> &getBels() const override;
+    IdString getBelType(BelId bel) const override;
+    const std::map<IdString, std::string> &getBelAttrs(BelId bel) const override;
+    WireId getBelPinWire(BelId bel, IdString pin) const override;
+    PortType getBelPinType(BelId bel, IdString pin) const override;
+    std::vector<IdString> getBelPins(BelId bel) const override;
 
-    WireId getWireByName(IdStringList name) const;
-    IdStringList getWireName(WireId wire) const;
-    IdString getWireType(WireId wire) const;
-    const std::map<IdString, std::string> &getWireAttrs(WireId wire) const;
-    uint32_t getWireChecksum(WireId wire) const;
-    void bindWire(WireId wire, NetInfo *net, PlaceStrength strength);
-    void unbindWire(WireId wire);
-    bool checkWireAvail(WireId wire) const;
-    NetInfo *getBoundWireNet(WireId wire) const;
-    WireId getConflictingWireWire(WireId wire) const { return wire; }
-    NetInfo *getConflictingWireNet(WireId wire) const;
-    DelayInfo getWireDelay(WireId wire) const { return DelayInfo(); }
-    const std::vector<WireId> &getWires() const;
-    const std::vector<BelPin> &getWireBelPins(WireId wire) const;
+    WireId getWireByName(IdStringList name) const override;
+    IdStringList getWireName(WireId wire) const override;
+    IdString getWireType(WireId wire) const override;
+    const std::map<IdString, std::string> &getWireAttrs(WireId wire) const override;
+    uint32_t getWireChecksum(WireId wire) const override;
+    void bindWire(WireId wire, NetInfo *net, PlaceStrength strength) override;
+    void unbindWire(WireId wire) override;
+    bool checkWireAvail(WireId wire) const override;
+    NetInfo *getBoundWireNet(WireId wire) const override;
+    WireId getConflictingWireWire(WireId wire) const override { return wire; }
+    NetInfo *getConflictingWireNet(WireId wire) const override;
+    DelayInfo getWireDelay(WireId wire) const override { return DelayInfo(); }
+    const std::vector<WireId> &getWires() const override;
+    const std::vector<BelPin> &getWireBelPins(WireId wire) const override;
 
-    PipId getPipByName(IdStringList name) const;
-    IdStringList getPipName(PipId pip) const;
-    IdString getPipType(PipId pip) const;
-    const std::map<IdString, std::string> &getPipAttrs(PipId pip) const;
-    uint32_t getPipChecksum(PipId pip) const;
-    void bindPip(PipId pip, NetInfo *net, PlaceStrength strength);
-    void unbindPip(PipId pip);
-    bool checkPipAvail(PipId pip) const;
-    NetInfo *getBoundPipNet(PipId pip) const;
-    WireId getConflictingPipWire(PipId pip) const;
-    NetInfo *getConflictingPipNet(PipId pip) const;
-    const std::vector<PipId> &getPips() const;
-    Loc getPipLocation(PipId pip) const;
-    WireId getPipSrcWire(PipId pip) const;
-    WireId getPipDstWire(PipId pip) const;
-    DelayInfo getPipDelay(PipId pip) const;
-    const std::vector<PipId> &getPipsDownhill(WireId wire) const;
-    const std::vector<PipId> &getPipsUphill(WireId wire) const;
+    PipId getPipByName(IdStringList name) const override;
+    IdStringList getPipName(PipId pip) const override;
+    IdString getPipType(PipId pip) const override;
+    const std::map<IdString, std::string> &getPipAttrs(PipId pip) const override;
+    uint32_t getPipChecksum(PipId pip) const override;
+    void bindPip(PipId pip, NetInfo *net, PlaceStrength strength) override;
+    void unbindPip(PipId pip) override;
+    bool checkPipAvail(PipId pip) const override;
+    NetInfo *getBoundPipNet(PipId pip) const override;
+    WireId getConflictingPipWire(PipId pip) const override;
+    NetInfo *getConflictingPipNet(PipId pip) const override;
+    const std::vector<PipId> &getPips() const override;
+    Loc getPipLocation(PipId pip) const override;
+    WireId getPipSrcWire(PipId pip) const override;
+    WireId getPipDstWire(PipId pip) const override;
+    DelayInfo getPipDelay(PipId pip) const override;
+    const std::vector<PipId> &getPipsDownhill(WireId wire) const override;
+    const std::vector<PipId> &getPipsUphill(WireId wire) const override;
 
-    GroupId getGroupByName(IdStringList name) const;
-    IdStringList getGroupName(GroupId group) const;
-    std::vector<GroupId> getGroups() const;
-    const std::vector<BelId> &getGroupBels(GroupId group) const;
-    const std::vector<WireId> &getGroupWires(GroupId group) const;
-    const std::vector<PipId> &getGroupPips(GroupId group) const;
-    const std::vector<GroupId> &getGroupGroups(GroupId group) const;
+    GroupId getGroupByName(IdStringList name) const override;
+    IdStringList getGroupName(GroupId group) const override;
+    std::vector<GroupId> getGroups() const override;
+    const std::vector<BelId> &getGroupBels(GroupId group) const override;
+    const std::vector<WireId> &getGroupWires(GroupId group) const override;
+    const std::vector<PipId> &getGroupPips(GroupId group) const override;
+    const std::vector<GroupId> &getGroupGroups(GroupId group) const override;
 
-    delay_t estimateDelay(WireId src, WireId dst) const;
-    delay_t predictDelay(const NetInfo *net_info, const PortRef &sink) const;
-    delay_t getDelayEpsilon() const { return 0.001; }
-    delay_t getRipupDelayPenalty() const { return 0.015; }
-    float getDelayNS(delay_t v) const { return v; }
+    delay_t estimateDelay(WireId src, WireId dst) const override;
+    delay_t predictDelay(const NetInfo *net_info, const PortRef &sink) const override;
+    delay_t getDelayEpsilon() const override { return 0.001; }
+    delay_t getRipupDelayPenalty() const override { return 0.015; }
+    float getDelayNS(delay_t v) const override { return v; }
 
-    DelayInfo getDelayFromNS(float ns) const
+    DelayInfo getDelayFromNS(float ns) const override
     {
         DelayInfo del;
         del.delay = ns;
         return del;
     }
 
-    uint32_t getDelayChecksum(delay_t v) const { return 0; }
-    bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const;
+    uint32_t getDelayChecksum(delay_t v) const override { return 0; }
+    bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const override;
 
-    ArcBounds getRouteBoundingBox(WireId src, WireId dst) const;
+    ArcBounds getRouteBoundingBox(WireId src, WireId dst) const override;
 
-    bool pack();
-    bool place();
-    bool route();
+    bool pack() override;
+    bool place() override;
+    bool route() override;
 
-    std::vector<IdString> getCellTypes() const
+    std::vector<IdString> getCellTypes() const override
     {
         std::unordered_set<IdString> cell_types;
         for (auto bel : bels) {
@@ -285,17 +315,17 @@ struct Arch : BaseCtx
         return std::vector<IdString>{cell_types.begin(), cell_types.end()};
     }
 
-    std::vector<BelBucketId> getBelBuckets() const { return getCellTypes(); }
+    std::vector<BelBucketId> getBelBuckets() const override { return getCellTypes(); }
 
-    IdString getBelBucketName(BelBucketId bucket) const { return bucket; }
+    IdString getBelBucketName(BelBucketId bucket) const override { return bucket; }
 
-    BelBucketId getBelBucketByName(IdString bucket) const { return bucket; }
+    BelBucketId getBelBucketByName(IdString bucket) const override { return bucket; }
 
-    BelBucketId getBelBucketForBel(BelId bel) const { return getBelType(bel); }
+    BelBucketId getBelBucketForBel(BelId bel) const override { return getBelType(bel); }
 
-    BelBucketId getBelBucketForCellType(IdString cell_type) const { return cell_type; }
+    BelBucketId getBelBucketForCellType(IdString cell_type) const override { return cell_type; }
 
-    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const
+    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const override
     {
         std::vector<BelId> bels;
         for (BelId bel : getBels()) {
@@ -306,21 +336,21 @@ struct Arch : BaseCtx
         return bels;
     }
 
-    const std::vector<GraphicElement> &getDecalGraphics(DecalId decal) const;
-    DecalXY getBelDecal(BelId bel) const;
-    DecalXY getWireDecal(WireId wire) const;
-    DecalXY getPipDecal(PipId pip) const;
-    DecalXY getGroupDecal(GroupId group) const;
+    const std::vector<GraphicElement> &getDecalGraphics(DecalId decal) const override;
+    DecalXY getBelDecal(BelId bel) const override;
+    DecalXY getWireDecal(WireId wire) const override;
+    DecalXY getPipDecal(PipId pip) const override;
+    DecalXY getGroupDecal(GroupId group) const override;
 
-    bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const;
+    bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const override;
     // Get the port class, also setting clockInfoCount to the number of TimingClockingInfos associated with a port
-    TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const;
+    TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const override;
     // Get the TimingClockingInfo of a port
-    TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const;
+    TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const override;
 
-    bool isValidBelForCellType(IdString cell_type, BelId bel) const { return cell_type == getBelType(bel); }
-    bool isValidBelForCell(CellInfo *cell, BelId bel) const;
-    bool isBelLocationValid(BelId bel) const;
+    bool isValidBelForCellType(IdString cell_type, BelId bel) const override { return cell_type == getBelType(bel); }
+    bool isValidBelForCell(CellInfo *cell, BelId bel) const override;
+    bool isBelLocationValid(BelId bel) const override;
 
     static const std::string defaultPlacer;
     static const std::vector<std::string> availablePlacers;
@@ -329,7 +359,7 @@ struct Arch : BaseCtx
 
     // ---------------------------------------------------------------
     // Internal usage
-    void assignArchInfo();
+    void assignArchInfo() override;
     bool cellsCompatible(const CellInfo **cells, int count) const;
 };
 

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -118,33 +118,33 @@ struct CellTiming
 
 struct ArchRanges
 {
-    using ArchArgsType = ArchArgs;
+    using ArchArgsT = ArchArgs;
     // Bels
-    using AllBelsRange = const std::vector<BelId> &;
-    using TileBelsRange = const std::vector<BelId> &;
-    using BelAttrsRange = const std::map<IdString, std::string> &;
-    using BelPinsRange = std::vector<IdString>;
+    using AllBelsRangeT = const std::vector<BelId> &;
+    using TileBelsRangeT = const std::vector<BelId> &;
+    using BelAttrsRangeT = const std::map<IdString, std::string> &;
+    using BelPinsRangeT = std::vector<IdString>;
     // Wires
-    using AllWiresRange = const std::vector<WireId> &;
-    using DownhillPipRange = const std::vector<PipId> &;
-    using UphillPipRange = const std::vector<PipId> &;
-    using WireBelPinRange = const std::vector<BelPin> &;
-    using WireAttrsRange = const std::map<IdString, std::string> &;
+    using AllWiresRangeT = const std::vector<WireId> &;
+    using DownhillPipRangeT = const std::vector<PipId> &;
+    using UphillPipRangeT = const std::vector<PipId> &;
+    using WireBelPinRangeT = const std::vector<BelPin> &;
+    using WireAttrsRangeT = const std::map<IdString, std::string> &;
     // Pips
-    using AllPipsRange = const std::vector<PipId> &;
-    using PipAttrsRange = const std::map<IdString, std::string> &;
+    using AllPipsRangeT = const std::vector<PipId> &;
+    using PipAttrsRangeT = const std::map<IdString, std::string> &;
     // Groups
-    using AllGroupsRange = std::vector<GroupId>;
-    using GroupBelsRange = const std::vector<BelId> &;
-    using GroupWiresRange = const std::vector<WireId> &;
-    using GroupPipsRange = const std::vector<PipId> &;
-    using GroupGroupsRange = const std::vector<GroupId> &;
+    using AllGroupsRangeT = std::vector<GroupId>;
+    using GroupBelsRangeT = const std::vector<BelId> &;
+    using GroupWiresRangeT = const std::vector<WireId> &;
+    using GroupPipsRangeT = const std::vector<PipId> &;
+    using GroupGroupsRangeT = const std::vector<GroupId> &;
     // Decals
-    using DecalGfxRange = const std::vector<GraphicElement> &;
+    using DecalGfxRangeT = const std::vector<GraphicElement> &;
     // Placement validity
-    using CellTypeRange = std::vector<IdString>;
-    using BelBucketRange = std::vector<BelBucketId>;
-    using BucketBelRange = std::vector<BelId>;
+    using CellTypeRangeT = std::vector<IdString>;
+    using BelBucketRangeT = std::vector<BelBucketId>;
+    using BucketBelRangeT = std::vector<BelId>;
 };
 
 struct Arch : ArchAPI<ArchRanges>

--- a/gowin/arch.cc
+++ b/gowin/arch.cc
@@ -736,17 +736,8 @@ Arch::Arch(ArchArgs args) : args(args)
             }
         }
     }
-    // Dummy for empty decals
-    decal_graphics[IdString()];
-
-    std::unordered_set<IdString> bel_types;
-    for (BelId bel : getBels()) {
-        bel_types.insert(getBelType(bel));
-    }
-
-    for (IdString bel_type : bel_types) {
-        cell_types.push_back(bel_type);
-    }
+    BaseArch::init_cell_types();
+    BaseArch::init_bel_buckets();
 }
 
 void IdString::initialize_arch(const BaseCtx *ctx)
@@ -784,8 +775,6 @@ BelId Arch::getBelByLocation(Loc loc) const
 const std::vector<BelId> &Arch::getBelsByTile(int x, int y) const { return bels_by_tile.at(x).at(y); }
 
 bool Arch::getBelGlobalBuf(BelId bel) const { return bels.at(bel).gb; }
-
-uint32_t Arch::getBelChecksum(BelId bel) const { return bel.index; }
 
 void Arch::bindBel(BelId bel, CellInfo *cell, PlaceStrength strength)
 {
@@ -848,12 +837,6 @@ IdString Arch::getWireType(WireId wire) const { return wires.at(wire).type; }
 
 const std::map<IdString, std::string> &Arch::getWireAttrs(WireId wire) const { return wires.at(wire).attrs; }
 
-uint32_t Arch::getWireChecksum(WireId wire) const
-{
-    // FIXME
-    return 0;
-}
-
 void Arch::bindWire(WireId wire, NetInfo *net, PlaceStrength strength)
 {
     wires.at(wire).bound_net = net;
@@ -901,8 +884,6 @@ IdStringList Arch::getPipName(PipId pip) const { return IdStringList(pip); }
 IdString Arch::getPipType(PipId pip) const { return pips.at(pip).type; }
 
 const std::map<IdString, std::string> &Arch::getPipAttrs(PipId pip) const { return pips.at(pip).attrs; }
-
-uint32_t Arch::getPipChecksum(PipId wire) const { return wire.index; }
 
 void Arch::bindPip(PipId pip, NetInfo *net, PlaceStrength strength)
 {
@@ -1071,25 +1052,6 @@ bool Arch::route()
     archInfoToAttributes();
     return result;
 }
-
-// ---------------------------------------------------------------
-
-const std::vector<GraphicElement> &Arch::getDecalGraphics(DecalId decal) const
-{
-    if (!decal_graphics.count(decal)) {
-        std::cerr << "No decal named " << decal.str(this) << std::endl;
-        log_error("No decal named %s!\n", decal.c_str(this));
-    }
-    return decal_graphics.at(decal);
-}
-
-DecalXY Arch::getBelDecal(BelId bel) const { return bels.at(bel).decalxy; }
-
-DecalXY Arch::getWireDecal(WireId wire) const { return wires.at(wire).decalxy; }
-
-DecalXY Arch::getPipDecal(PipId pip) const { return pips.at(pip).decalxy; }
-
-DecalXY Arch::getGroupDecal(GroupId group) const { return groups.at(group).decalxy; }
 
 // ---------------------------------------------------------------
 

--- a/gowin/arch.h
+++ b/gowin/arch.h
@@ -243,7 +243,37 @@ struct CellTiming
     std::unordered_map<IdString, std::vector<TimingClockingInfo>> clockingInfo;
 };
 
-struct Arch : BaseCtx
+struct ArchRanges
+{
+    // Bels
+    using AllBelsRange = const std::vector<BelId> &;
+    using TileBelsRange = const std::vector<BelId> &;
+    using BelAttrsRange = const std::map<IdString, std::string> &;
+    using BelPinsRange = std::vector<IdString>;
+    // Wires
+    using AllWiresRange = const std::vector<WireId> &;
+    using DownhillPipRange = const std::vector<PipId> &;
+    using UphillPipRange = const std::vector<PipId> &;
+    using WireBelPinRange = const std::vector<BelPin> &;
+    using WireAttrsRange = const std::map<IdString, std::string> &;
+    // Pips
+    using AllPipsRange = const std::vector<PipId> &;
+    using PipAttrsRange = const std::map<IdString, std::string> &;
+    // Groups
+    using AllGroupsRange = std::vector<GroupId>;
+    using GroupBelsRange = const std::vector<BelId> &;
+    using GroupWiresRange = const std::vector<WireId> &;
+    using GroupPipsRange = const std::vector<PipId> &;
+    using GroupGroupsRange = const std::vector<GroupId> &;
+    // Decals
+    using DecalGfxRange = const std::vector<GraphicElement> &;
+    // Placement validity
+    using CellTypeRange = std::vector<IdString>;
+    using BelBucketRange = std::vector<BelBucketId>;
+    using BucketBelRange = std::vector<BelId>;
+};
+
+struct Arch : BaseArch<ArchRanges>
 {
     std::string family;
     std::string device;
@@ -313,14 +343,13 @@ struct Arch : BaseCtx
     ArchArgs args;
     Arch(ArchArgs args);
 
-    std::string getChipName() const { return device; }
+    std::string getChipName() const override { return device; }
 
-    IdString archId() const { return id("gowin"); }
     ArchArgs archArgs() const { return args; }
     IdString archArgsToId(ArchArgs args) const { return id("none"); }
 
-    int getGridDimX() const { return gridDimX; }
-    int getGridDimY() const { return gridDimY; }
+    int getGridDimX() const override { return gridDimX; }
+    int getGridDimY() const override { return gridDimY; }
     int getTileBelDimZ(int x, int y) const { return tileBelDimZ[x][y]; }
     int getTilePipDimZ(int x, int y) const { return tilePipDimZ[x][y]; }
     char getNameDelimiter() const
@@ -328,74 +357,71 @@ struct Arch : BaseCtx
         return ' '; /* use a non-existent delimiter as we aren't using IdStringLists yet */
     }
 
-    BelId getBelByName(IdStringList name) const;
-    IdStringList getBelName(BelId bel) const;
-    Loc getBelLocation(BelId bel) const;
-    BelId getBelByLocation(Loc loc) const;
-    const std::vector<BelId> &getBelsByTile(int x, int y) const;
-    bool getBelGlobalBuf(BelId bel) const;
-    uint32_t getBelChecksum(BelId bel) const;
-    void bindBel(BelId bel, CellInfo *cell, PlaceStrength strength);
-    void unbindBel(BelId bel);
-    bool checkBelAvail(BelId bel) const;
-    CellInfo *getBoundBelCell(BelId bel) const;
-    CellInfo *getConflictingBelCell(BelId bel) const;
-    const std::vector<BelId> &getBels() const;
-    IdString getBelType(BelId bel) const;
-    const std::map<IdString, std::string> &getBelAttrs(BelId bel) const;
-    WireId getBelPinWire(BelId bel, IdString pin) const;
-    PortType getBelPinType(BelId bel, IdString pin) const;
-    std::vector<IdString> getBelPins(BelId bel) const;
+    BelId getBelByName(IdStringList name) const override;
+    IdStringList getBelName(BelId bel) const override;
+    Loc getBelLocation(BelId bel) const override;
+    BelId getBelByLocation(Loc loc) const override;
+    const std::vector<BelId> &getBelsByTile(int x, int y) const override;
+    bool getBelGlobalBuf(BelId bel) const override;
+    void bindBel(BelId bel, CellInfo *cell, PlaceStrength strength) override;
+    void unbindBel(BelId bel) override;
+    bool checkBelAvail(BelId bel) const override;
+    CellInfo *getBoundBelCell(BelId bel) const override;
+    CellInfo *getConflictingBelCell(BelId bel) const override;
+    const std::vector<BelId> &getBels() const override;
+    IdString getBelType(BelId bel) const override;
+    const std::map<IdString, std::string> &getBelAttrs(BelId bel) const override;
+    WireId getBelPinWire(BelId bel, IdString pin) const override;
+    PortType getBelPinType(BelId bel, IdString pin) const override;
+    std::vector<IdString> getBelPins(BelId bel) const override;
 
-    WireId getWireByName(IdStringList name) const;
-    IdStringList getWireName(WireId wire) const;
-    IdString getWireType(WireId wire) const;
-    const std::map<IdString, std::string> &getWireAttrs(WireId wire) const;
-    uint32_t getWireChecksum(WireId wire) const;
-    void bindWire(WireId wire, NetInfo *net, PlaceStrength strength);
-    void unbindWire(WireId wire);
-    bool checkWireAvail(WireId wire) const;
-    NetInfo *getBoundWireNet(WireId wire) const;
-    WireId getConflictingWireWire(WireId wire) const { return wire; }
-    NetInfo *getConflictingWireNet(WireId wire) const;
-    DelayInfo getWireDelay(WireId wire) const { return DelayInfo(); }
-    const std::vector<WireId> &getWires() const;
-    const std::vector<BelPin> &getWireBelPins(WireId wire) const;
+    WireId getWireByName(IdStringList name) const override;
+    IdStringList getWireName(WireId wire) const override;
+    IdString getWireType(WireId wire) const override;
+    const std::map<IdString, std::string> &getWireAttrs(WireId wire) const override;
+    void bindWire(WireId wire, NetInfo *net, PlaceStrength strength) override;
+    void unbindWire(WireId wire) override;
+    bool checkWireAvail(WireId wire) const override;
+    NetInfo *getBoundWireNet(WireId wire) const override;
+    WireId getConflictingWireWire(WireId wire) const override { return wire; }
+    NetInfo *getConflictingWireNet(WireId wire) const override;
+    DelayInfo getWireDelay(WireId wire) const override { return DelayInfo(); }
+    const std::vector<WireId> &getWires() const override;
+    const std::vector<BelPin> &getWireBelPins(WireId wire) const override;
 
-    PipId getPipByName(IdStringList name) const;
-    IdStringList getPipName(PipId pip) const;
-    IdString getPipType(PipId pip) const;
-    const std::map<IdString, std::string> &getPipAttrs(PipId pip) const;
-    uint32_t getPipChecksum(PipId pip) const;
-    void bindPip(PipId pip, NetInfo *net, PlaceStrength strength);
-    void unbindPip(PipId pip);
-    bool checkPipAvail(PipId pip) const;
-    NetInfo *getBoundPipNet(PipId pip) const;
-    WireId getConflictingPipWire(PipId pip) const;
-    NetInfo *getConflictingPipNet(PipId pip) const;
-    const std::vector<PipId> &getPips() const;
-    Loc getPipLocation(PipId pip) const;
-    WireId getPipSrcWire(PipId pip) const;
-    WireId getPipDstWire(PipId pip) const;
-    DelayInfo getPipDelay(PipId pip) const;
-    const std::vector<PipId> &getPipsDownhill(WireId wire) const;
-    const std::vector<PipId> &getPipsUphill(WireId wire) const;
+    PipId getPipByName(IdStringList name) const override;
+    IdStringList getPipName(PipId pip) const override;
+    IdString getPipType(PipId pip) const override;
+    const std::map<IdString, std::string> &getPipAttrs(PipId pip) const override;
+    void bindPip(PipId pip, NetInfo *net, PlaceStrength strength) override;
+    void unbindPip(PipId pip) override;
+    bool checkPipAvail(PipId pip) const override;
+    NetInfo *getBoundPipNet(PipId pip) const override;
+    WireId getConflictingPipWire(PipId pip) const override;
+    NetInfo *getConflictingPipNet(PipId pip) const override;
+    const std::vector<PipId> &getPips() const override;
+    Loc getPipLocation(PipId pip) const override;
+    WireId getPipSrcWire(PipId pip) const override;
+    WireId getPipDstWire(PipId pip) const override;
+    DelayInfo getPipDelay(PipId pip) const override;
+    const std::vector<PipId> &getPipsDownhill(WireId wire) const override;
+    const std::vector<PipId> &getPipsUphill(WireId wire) const override;
 
-    GroupId getGroupByName(IdStringList name) const;
-    IdStringList getGroupName(GroupId group) const;
-    std::vector<GroupId> getGroups() const;
-    const std::vector<BelId> &getGroupBels(GroupId group) const;
-    const std::vector<WireId> &getGroupWires(GroupId group) const;
-    const std::vector<PipId> &getGroupPips(GroupId group) const;
-    const std::vector<GroupId> &getGroupGroups(GroupId group) const;
+    GroupId getGroupByName(IdStringList name) const override;
+    IdStringList getGroupName(GroupId group) const override;
+    std::vector<GroupId> getGroups() const override;
+    const std::vector<BelId> &getGroupBels(GroupId group) const override;
+    const std::vector<WireId> &getGroupWires(GroupId group) const override;
+    const std::vector<PipId> &getGroupPips(GroupId group) const override;
+    const std::vector<GroupId> &getGroupGroups(GroupId group) const override;
 
-    delay_t estimateDelay(WireId src, WireId dst) const;
-    delay_t predictDelay(const NetInfo *net_info, const PortRef &sink) const;
-    delay_t getDelayEpsilon() const { return 0.01; }
-    delay_t getRipupDelayPenalty() const { return 0.4; }
-    float getDelayNS(delay_t v) const { return v; }
+    delay_t estimateDelay(WireId src, WireId dst) const override;
+    delay_t predictDelay(const NetInfo *net_info, const PortRef &sink) const override;
+    delay_t getDelayEpsilon() const override { return 0.01; }
+    delay_t getRipupDelayPenalty() const override { return 0.4; }
+    float getDelayNS(delay_t v) const override { return v; }
 
-    DelayInfo getDelayFromNS(float ns) const
+    DelayInfo getDelayFromNS(float ns) const override
     {
         DelayInfo del;
         del.maxRaise = ns;
@@ -405,51 +431,20 @@ struct Arch : BaseCtx
         return del;
     }
 
-    uint32_t getDelayChecksum(delay_t v) const { return 0; }
-    bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const;
+    uint32_t getDelayChecksum(delay_t v) const override { return 0; }
+    bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const override;
 
-    ArcBounds getRouteBoundingBox(WireId src, WireId dst) const;
+    ArcBounds getRouteBoundingBox(WireId src, WireId dst) const override;
 
-    bool pack();
-    bool place();
-    bool route();
-
-    const std::vector<GraphicElement> &getDecalGraphics(DecalId decal) const;
-    DecalXY getBelDecal(BelId bel) const;
-    DecalXY getWireDecal(WireId wire) const;
-    DecalXY getPipDecal(PipId pip) const;
-    DecalXY getGroupDecal(GroupId group) const;
+    bool pack() override;
+    bool place() override;
+    bool route() override;
 
     bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const;
     // Get the port class, also setting clockInfoCount to the number of TimingClockingInfos associated with a port
     TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const;
     // Get the TimingClockingInfo of a port
     TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const;
-
-    bool isValidBelForCellType(IdString cell_type, BelId bel) const { return cell_type == getBelType(bel); }
-
-    const std::vector<IdString> &getCellTypes() const { return cell_types; }
-
-    std::vector<BelBucketId> getBelBuckets() const { return cell_types; }
-
-    IdString getBelBucketName(BelBucketId bucket) const { return bucket; }
-
-    BelBucketId getBelBucketByName(IdString name) const { return name; }
-
-    BelBucketId getBelBucketForBel(BelId bel) const { return getBelType(bel); }
-
-    BelBucketId getBelBucketForCellType(IdString cell_type) const { return cell_type; }
-
-    std::vector<BelId> getBelsInBucket(BelBucketId bucket) const
-    {
-        std::vector<BelId> bels;
-        for (BelId bel : getBels()) {
-            if (getBelType(bel) == bucket) {
-                bels.push_back(bel);
-            }
-        }
-        return bels;
-    }
 
     bool isValidBelForCell(CellInfo *cell, BelId bel) const;
     bool isBelLocationValid(BelId bel) const;

--- a/gowin/arch.h
+++ b/gowin/arch.h
@@ -245,6 +245,7 @@ struct CellTiming
 
 struct ArchRanges
 {
+    using ArchArgsType = ArchArgs;
     // Bels
     using AllBelsRange = const std::vector<BelId> &;
     using TileBelsRange = const std::vector<BelId> &;
@@ -345,8 +346,8 @@ struct Arch : BaseArch<ArchRanges>
 
     std::string getChipName() const override { return device; }
 
-    ArchArgs archArgs() const { return args; }
-    IdString archArgsToId(ArchArgs args) const { return id("none"); }
+    ArchArgs archArgs() const override { return args; }
+    IdString archArgsToId(ArchArgs args) const override { return id("none"); }
 
     int getGridDimX() const override { return gridDimX; }
     int getGridDimY() const override { return gridDimY; }

--- a/gowin/arch.h
+++ b/gowin/arch.h
@@ -245,33 +245,33 @@ struct CellTiming
 
 struct ArchRanges
 {
-    using ArchArgsType = ArchArgs;
+    using ArchArgsT = ArchArgs;
     // Bels
-    using AllBelsRange = const std::vector<BelId> &;
-    using TileBelsRange = const std::vector<BelId> &;
-    using BelAttrsRange = const std::map<IdString, std::string> &;
-    using BelPinsRange = std::vector<IdString>;
+    using AllBelsRangeT = const std::vector<BelId> &;
+    using TileBelsRangeT = const std::vector<BelId> &;
+    using BelAttrsRangeT = const std::map<IdString, std::string> &;
+    using BelPinsRangeT = std::vector<IdString>;
     // Wires
-    using AllWiresRange = const std::vector<WireId> &;
-    using DownhillPipRange = const std::vector<PipId> &;
-    using UphillPipRange = const std::vector<PipId> &;
-    using WireBelPinRange = const std::vector<BelPin> &;
-    using WireAttrsRange = const std::map<IdString, std::string> &;
+    using AllWiresRangeT = const std::vector<WireId> &;
+    using DownhillPipRangeT = const std::vector<PipId> &;
+    using UphillPipRangeT = const std::vector<PipId> &;
+    using WireBelPinRangeT = const std::vector<BelPin> &;
+    using WireAttrsRangeT = const std::map<IdString, std::string> &;
     // Pips
-    using AllPipsRange = const std::vector<PipId> &;
-    using PipAttrsRange = const std::map<IdString, std::string> &;
+    using AllPipsRangeT = const std::vector<PipId> &;
+    using PipAttrsRangeT = const std::map<IdString, std::string> &;
     // Groups
-    using AllGroupsRange = std::vector<GroupId>;
-    using GroupBelsRange = const std::vector<BelId> &;
-    using GroupWiresRange = const std::vector<WireId> &;
-    using GroupPipsRange = const std::vector<PipId> &;
-    using GroupGroupsRange = const std::vector<GroupId> &;
+    using AllGroupsRangeT = std::vector<GroupId>;
+    using GroupBelsRangeT = const std::vector<BelId> &;
+    using GroupWiresRangeT = const std::vector<WireId> &;
+    using GroupPipsRangeT = const std::vector<PipId> &;
+    using GroupGroupsRangeT = const std::vector<GroupId> &;
     // Decals
-    using DecalGfxRange = const std::vector<GraphicElement> &;
+    using DecalGfxRangeT = const std::vector<GraphicElement> &;
     // Placement validity
-    using CellTypeRange = std::vector<IdString>;
-    using BelBucketRange = std::vector<BelBucketId>;
-    using BucketBelRange = std::vector<BelId>;
+    using CellTypeRangeT = std::vector<IdString>;
+    using BelBucketRangeT = std::vector<BelBucketId>;
+    using BucketBelRangeT = std::vector<BelId>;
 };
 
 struct Arch : BaseArch<ArchRanges>

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -127,18 +127,8 @@ Arch::Arch(ArchArgs args) : args(args)
     pip_to_net.resize(chip_info->pip_data.size());
     switches_locked.resize(chip_info->num_switches);
 
-    std::unordered_set<IdString> bel_types;
-    for (BelId bel : getBels()) {
-        bel_types.insert(getBelType(bel));
-    }
-
-    for (IdString bel_type : bel_types) {
-        cell_types.push_back(bel_type);
-
-        BelBucketId bucket;
-        bucket.name = bel_type;
-        buckets.push_back(bucket);
-    }
+    BaseArch::init_cell_types();
+    BaseArch::init_bel_buckets();
 }
 
 // -----------------------------------------------------------------------

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -376,6 +376,7 @@ struct ArchArgs
 
 struct ArchRanges
 {
+    using ArchArgsType = ArchArgs;
     // Bels
     using AllBelsRange = BelRange;
     using TileBelsRange = BelRange;
@@ -434,8 +435,8 @@ struct Arch : BaseArch<ArchRanges>
 
     std::string getChipName() const override;
 
-    ArchArgs archArgs() const { return args; }
-    IdString archArgsToId(ArchArgs args) const;
+    ArchArgs archArgs() const override { return args; }
+    IdString archArgsToId(ArchArgs args) const override;
 
     // -------------------------------------------------
 

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -376,33 +376,33 @@ struct ArchArgs
 
 struct ArchRanges
 {
-    using ArchArgsType = ArchArgs;
+    using ArchArgsT = ArchArgs;
     // Bels
-    using AllBelsRange = BelRange;
-    using TileBelsRange = BelRange;
-    using BelAttrsRange = std::vector<std::pair<IdString, std::string>>;
-    using BelPinsRange = std::vector<IdString>;
+    using AllBelsRangeT = BelRange;
+    using TileBelsRangeT = BelRange;
+    using BelAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
+    using BelPinsRangeT = std::vector<IdString>;
     // Wires
-    using AllWiresRange = WireRange;
-    using DownhillPipRange = PipRange;
-    using UphillPipRange = PipRange;
-    using WireBelPinRange = BelPinRange;
-    using WireAttrsRange = std::vector<std::pair<IdString, std::string>>;
+    using AllWiresRangeT = WireRange;
+    using DownhillPipRangeT = PipRange;
+    using UphillPipRangeT = PipRange;
+    using WireBelPinRangeT = BelPinRange;
+    using WireAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
     // Pips
-    using AllPipsRange = AllPipRange;
-    using PipAttrsRange = std::vector<std::pair<IdString, std::string>>;
+    using AllPipsRangeT = AllPipRange;
+    using PipAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
     // Groups
-    using AllGroupsRange = std::vector<GroupId>;
-    using GroupBelsRange = std::vector<BelId>;
-    using GroupWiresRange = std::vector<WireId>;
-    using GroupPipsRange = std::vector<PipId>;
-    using GroupGroupsRange = std::vector<GroupId>;
+    using AllGroupsRangeT = std::vector<GroupId>;
+    using GroupBelsRangeT = std::vector<BelId>;
+    using GroupWiresRangeT = std::vector<WireId>;
+    using GroupPipsRangeT = std::vector<PipId>;
+    using GroupGroupsRangeT = std::vector<GroupId>;
     // Decals
-    using DecalGfxRange = std::vector<GraphicElement>;
+    using DecalGfxRangeT = std::vector<GraphicElement>;
     // Placement validity
-    using CellTypeRange = const std::vector<IdString> &;
-    using BelBucketRange = const std::vector<BelBucketId> &;
-    using BucketBelRange = const std::vector<BelId> &;
+    using CellTypeRangeT = const std::vector<IdString> &;
+    using BelBucketRangeT = const std::vector<BelBucketId> &;
+    using BucketBelRangeT = const std::vector<BelId> &;
 };
 
 struct Arch : BaseArch<ArchRanges>

--- a/ice40/arch_pybindings.h
+++ b/ice40/arch_pybindings.h
@@ -76,18 +76,6 @@ template <> struct string_converter<PipId>
     }
 };
 
-template <> struct string_converter<BelBucketId>
-{
-    BelBucketId from_str(Context *ctx, std::string name) { return ctx->getBelBucketByName(ctx->id(name)); }
-
-    std::string to_str(Context *ctx, BelBucketId id)
-    {
-        if (id == BelBucketId())
-            throw bad_wrap();
-        return ctx->getBelBucketName(id).str(ctx);
-    }
-};
-
 template <> struct string_converter<BelPin>
 {
     BelPin from_str(Context *ctx, std::string name)

--- a/ice40/archdefs.h
+++ b/ice40/archdefs.h
@@ -170,14 +170,7 @@ struct ArchCellInfo
     };
 };
 
-struct BelBucketId
-{
-    IdString name;
-
-    bool operator==(const BelBucketId &other) const { return (name == other.name); }
-    bool operator!=(const BelBucketId &other) const { return (name != other.name); }
-    bool operator<(const BelBucketId &other) const { return name < other.name; }
-};
+typedef IdString BelBucketId;
 
 NEXTPNR_NAMESPACE_END
 
@@ -219,16 +212,6 @@ template <> struct hash<NEXTPNR_NAMESPACE_PREFIX DecalId>
         std::size_t seed = 0;
         boost::hash_combine(seed, hash<int>()(decal.type));
         boost::hash_combine(seed, hash<int>()(decal.index));
-        return seed;
-    }
-};
-
-template <> struct hash<NEXTPNR_NAMESPACE_PREFIX BelBucketId>
-{
-    std::size_t operator()(const NEXTPNR_NAMESPACE_PREFIX BelBucketId &bucket) const noexcept
-    {
-        std::size_t seed = 0;
-        boost::hash_combine(seed, hash<NEXTPNR_NAMESPACE_PREFIX IdString>()(bucket.name));
         return seed;
     }
 };

--- a/nexus/arch.cc
+++ b/nexus/arch.cc
@@ -169,18 +169,8 @@ Arch::Arch(ArchArgs args) : args(args)
     if (!speed_grade)
         log_error("Unknown speed grade '%s'.\n", speed.c_str());
 
-    std::unordered_set<IdString> bel_types;
-    for (BelId bel : getBels()) {
-        bel_types.insert(getBelType(bel));
-    }
-
-    for (IdString bel_type : bel_types) {
-        cell_types.push_back(bel_type);
-
-        BelBucketId bucket;
-        bucket.name = bel_type;
-        buckets.push_back(bucket);
-    }
+    BaseArch::init_cell_types();
+    BaseArch::init_bel_buckets();
 }
 
 // -----------------------------------------------------------------------
@@ -321,8 +311,6 @@ WireId Arch::getWireByName(IdStringList name) const
     }
     return WireId();
 }
-
-IdString Arch::getWireType(WireId wire) const { return id("WIRE"); }
 
 std::vector<std::pair<IdString, std::string>> Arch::getWireAttrs(WireId wire) const
 {

--- a/nexus/arch.h
+++ b/nexus/arch.h
@@ -857,6 +857,7 @@ struct ArchArgs
 
 struct ArchRanges
 {
+    using ArchArgsType = ArchArgs;
     // Bels
     using AllBelsRange = BelRange;
     using TileBelsRange = std::vector<BelId>;
@@ -934,8 +935,8 @@ struct Arch : BaseArch<ArchRanges>
 
     std::string getChipName() const override;
 
-    ArchArgs archArgs() const { return args; }
-    IdString archArgsToId(ArchArgs args) const;
+    ArchArgs archArgs() const override { return args; }
+    IdString archArgsToId(ArchArgs args) const override;
 
     int getGridDimX() const override { return chip_info->width; }
     int getGridDimY() const override { return chip_info->height; }

--- a/nexus/arch.h
+++ b/nexus/arch.h
@@ -857,33 +857,33 @@ struct ArchArgs
 
 struct ArchRanges
 {
-    using ArchArgsType = ArchArgs;
+    using ArchArgsT = ArchArgs;
     // Bels
-    using AllBelsRange = BelRange;
-    using TileBelsRange = std::vector<BelId>;
-    using BelAttrsRange = std::vector<std::pair<IdString, std::string>>;
-    using BelPinsRange = std::vector<IdString>;
+    using AllBelsRangeT = BelRange;
+    using TileBelsRangeT = std::vector<BelId>;
+    using BelAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
+    using BelPinsRangeT = std::vector<IdString>;
     // Wires
-    using AllWiresRange = WireRange;
-    using DownhillPipRange = UpDownhillPipRange;
-    using UphillPipRange = UpDownhillPipRange;
-    using WireBelPinRange = BelPinRange;
-    using WireAttrsRange = std::vector<std::pair<IdString, std::string>>;
+    using AllWiresRangeT = WireRange;
+    using DownhillPipRangeT = UpDownhillPipRange;
+    using UphillPipRangeT = UpDownhillPipRange;
+    using WireBelPinRangeT = BelPinRange;
+    using WireAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
     // Pips
-    using AllPipsRange = AllPipRange;
-    using PipAttrsRange = std::vector<std::pair<IdString, std::string>>;
+    using AllPipsRangeT = AllPipRange;
+    using PipAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
     // Groups
-    using AllGroupsRange = std::vector<GroupId>;
-    using GroupBelsRange = std::vector<BelId>;
-    using GroupWiresRange = std::vector<WireId>;
-    using GroupPipsRange = std::vector<PipId>;
-    using GroupGroupsRange = std::vector<GroupId>;
+    using AllGroupsRangeT = std::vector<GroupId>;
+    using GroupBelsRangeT = std::vector<BelId>;
+    using GroupWiresRangeT = std::vector<WireId>;
+    using GroupPipsRangeT = std::vector<PipId>;
+    using GroupGroupsRangeT = std::vector<GroupId>;
     // Decals
-    using DecalGfxRange = std::vector<GraphicElement>;
+    using DecalGfxRangeT = std::vector<GraphicElement>;
     // Placement validity
-    using CellTypeRange = const std::vector<IdString> &;
-    using BelBucketRange = const std::vector<BelBucketId> &;
-    using BucketBelRange = const std::vector<BelId> &;
+    using CellTypeRangeT = const std::vector<IdString> &;
+    using BelBucketRangeT = const std::vector<BelBucketId> &;
+    using BucketBelRangeT = const std::vector<BelId> &;
 };
 
 struct Arch : BaseArch<ArchRanges>

--- a/nexus/arch_pybindings.cc
+++ b/nexus/arch_pybindings.cc
@@ -53,7 +53,6 @@ void arch_wrap_python(py::module &m)
 
     typedef UpDownhillPipRange UphillPipRange;
     typedef UpDownhillPipRange DownhillPipRange;
-    typedef WireBelPinRange BelPinRange;
 
     typedef const std::vector<BelBucketId> &BelBucketRange;
     typedef const std::vector<BelId> &BelRangeForBelBucket;
@@ -64,7 +63,7 @@ void arch_wrap_python(py::module &m)
     WRAP_RANGE(m, Wire, conv_to_str<WireId>);
     WRAP_RANGE(m, AllPip, conv_to_str<PipId>);
     WRAP_RANGE(m, UpDownhillPip, conv_to_str<PipId>);
-    WRAP_RANGE(m, WireBelPin, wrap_context<BelPin>);
+    WRAP_RANGE(m, BelPin, wrap_context<BelPin>);
 
     WRAP_MAP_UPTR(m, CellMap, "IdCellMap");
     WRAP_MAP_UPTR(m, NetMap, "IdNetMap");

--- a/nexus/arch_pybindings.h
+++ b/nexus/arch_pybindings.h
@@ -76,18 +76,6 @@ template <> struct string_converter<PipId>
     }
 };
 
-template <> struct string_converter<BelBucketId>
-{
-    BelBucketId from_str(Context *ctx, std::string name) { return ctx->getBelBucketByName(ctx->id(name)); }
-
-    std::string to_str(Context *ctx, BelBucketId id)
-    {
-        if (id == BelBucketId())
-            throw bad_wrap();
-        return ctx->getBelBucketName(id).str(ctx);
-    }
-};
-
 template <> struct string_converter<BelPin>
 {
     BelPin from_str(Context *ctx, std::string name)

--- a/nexus/archdefs.h
+++ b/nexus/archdefs.h
@@ -114,14 +114,7 @@ struct PipId
     }
 };
 
-struct BelBucketId
-{
-    IdString name;
-
-    bool operator==(const BelBucketId &other) const { return (name == other.name); }
-    bool operator!=(const BelBucketId &other) const { return (name != other.name); }
-    bool operator<(const BelBucketId &other) const { return name < other.name; }
-};
+typedef IdString BelBucketId;
 
 struct GroupId
 {
@@ -256,16 +249,6 @@ template <> struct hash<NEXTPNR_NAMESPACE_PREFIX DecalId>
         std::size_t seed = 0;
         boost::hash_combine(seed, hash<int>()(decal.type));
         boost::hash_combine(seed, hash<int>()(decal.index));
-        return seed;
-    }
-};
-
-template <> struct hash<NEXTPNR_NAMESPACE_PREFIX BelBucketId>
-{
-    std::size_t operator()(const NEXTPNR_NAMESPACE_PREFIX BelBucketId &bucket) const noexcept
-    {
-        std::size_t seed = 0;
-        boost::hash_combine(seed, hash<NEXTPNR_NAMESPACE_PREFIX IdString>()(bucket.name));
         return seed;
     }
 };


### PR DESCRIPTION
This creates a new `BaseArch` layer which `Arch` inherits from, and which implements the `Arch` functions virtually with a struct of `using`s as a template parameter for the functions where the return type is Arch-defined (as suggested in https://github.com/SymbiFlow/nextpnr/pull/195#discussion_r566203422 ).

Some further template magic is used to provide default implementations when the range types comply to certain traits or error out otherwise.

Things still to consider:
 - [ ] arches other than ECP5
 - [ ] more default implementations of functions
 - [ ] should BelId/WireId/PipId/etc also become template parameters to BaseArch, or will that make downstream code unwieldy

cc @ravenslofty @litghost 