### PR TITLE
Add BaseArchRanges for default ArchRanges types

### DIFF
--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -1176,6 +1176,27 @@ template <typename R> struct ArchAPI : BaseCtx
     virtual void assignArchInfo() = 0;
 };
 
+// This contains the relevant range types for the default implementations of Arch functions
+struct BaseArchRanges
+{
+    // Attributes
+    using BelAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
+    using WireAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
+    using PipAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
+    // Groups
+    using AllGroupsRangeT = std::vector<GroupId>;
+    using GroupBelsRangeT = std::vector<BelId>;
+    using GroupWiresRangeT = std::vector<WireId>;
+    using GroupPipsRangeT = std::vector<PipId>;
+    using GroupGroupsRangeT = std::vector<GroupId>;
+    // Decals
+    using DecalGfxRangeT = std::vector<GraphicElement>;
+    // Placement validity
+    using CellTypeRangeT = const std::vector<IdString> &;
+    using BelBucketRangeT = const std::vector<BelBucketId> &;
+    using BucketBelRangeT = const std::vector<BelId> &;
+};
+
 template <typename R> struct BaseArch : ArchAPI<R>
 {
     // --------------------------------------------------------------

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -29,7 +29,7 @@ The contents of `ArchRanges` is as follows:
 |`BelBucketRangeT`          | `BelBucketRange`                 |
 |`BucketBelRangeT`          | `BelId`                          |
 
-The functions that return a particular type are described below
+The functions that return a particular type are described below. Where a default function implementation is provided, `BaseArchRanges` (which `ArchRanges` can inherit from) will set the range type appropriately.
 
 archdefs.h
 ==========

--- a/ecp5/arch.h
+++ b/ecp5/arch.h
@@ -435,35 +435,20 @@ template <> struct hash<NEXTPNR_NAMESPACE_PREFIX DelayKey>
 } // namespace std
 NEXTPNR_NAMESPACE_BEGIN
 
-struct ArchRanges
+struct ArchRanges : BaseArchRanges
 {
     using ArchArgsT = ArchArgs;
     // Bels
     using AllBelsRangeT = BelRange;
     using TileBelsRangeT = BelRange;
-    using BelAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
     using BelPinsRangeT = std::vector<IdString>;
     // Wires
     using AllWiresRangeT = WireRange;
     using DownhillPipRangeT = PipRange;
     using UphillPipRangeT = PipRange;
     using WireBelPinRangeT = BelPinRange;
-    using WireAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
     // Pips
     using AllPipsRangeT = AllPipRange;
-    using PipAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
-    // Groups
-    using AllGroupsRangeT = std::vector<GroupId>;
-    using GroupBelsRangeT = std::vector<BelId>;
-    using GroupWiresRangeT = std::vector<WireId>;
-    using GroupPipsRangeT = std::vector<PipId>;
-    using GroupGroupsRangeT = std::vector<GroupId>;
-    // Decals
-    using DecalGfxRangeT = std::vector<GraphicElement>;
-    // Placement validity
-    using CellTypeRangeT = const std::vector<IdString> &;
-    using BelBucketRangeT = const std::vector<BelBucketId> &;
-    using BucketBelRangeT = const std::vector<BelId> &;
 };
 
 struct Arch : BaseArch<ArchRanges>

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -374,35 +374,20 @@ struct ArchArgs
     std::string package;
 };
 
-struct ArchRanges
+struct ArchRanges : BaseArchRanges
 {
     using ArchArgsT = ArchArgs;
     // Bels
     using AllBelsRangeT = BelRange;
     using TileBelsRangeT = BelRange;
-    using BelAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
     using BelPinsRangeT = std::vector<IdString>;
     // Wires
     using AllWiresRangeT = WireRange;
     using DownhillPipRangeT = PipRange;
     using UphillPipRangeT = PipRange;
     using WireBelPinRangeT = BelPinRange;
-    using WireAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
     // Pips
     using AllPipsRangeT = AllPipRange;
-    using PipAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
-    // Groups
-    using AllGroupsRangeT = std::vector<GroupId>;
-    using GroupBelsRangeT = std::vector<BelId>;
-    using GroupWiresRangeT = std::vector<WireId>;
-    using GroupPipsRangeT = std::vector<PipId>;
-    using GroupGroupsRangeT = std::vector<GroupId>;
-    // Decals
-    using DecalGfxRangeT = std::vector<GraphicElement>;
-    // Placement validity
-    using CellTypeRangeT = const std::vector<IdString> &;
-    using BelBucketRangeT = const std::vector<BelBucketId> &;
-    using BucketBelRangeT = const std::vector<BelId> &;
 };
 
 struct Arch : BaseArch<ArchRanges>

--- a/nexus/arch.h
+++ b/nexus/arch.h
@@ -855,35 +855,20 @@ struct ArchArgs
     std::string device;
 };
 
-struct ArchRanges
+struct ArchRanges : BaseArchRanges
 {
     using ArchArgsT = ArchArgs;
     // Bels
     using AllBelsRangeT = BelRange;
     using TileBelsRangeT = std::vector<BelId>;
-    using BelAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
     using BelPinsRangeT = std::vector<IdString>;
     // Wires
     using AllWiresRangeT = WireRange;
     using DownhillPipRangeT = UpDownhillPipRange;
     using UphillPipRangeT = UpDownhillPipRange;
     using WireBelPinRangeT = BelPinRange;
-    using WireAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
     // Pips
     using AllPipsRangeT = AllPipRange;
-    using PipAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
-    // Groups
-    using AllGroupsRangeT = std::vector<GroupId>;
-    using GroupBelsRangeT = std::vector<BelId>;
-    using GroupWiresRangeT = std::vector<WireId>;
-    using GroupPipsRangeT = std::vector<PipId>;
-    using GroupGroupsRangeT = std::vector<GroupId>;
-    // Decals
-    using DecalGfxRangeT = std::vector<GraphicElement>;
-    // Placement validity
-    using CellTypeRangeT = const std::vector<IdString> &;
-    using BelBucketRangeT = const std::vector<BelBucketId> &;
-    using BucketBelRangeT = const std::vector<BelId> &;
 };
 
 struct Arch : BaseArch<ArchRanges>


### PR DESCRIPTION
This reduces the amount of per-arch code a bit more.