### PR TITLE
Mark IdString and IdStringList single argument constructors explicit.

### DIFF
--- a/common/archcheck.cc
+++ b/common/archcheck.cc
@@ -135,8 +135,10 @@ void archcheck_locs(const Context *ctx)
 //
 // This allows a fast way to check getPipsDownhill/getPipsUphill from getPips,
 // without balloning memory usage.
-struct LruWireCacheMap {
-    LruWireCacheMap(const Context *ctx, size_t cache_size) : ctx(ctx), cache_size(cache_size) {
+struct LruWireCacheMap
+{
+    LruWireCacheMap(const Context *ctx, size_t cache_size) : ctx(ctx), cache_size(cache_size)
+    {
         cache_hits = 0;
         cache_misses = 0;
         cache_evictions = 0;
@@ -159,7 +161,8 @@ struct LruWireCacheMap {
     std::unordered_map<PipId, WireId> pips_downhill;
     std::unordered_map<PipId, WireId> pips_uphill;
 
-    void removeWireFromCache(WireId wire_to_remove) {
+    void removeWireFromCache(WireId wire_to_remove)
+    {
         for (PipId pip : ctx->getPipsDownhill(wire_to_remove)) {
             log_assert(pips_downhill.erase(pip) == 1);
         }
@@ -169,7 +172,8 @@ struct LruWireCacheMap {
         }
     }
 
-    void addWireToCache(WireId wire) {
+    void addWireToCache(WireId wire)
+    {
         for (PipId pip : ctx->getPipsDownhill(wire)) {
             auto result = pips_downhill.emplace(pip, wire);
             log_assert(result.second);
@@ -181,12 +185,13 @@ struct LruWireCacheMap {
         }
     }
 
-    void populateCache(WireId wire) {
+    void populateCache(WireId wire)
+    {
         // Put this wire at the end of last_access_list.
         auto iter = last_access_list.emplace(last_access_list.end(), wire);
         last_access_map.emplace(wire, iter);
 
-        if(last_access_list.size() > cache_size) {
+        if (last_access_list.size() > cache_size) {
             // Cache is full, remove front of last_access_list.
             cache_evictions += 1;
             WireId wire_to_remove = last_access_list.front();
@@ -202,9 +207,10 @@ struct LruWireCacheMap {
     // Determine if wire is in the cache.  If wire is not in the cache,
     // adds the wire to the cache, and potentially evicts the oldest wire if
     // cache is now full.
-    void checkCache(WireId wire) {
+    void checkCache(WireId wire)
+    {
         auto iter = last_access_map.find(wire);
-        if(iter == last_access_map.end()) {
+        if (iter == last_access_map.end()) {
             cache_misses += 1;
             populateCache(wire);
         } else {
@@ -215,18 +221,21 @@ struct LruWireCacheMap {
     }
 
     // Returns true if pip is uphill of wire (e.g. pip in getPipsUphill(wire)).
-    bool isPipUphill(PipId pip, WireId wire) {
+    bool isPipUphill(PipId pip, WireId wire)
+    {
         checkCache(wire);
         return pips_uphill.at(pip) == wire;
     }
 
     // Returns true if pip is downhill of wire (e.g. pip in getPipsDownhill(wire)).
-    bool isPipDownhill(PipId pip, WireId wire) {
+    bool isPipDownhill(PipId pip, WireId wire)
+    {
         checkCache(wire);
         return pips_downhill.at(pip) == wire;
     }
 
-    void cache_info() const {
+    void cache_info() const
+    {
         log_info("Cache hits: %zu\n", cache_hits);
         log_info("Cache misses: %zu\n", cache_misses);
         log_info("Cache evictions: %zu\n", cache_evictions);
@@ -285,7 +294,7 @@ void archcheck_conn(const Context *ctx)
     // gains by avoiding the full pip -> wire map, and still preserves a fast
     // pip -> wire, assuming that pips are returned from getPips with some
     // chip locality.
-    LruWireCacheMap pip_cache(ctx, /*cache_size=*/64*1024);
+    LruWireCacheMap pip_cache(ctx, /*cache_size=*/64 * 1024);
     log_info("Checking all PIPs...\n");
     for (PipId pip : ctx->getPips()) {
         WireId src_wire = ctx->getPipSrcWire(pip);

--- a/common/nextpnr.cc
+++ b/common/nextpnr.cc
@@ -805,9 +805,9 @@ void BaseCtx::attributesToArchInfo()
                 std::string pip = strs[i * 3 + 1];
                 PlaceStrength strength = (PlaceStrength)std::stoi(strs[i * 3 + 2]);
                 if (pip.empty())
-                    getCtx()->bindWire(getCtx()->getWireByName(id(wire)), ni, strength);
+                    getCtx()->bindWire(getCtx()->getWireByName(IdStringList::parse(getCtx(), wire)), ni, strength);
                 else
-                    getCtx()->bindPip(getCtx()->getPipByName(id(pip)), ni, strength);
+                    getCtx()->bindPip(getCtx()->getPipByName(IdStringList::parse(getCtx(), pip)), ni, strength);
             }
         }
     }

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -110,7 +110,8 @@ struct IdString
 
     static void initialize_add(const BaseCtx *ctx, const char *s, int idx);
 
-    constexpr IdString(int index = 0) : index(index) {}
+    constexpr IdString() : index(0) {}
+    explicit constexpr IdString(int index) : index(index) {}
 
     void set(const BaseCtx *ctx, const std::string &s);
 
@@ -229,9 +230,9 @@ struct IdStringList
     SSOArray<IdString, 4> ids;
 
     IdStringList(){};
-    IdStringList(size_t n) : ids(n, IdString()){};
-    IdStringList(IdString id) : ids(1, id){};
-    template <typename Tlist> IdStringList(const Tlist &list) : ids(list){};
+    explicit IdStringList(size_t n) : ids(n, IdString()){};
+    explicit IdStringList(IdString id) : ids(1, id){};
+    template <typename Tlist> explicit IdStringList(const Tlist &list) : ids(list){};
 
     static IdStringList parse(Context *ctx, const std::string &str);
     void build_str(const Context *ctx, std::string &str) const;

--- a/generic/arch.cc
+++ b/generic/arch.cc
@@ -129,7 +129,7 @@ void Arch::addBelInput(IdStringList bel, IdString name, IdStringList wire)
 {
     NPNR_ASSERT(bel_info(bel).pins.count(name) == 0);
     PinInfo &pi = bel_info(bel).pins[name];
-    pi.name = name;
+    pi.name = IdStringList(name);
     pi.wire = wire;
     pi.type = PORT_IN;
 
@@ -141,7 +141,7 @@ void Arch::addBelOutput(IdStringList bel, IdString name, IdStringList wire)
 {
     NPNR_ASSERT(bel_info(bel).pins.count(name) == 0);
     PinInfo &pi = bel_info(bel).pins[name];
-    pi.name = name;
+    pi.name = IdStringList(name);
     pi.wire = wire;
     pi.type = PORT_OUT;
 
@@ -153,7 +153,7 @@ void Arch::addBelInout(IdStringList bel, IdString name, IdStringList wire)
 {
     NPNR_ASSERT(bel_info(bel).pins.count(name) == 0);
     PinInfo &pi = bel_info(bel).pins[name];
-    pi.name = name;
+    pi.name = IdStringList(name);
     pi.wire = wire;
     pi.type = PORT_INOUT;
 
@@ -216,12 +216,9 @@ void Arch::setDelayScaling(double scale, double offset)
     args.delayOffset = offset;
 }
 
-void Arch::addCellTimingClock(IdStringList cell, IdString port)
-{
-    cellTiming[cell].portClasses[port] = TMG_CLOCK_INPUT;
-}
+void Arch::addCellTimingClock(IdString cell, IdString port) { cellTiming[cell].portClasses[port] = TMG_CLOCK_INPUT; }
 
-void Arch::addCellTimingDelay(IdStringList cell, IdString fromPort, IdString toPort, DelayInfo delay)
+void Arch::addCellTimingDelay(IdString cell, IdString fromPort, IdString toPort, DelayInfo delay)
 {
     if (get_or_default(cellTiming[cell].portClasses, fromPort, TMG_IGNORE) == TMG_IGNORE)
         cellTiming[cell].portClasses[fromPort] = TMG_COMB_INPUT;
@@ -230,7 +227,7 @@ void Arch::addCellTimingDelay(IdStringList cell, IdString fromPort, IdString toP
     cellTiming[cell].combDelays[CellDelayKey{fromPort, toPort}] = delay;
 }
 
-void Arch::addCellTimingSetupHold(IdStringList cell, IdString port, IdString clock, DelayInfo setup, DelayInfo hold)
+void Arch::addCellTimingSetupHold(IdString cell, IdString port, IdString clock, DelayInfo setup, DelayInfo hold)
 {
     TimingClockingInfo ci;
     ci.clock_port = clock;
@@ -241,7 +238,7 @@ void Arch::addCellTimingSetupHold(IdStringList cell, IdString port, IdString clo
     cellTiming[cell].portClasses[port] = TMG_REGISTER_INPUT;
 }
 
-void Arch::addCellTimingClockToOut(IdStringList cell, IdString port, IdString clock, DelayInfo clktoq)
+void Arch::addCellTimingClockToOut(IdString cell, IdString port, IdString clock, DelayInfo clktoq)
 {
     TimingClockingInfo ci;
     ci.clock_port = clock;
@@ -256,7 +253,7 @@ void Arch::addCellTimingClockToOut(IdStringList cell, IdString port, IdString cl
 Arch::Arch(ArchArgs args) : chipName("generic"), args(args)
 {
     // Dummy for empty decals
-    decal_graphics[IdString()];
+    decal_graphics[DecalId()];
 }
 
 void IdString::initialize_arch(const BaseCtx *ctx) {}

--- a/generic/arch.cc
+++ b/generic/arch.cc
@@ -129,7 +129,7 @@ void Arch::addBelInput(IdStringList bel, IdString name, IdStringList wire)
 {
     NPNR_ASSERT(bel_info(bel).pins.count(name) == 0);
     PinInfo &pi = bel_info(bel).pins[name];
-    pi.name = IdStringList(name);
+    pi.name = name;
     pi.wire = wire;
     pi.type = PORT_IN;
 
@@ -141,7 +141,7 @@ void Arch::addBelOutput(IdStringList bel, IdString name, IdStringList wire)
 {
     NPNR_ASSERT(bel_info(bel).pins.count(name) == 0);
     PinInfo &pi = bel_info(bel).pins[name];
-    pi.name = IdStringList(name);
+    pi.name = name;
     pi.wire = wire;
     pi.type = PORT_OUT;
 
@@ -153,7 +153,7 @@ void Arch::addBelInout(IdStringList bel, IdString name, IdStringList wire)
 {
     NPNR_ASSERT(bel_info(bel).pins.count(name) == 0);
     PinInfo &pi = bel_info(bel).pins[name];
-    pi.name = IdStringList(name);
+    pi.name = name;
     pi.wire = wire;
     pi.type = PORT_INOUT;
 

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -141,7 +141,7 @@ struct Arch : BaseCtx
     std::vector<std::vector<int>> tileBelDimZ;
     std::vector<std::vector<int>> tilePipDimZ;
 
-    std::unordered_map<IdStringList, CellTiming> cellTiming;
+    std::unordered_map<IdString, CellTiming> cellTiming;
 
     void addWire(IdStringList name, IdString type, int x, int y);
     void addPip(IdStringList name, IdString type, IdStringList srcWire, IdStringList dstWire, DelayInfo delay, Loc loc);
@@ -169,10 +169,10 @@ struct Arch : BaseCtx
     void setLutK(int K);
     void setDelayScaling(double scale, double offset);
 
-    void addCellTimingClock(IdStringList cell, IdString port);
-    void addCellTimingDelay(IdStringList cell, IdString fromPort, IdString toPort, DelayInfo delay);
-    void addCellTimingSetupHold(IdStringList cell, IdString port, IdString clock, DelayInfo setup, DelayInfo hold);
-    void addCellTimingClockToOut(IdStringList cell, IdString port, IdString clock, DelayInfo clktoq);
+    void addCellTimingClock(IdString cell, IdString port);
+    void addCellTimingDelay(IdString cell, IdString fromPort, IdString toPort, DelayInfo delay);
+    void addCellTimingSetupHold(IdString cell, IdString port, IdString clock, DelayInfo setup, DelayInfo hold);
+    void addCellTimingClockToOut(IdString cell, IdString port, IdString clock, DelayInfo clktoq);
 
     // ---------------------------------------------------------------
     // Common Arch API. Every arch must provide the following methods.

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -62,7 +62,7 @@ struct WireInfo
 
 struct PinInfo
 {
-    IdStringList name;
+    IdString name;
     WireId wire;
     PortType type;
 };

--- a/generic/arch_pybindings.cc
+++ b/generic/arch_pybindings.cc
@@ -212,17 +212,16 @@ void arch_wrap_python(py::module &m)
                     pass_through<double>>::def_wrap(ctx_cls, "setDelayScaling", "scale"_a, "offset"_a);
 
     fn_wrapper_2a_v<Context, decltype(&Context::addCellTimingClock), &Context::addCellTimingClock,
-                    conv_from_str<IdStringList>, conv_from_str<IdString>>::def_wrap(ctx_cls, "addCellTimingClock",
-                                                                                    "cell"_a, "port"_a);
+                    conv_from_str<IdString>, conv_from_str<IdString>>::def_wrap(ctx_cls, "addCellTimingClock", "cell"_a,
+                                                                                "port"_a);
     fn_wrapper_4a_v<Context, decltype(&Context::addCellTimingDelay), &Context::addCellTimingDelay,
-                    conv_from_str<IdStringList>, conv_from_str<IdString>, conv_from_str<IdString>,
+                    conv_from_str<IdString>, conv_from_str<IdString>, conv_from_str<IdString>,
                     pass_through<DelayInfo>>::def_wrap(ctx_cls, "addCellTimingDelay", "cell"_a, "fromPort"_a,
                                                        "toPort"_a, "delay"_a);
     fn_wrapper_5a_v<Context, decltype(&Context::addCellTimingSetupHold), &Context::addCellTimingSetupHold,
-                    conv_from_str<IdStringList>, conv_from_str<IdString>, conv_from_str<IdString>,
-                    pass_through<DelayInfo>, pass_through<DelayInfo>>::def_wrap(ctx_cls, "addCellTimingSetupHold",
-                                                                                "cell"_a, "port"_a, "clock"_a,
-                                                                                "setup"_a, "hold"_a);
+                    conv_from_str<IdString>, conv_from_str<IdString>, conv_from_str<IdString>, pass_through<DelayInfo>,
+                    pass_through<DelayInfo>>::def_wrap(ctx_cls, "addCellTimingSetupHold", "cell"_a, "port"_a, "clock"_a,
+                                                       "setup"_a, "hold"_a);
     fn_wrapper_4a_v<Context, decltype(&Context::addCellTimingClockToOut), &Context::addCellTimingClockToOut,
                     conv_from_str<IdString>, conv_from_str<IdString>, conv_from_str<IdString>,
                     pass_through<DelayInfo>>::def_wrap(ctx_cls, "addCellTimingClockToOut", "cell"_a, "port"_a,

--- a/gowin/arch.cc
+++ b/gowin/arch.cc
@@ -459,9 +459,9 @@ DelayInfo Arch::getWireTypeDelay(IdString wire)
         break;
     default:
         if (wire.str(this).rfind("SPINE", 0) == 0) {
-            glbsrc = ID_CENT_SPINE_PCLK;
+            glbsrc = IdString(ID_CENT_SPINE_PCLK);
         } else if (wire.str(this).rfind("UNK", 0) == 0) {
-            glbsrc = ID_PIO_CENT_PCLK;
+            glbsrc = IdString(ID_PIO_CENT_PCLK);
         }
         break;
     }
@@ -511,7 +511,7 @@ void Arch::read_cst(std::istream &in)
             continue;
         }
         std::string bel = IdString(belname->src_id).str(this);
-        it->second->attrs[ID_BEL] = bel;
+        it->second->attrs[IdString(ID_BEL)] = bel;
     }
 }
 
@@ -589,16 +589,16 @@ Arch::Arch(ArchArgs args) : args(args)
                 const PairPOD pip = pips[p][j];
                 int destrow = row;
                 int destcol = col;
-                IdString destid = pip.dest_id;
+                IdString destid(pip.dest_id);
                 IdString gdestname = wireToGlobal(destrow, destcol, db, destid);
                 if (wires.count(gdestname) == 0)
-                    addWire(gdestname, pip.dest_id, destcol, destrow);
+                    addWire(gdestname, destid, destcol, destrow);
                 int srcrow = row;
                 int srccol = col;
-                IdString srcid = pip.src_id;
+                IdString srcid(pip.src_id);
                 IdString gsrcname = wireToGlobal(srcrow, srccol, db, srcid);
                 if (wires.count(gsrcname) == 0)
-                    addWire(gsrcname, pip.src_id, srccol, srcrow);
+                    addWire(gsrcname, srcid, srccol, srcrow);
             }
         }
         for (unsigned int j = 0; j < tile->num_bels; j++) {
@@ -673,13 +673,13 @@ Arch::Arch(ArchArgs args) : args(args)
                 snprintf(buf, 32, "R%dC%d_IOB%c", row + 1, col + 1, 'A' + z);
                 belname = id(buf);
                 addBel(belname, id_IOB, Loc(col, row, z), false);
-                portname = pairLookup(bel->ports.get(), bel->num_ports, ID_O)->src_id;
+                portname = IdString(pairLookup(bel->ports.get(), bel->num_ports, ID_O)->src_id);
                 snprintf(buf, 32, "R%dC%d_%s", row + 1, col + 1, portname.c_str(this));
                 addBelOutput(belname, id_O, id(buf));
-                portname = pairLookup(bel->ports.get(), bel->num_ports, ID_I)->src_id;
+                portname = IdString(pairLookup(bel->ports.get(), bel->num_ports, ID_I)->src_id);
                 snprintf(buf, 32, "R%dC%d_%s", row + 1, col + 1, portname.c_str(this));
                 addBelInput(belname, id_I, id(buf));
-                portname = pairLookup(bel->ports.get(), bel->num_ports, ID_OE)->src_id;
+                portname = IdString(pairLookup(bel->ports.get(), bel->num_ports, ID_OE)->src_id);
                 snprintf(buf, 32, "R%dC%d_%s", row + 1, col + 1, portname.c_str(this));
                 addBelInput(belname, id_OEN, id(buf));
                 break;
@@ -701,26 +701,25 @@ Arch::Arch(ArchArgs args) : args(args)
                 const PairPOD pip = pips[p][j];
                 int destrow = row;
                 int destcol = col;
-                IdString destid = pip.dest_id;
+                IdString destid(pip.dest_id);
                 IdString gdestname = wireToGlobal(destrow, destcol, db, destid);
                 int srcrow = row;
                 int srccol = col;
-                IdString srcid = pip.src_id;
+                IdString srcid(pip.src_id);
                 IdString gsrcname = wireToGlobal(srcrow, srccol, db, srcid);
 
-                snprintf(buf, 32, "R%dC%d_%s_%s", row + 1, col + 1, IdString(pip.src_id).c_str(this),
-                         IdString(pip.dest_id).c_str(this));
+                snprintf(buf, 32, "R%dC%d_%s_%s", row + 1, col + 1, srcid.c_str(this), destid.c_str(this));
                 IdString pipname = id(buf);
-                DelayInfo delay = getWireTypeDelay(pip.dest_id);
+                DelayInfo delay = getWireTypeDelay(destid);
                 // local alias
                 auto local_alias = pairLookup(tile->aliases.get(), tile->num_aliases, srcid.index);
                 // std::cout << "srcid " << srcid.str(this) << std::endl;
                 if (local_alias != nullptr) {
-                    srcid = local_alias->src_id;
+                    srcid = IdString(local_alias->src_id);
                     gsrcname = wireToGlobal(srcrow, srccol, db, srcid);
                 }
                 // global alias
-                srcid = pip.src_id;
+                srcid = IdString(pip.src_id);
                 GlobalAliasPOD alias;
                 alias.dest_col = srccol;
                 alias.dest_row = srcrow;
@@ -729,11 +728,11 @@ Arch::Arch(ArchArgs args) : args(args)
                 if (alias_src != nullptr) {
                     srccol = alias_src->src_col;
                     srcrow = alias_src->src_row;
-                    srcid = alias_src->src_id;
+                    srcid = IdString(alias_src->src_id);
                     gsrcname = wireToGlobal(srcrow, srccol, db, srcid);
                     // std::cout << buf << std::endl;
                 }
-                addPip(pipname, pip.dest_id, gsrcname, gdestname, delay, Loc(col, row, j));
+                addPip(pipname, destid, gsrcname, gdestname, delay, Loc(col, row, j));
             }
         }
     }

--- a/gui/designwidget.cc
+++ b/gui/designwidget.cc
@@ -911,7 +911,7 @@ void DesignWidget::prepareMenuProperty(const QPoint &pos)
         ElementType type = getElementTypeByName(selectedProperty->propertyId());
         if (type == ElementType::NONE)
             continue;
-        IdString value = ctx->id(selectedProperty->valueText().toStdString());
+        IdStringList value = IdStringList::parse(ctx, selectedProperty->valueText().toStdString());
         auto node = getTreeByElementType(type)->nodeForId(value);
         if (!node)
             continue;
@@ -996,7 +996,9 @@ void DesignWidget::onItemDoubleClicked(QTreeWidgetItem *item, int column)
     ElementType type = getElementTypeByName(selectedProperty->propertyId());
     if (type == ElementType::NONE)
         return;
-    auto it = getTreeByElementType(type)->nodeForId(ctx->id(selectedProperty->valueText().toStdString()));
+
+    IdStringList value = IdStringList::parse(ctx, selectedProperty->valueText().toStdString());
+    auto it = getTreeByElementType(type)->nodeForId(value);
     if (it) {
         int num = getIndexByElementType(type);
         clearAllSelectionModels();
@@ -1049,8 +1051,8 @@ void DesignWidget::onHoverPropertyChanged(QtBrowserItem *item)
         QtProperty *selectedProperty = item->property();
         ElementType type = getElementTypeByName(selectedProperty->propertyId());
         if (type != ElementType::NONE) {
-            IdString value = ctx->id(selectedProperty->valueText().toStdString());
-            if (value != IdString()) {
+            IdStringList value = IdStringList::parse(ctx, selectedProperty->valueText().toStdString());
+            if (value != IdStringList()) {
                 auto node = getTreeByElementType(type)->nodeForId(value);
                 if (node) {
                     std::vector<DecalXY> decals = getDecals((*node)->type(), (*node)->id());

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -564,7 +564,7 @@ IdStringList Arch::getGroupName(GroupId group) const
         suffix = "lc7_sw";
         break;
     default:
-        return IdString();
+        return IdStringList();
     }
 
     std::array<IdString, 3> ids{x_ids.at(group.x), y_ids.at(group.y), id(suffix)};

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -269,7 +269,7 @@ struct BelPinIterator
     {
         BelPin ret;
         ret.bel.index = ptr->bel_index;
-        ret.pin = ptr->port;
+        ret.pin = IdString(ptr->port);
         return ret;
     }
 };

--- a/ice40/arch_pybindings.h
+++ b/ice40/arch_pybindings.h
@@ -30,7 +30,7 @@ namespace PythonConversion {
 
 template <> struct string_converter<BelId>
 {
-    BelId from_str(Context *ctx, std::string name) { return ctx->getBelByName(ctx->id(name)); }
+    BelId from_str(Context *ctx, std::string name) { return ctx->getBelByName(IdStringList::parse(ctx, name)); }
 
     std::string to_str(Context *ctx, BelId id)
     {
@@ -42,7 +42,7 @@ template <> struct string_converter<BelId>
 
 template <> struct string_converter<WireId>
 {
-    WireId from_str(Context *ctx, std::string name) { return ctx->getWireByName(ctx->id(name)); }
+    WireId from_str(Context *ctx, std::string name) { return ctx->getWireByName(IdStringList::parse(ctx, name)); }
 
     std::string to_str(Context *ctx, WireId id)
     {
@@ -54,7 +54,7 @@ template <> struct string_converter<WireId>
 
 template <> struct string_converter<const WireId>
 {
-    WireId from_str(Context *ctx, std::string name) { return ctx->getWireByName(ctx->id(name)); }
+    WireId from_str(Context *ctx, std::string name) { return ctx->getWireByName(IdStringList::parse(ctx, name)); }
 
     std::string to_str(Context *ctx, WireId id)
     {
@@ -66,7 +66,7 @@ template <> struct string_converter<const WireId>
 
 template <> struct string_converter<PipId>
 {
-    PipId from_str(Context *ctx, std::string name) { return ctx->getPipByName(ctx->id(name)); }
+    PipId from_str(Context *ctx, std::string name) { return ctx->getPipByName(IdStringList::parse(ctx, name)); }
 
     std::string to_str(Context *ctx, PipId id)
     {

--- a/nexus/arch.cc
+++ b/nexus/arch.cc
@@ -373,8 +373,8 @@ std::vector<std::pair<IdString, std::string>> Arch::getPipAttrs(PipId pip) const
     ret.emplace_back(id("GRID_X"), stringf("%d", pip.tile % chip_info->width));
     ret.emplace_back(id("GRID_Y"), stringf("%d", pip.tile / chip_info->width));
 
-    ret.emplace_back(id("FROM_TILE_WIRE"), nameOf(loc_data(pip).wires[pip_data(pip).from_wire].name));
-    ret.emplace_back(id("TO_TILE_WIRE"), nameOf(loc_data(pip).wires[pip_data(pip).to_wire].name));
+    ret.emplace_back(id("FROM_TILE_WIRE"), nameOf(IdString(loc_data(pip).wires[pip_data(pip).from_wire].name)));
+    ret.emplace_back(id("TO_TILE_WIRE"), nameOf(IdString(loc_data(pip).wires[pip_data(pip).to_wire].name)));
 
     return ret;
 }
@@ -936,7 +936,7 @@ void Arch::lookup_cell_clock_out(int type_idx, IdString to_port, IdString &clock
             ct.prop_delays.get(), ct.prop_delays.size(), [](const CellPropDelayPOD &pd) { return pd.to_port; },
             to_port.index);
     NPNR_ASSERT(dly_idx != -1);
-    clock = ct.prop_delays[dly_idx].from_port;
+    clock = IdString(ct.prop_delays[dly_idx].from_port);
     delay.min_delay = ct.prop_delays[dly_idx].min_delay;
     delay.max_delay = ct.prop_delays[dly_idx].max_delay;
 }

--- a/nexus/arch.h
+++ b/nexus/arch.h
@@ -1444,12 +1444,12 @@ struct Arch : BaseCtx
     IdString pip_src_wire_name(PipId pip) const
     {
         int wire = pip_data(pip).from_wire;
-        return db->loctypes[chip_info->grid[pip.tile].loc_type].wires[wire].name;
+        return IdString(db->loctypes[chip_info->grid[pip.tile].loc_type].wires[wire].name);
     }
     IdString pip_dst_wire_name(PipId pip) const
     {
         int wire = pip_data(pip).to_wire;
-        return db->loctypes[chip_info->grid[pip.tile].loc_type].wires[wire].name;
+        return IdString(db->loctypes[chip_info->grid[pip.tile].loc_type].wires[wire].name);
     }
 
     // -------------------------------------------------

--- a/nexus/arch_pybindings.h
+++ b/nexus/arch_pybindings.h
@@ -30,7 +30,7 @@ namespace PythonConversion {
 
 template <> struct string_converter<BelId>
 {
-    BelId from_str(Context *ctx, std::string name) { return ctx->getBelByName(ctx->id(name)); }
+    BelId from_str(Context *ctx, std::string name) { return ctx->getBelByName(IdStringList::parse(ctx, name)); }
 
     std::string to_str(Context *ctx, BelId id)
     {
@@ -42,7 +42,7 @@ template <> struct string_converter<BelId>
 
 template <> struct string_converter<WireId>
 {
-    WireId from_str(Context *ctx, std::string name) { return ctx->getWireByName(ctx->id(name)); }
+    WireId from_str(Context *ctx, std::string name) { return ctx->getWireByName(IdStringList::parse(ctx, name)); }
 
     std::string to_str(Context *ctx, WireId id)
     {
@@ -54,7 +54,7 @@ template <> struct string_converter<WireId>
 
 template <> struct string_converter<const WireId>
 {
-    WireId from_str(Context *ctx, std::string name) { return ctx->getWireByName(ctx->id(name)); }
+    WireId from_str(Context *ctx, std::string name) { return ctx->getWireByName(IdStringList::parse(ctx, name)); }
 
     std::string to_str(Context *ctx, WireId id)
     {
@@ -66,7 +66,7 @@ template <> struct string_converter<const WireId>
 
 template <> struct string_converter<PipId>
 {
-    PipId from_str(Context *ctx, std::string name) { return ctx->getPipByName(ctx->id(name)); }
+    PipId from_str(Context *ctx, std::string name) { return ctx->getPipByName(IdStringList::parse(ctx, name)); }
 
     std::string to_str(Context *ctx, PipId id)
     {

--- a/nexus/fasm.cc
+++ b/nexus/fasm.cc
@@ -144,7 +144,7 @@ struct NexusFasmWriter
     {
         int r = loc / ctx->chip_info->width;
         int c = loc % ctx->chip_info->width;
-        return stringf("%sR%dC%d__%s", ctx->nameOf(tile.prefix), r, c, ctx->nameOf(tile.tiletype));
+        return stringf("%sR%dC%d__%s", ctx->nameOf(IdString(tile.prefix)), r, c, ctx->nameOf(IdString(tile.tiletype)));
     }
     // Look up a tile by location index and tile type
     const PhysicalTileInfoPOD &tile_by_type_and_loc(int loc, IdString type)
@@ -180,7 +180,7 @@ struct NexusFasmWriter
     void push_tile(int loc, IdString tile_type) { push(tile_name(loc, tile_by_type_and_loc(loc, tile_type))); }
     void push_tile(int loc) { push(tile_name(loc, tile_at_loc(loc))); }
     // Push a bel name onto the prefix stack
-    void push_belname(BelId bel) { push(ctx->nameOf(ctx->bel_data(bel).name)); }
+    void push_belname(BelId bel) { push(ctx->nameOf(IdString(ctx->bel_data(bel).name))); }
     // Push the tile group name corresponding to a bel onto the prefix stack
     void push_belgroup(BelId bel)
     {
@@ -189,14 +189,14 @@ struct NexusFasmWriter
         auto &bel_data = ctx->bel_data(bel);
         r += bel_data.rel_y;
         c += bel_data.rel_x;
-        std::string s = stringf("R%dC%d_%s", r, c, ctx->nameOf(ctx->bel_data(bel).name));
+        std::string s = stringf("R%dC%d_%s", r, c, ctx->nameOf(IdString(ctx->bel_data(bel).name)));
         push(s);
     }
     // Push a bel's group and name
     void push_bel(BelId bel)
     {
         push_belgroup(bel);
-        fasm_ctx.back() += stringf(".%s", ctx->nameOf(ctx->bel_data(bel).name));
+        fasm_ctx.back() += stringf(".%s", ctx->nameOf(IdString(ctx->bel_data(bel).name)));
     }
     // Write out a pip in tile.dst.src format
     void write_pip(PipId pip)
@@ -204,7 +204,7 @@ struct NexusFasmWriter
         auto &pd = ctx->pip_data(pip);
         if (pd.flags & PIP_FIXED_CONN)
             return;
-        std::string tile = tile_name(pip.tile, tile_by_type_and_loc(pip.tile, pd.tile_type));
+        std::string tile = tile_name(pip.tile, tile_by_type_and_loc(pip.tile, IdString(pd.tile_type)));
         std::string source_wire = escape_name(ctx->pip_src_wire_name(pip).str(ctx));
         std::string dest_wire = escape_name(ctx->pip_dst_wire_name(pip).str(ctx));
         out << stringf("%s.PIP.%s.%s", tile.c_str(), dest_wire.c_str(), source_wire.c_str()) << std::endl;
@@ -580,7 +580,7 @@ struct NexusFasmWriter
         write_enum(cell, "CLKMUX_FB");
         write_cell_muxes(cell);
         pop();
-        push(stringf("IP_%s", ctx->nameOf(ctx->bel_data(bel).name)));
+        push(stringf("IP_%s", ctx->nameOf(IdString(ctx->bel_data(bel).name))));
         for (auto param : sorted_cref(cell->params)) {
             const std::string &name = param.first.str(ctx);
             if (is_mux_param(name) || name == "CLKMUX_FB" || name == "SEL_FBK")

--- a/nexus/pack.cc
+++ b/nexus/pack.cc
@@ -1283,7 +1283,7 @@ struct NexusPacker
     // Function to check if a wire is general routing; and therefore skipped for cascade purposes
     bool is_general_routing(WireId wire)
     {
-        std::string name = ctx->nameOf(ctx->wire_data(wire).name);
+        std::string name = ctx->nameOf(IdString(ctx->wire_data(wire).name));
         if (name.size() == 3 && (name.substr(0, 2) == "JF" || name.substr(0, 2) == "JQ"))
             return true;
         if (name.size() == 12 && (name.substr(0, 10) == "JCIBMUXOUT"))


### PR DESCRIPTION
Non-explicit single argument constructors will silently convert to that type.  This
is typically not the right thing to do.  For example, the nexus and
ice40 arch_pybindings.h files were incorrectly parsing bel name strings,
etc.

I discovered this issue when checking the python API.