### PR TITLE
Remove the unused CellInfo::pins field

### DIFF
--- a/common/nextpnr.cc
+++ b/common/nextpnr.cc
@@ -355,11 +355,6 @@ WireId Context::getNetinfoSourceWire(const NetInfo *net_info) const
         return WireId();
 
     IdString driver_port = net_info->driver.port;
-
-    auto driver_port_it = net_info->driver.cell->pins.find(driver_port);
-    if (driver_port_it != net_info->driver.cell->pins.end())
-        driver_port = driver_port_it->second;
-
     return getBelPinWire(src_bel, driver_port);
 }
 
@@ -371,12 +366,6 @@ WireId Context::getNetinfoSinkWire(const NetInfo *net_info, const PortRef &user_
         return WireId();
 
     IdString user_port = user_info.port;
-
-    auto user_port_it = user_info.cell->pins.find(user_port);
-
-    if (user_port_it != user_info.cell->pins.end())
-        user_port = user_port_it->second;
-
     return getBelPinWire(dst_bel, user_port);
 }
 
@@ -515,15 +504,6 @@ uint32_t Context::checksum() const
 
         x = xorshift32(x + xorshift32(getBelChecksum(ci.bel)));
         x = xorshift32(x + xorshift32(ci.belStrength));
-
-        uint32_t pin_x_sum = 0;
-        for (auto &a : ci.pins) {
-            uint32_t pin_x = 123456789;
-            pin_x = xorshift32(pin_x + xorshift32(a.first.index));
-            pin_x = xorshift32(pin_x + xorshift32(a.second.index));
-            pin_x_sum += pin_x;
-        }
-        x = xorshift32(x + xorshift32(pin_x_sum));
 
         cksum_cells_sum += x;
     }

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -605,9 +605,6 @@ struct CellInfo : ArchCellInfo
     BelId bel;
     PlaceStrength belStrength = STRENGTH_NONE;
 
-    // cell_port -> bel_pin
-    std::unordered_map<IdString, IdString> pins;
-
     // placement constraints
     CellInfo *constr_parent = nullptr;
     std::vector<CellInfo *> constr_children;

--- a/common/pybindings.cc
+++ b/common/pybindings.cc
@@ -167,8 +167,6 @@ PYBIND11_EMBEDDED_MODULE(MODULE_NAME, m)
                       conv_from_str<BelId>>::def_wrap(ci_cls, "bel");
     readwrite_wrapper<CellInfo &, decltype(&CellInfo::belStrength), &CellInfo::belStrength, pass_through<PlaceStrength>,
                       pass_through<PlaceStrength>>::def_wrap(ci_cls, "belStrength");
-    readonly_wrapper<CellInfo &, decltype(&CellInfo::pins), &CellInfo::pins, wrap_context<IdIdMap &>>::def_wrap(ci_cls,
-                                                                                                                "pins");
 
     fn_wrapper_1a_v<CellInfo &, decltype(&CellInfo::addInput), &CellInfo::addInput, conv_from_str<IdString>>::def_wrap(
             ci_cls, "addInput");

--- a/gui/designwidget.cc
+++ b/gui/designwidget.cc
@@ -819,18 +819,6 @@ void DesignWidget::onSelectionChanged(int num, const QItemSelection &, const QIt
             addProperty(cellParamsItem, QVariant::String, item.first.c_str(ctx),
                         item.second.is_string ? item.second.as_string().c_str() : item.second.to_string().c_str());
         }
-
-        QtProperty *cellPinsItem = groupManager->addProperty("Pins");
-        topItem->addSubProperty(cellPinsItem);
-        for (auto &item : cell->pins) {
-            std::string cell_port = item.first.c_str(ctx);
-            std::string bel_pin = item.second.c_str(ctx);
-
-            QtProperty *pinGroupItem = addSubGroup(cellPortsItem, (cell_port + " -> " + bel_pin).c_str());
-
-            addProperty(pinGroupItem, QVariant::String, "Cell", cell_port.c_str(), ElementType::CELL);
-            addProperty(pinGroupItem, QVariant::String, "Bel", bel_pin.c_str(), ElementType::BEL);
-        }
     }
 }
 


### PR DESCRIPTION
No arches ever actually used this to implement a Cell->Bel pin mapping, and in practice if any did try they would inevitably hit bitrot.

This field had limited use in practice as it is necessary to also support cases where one cell pin maps to more than one bel pin. Removing this old field is the first step towards developing a new API for this.

