### PR TITLE
Support for cell pin to bel pin mappings

### DIFF
--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -1494,7 +1494,9 @@ struct Context : Arch, DeterministicRNG
     // --------------------------------------------------------------
 
     WireId getNetinfoSourceWire(const NetInfo *net_info) const;
-    WireId getNetinfoSinkWire(const NetInfo *net_info, const PortRef &sink) const;
+    SSOArray<WireId, 2> getNetinfoSinkWires(const NetInfo *net_info, const PortRef &sink) const;
+    size_t getNetinfoSinkWireCount(const NetInfo *net_info, const PortRef &sink) const;
+    WireId getNetinfoSinkWire(const NetInfo *net_info, const PortRef &sink, size_t phys_idx) const;
     delay_t getNetinfoRouteDelay(const NetInfo *net_info, const PortRef &sink) const;
 
     // provided by router1.cc

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -1093,6 +1093,7 @@ template <typename R> struct ArchAPI : BaseCtx
     virtual WireId getBelPinWire(BelId bel, IdString pin) const = 0;
     virtual PortType getBelPinType(BelId bel, IdString pin) const = 0;
     virtual typename R::BelPinsRangeT getBelPins(BelId bel) const = 0;
+    virtual typename R::CellBelPinRangeT getBelPinsForCellPin(CellInfo *cell_info, IdString pin) const = 0;
     // Wire methods
     virtual typename R::AllWiresRangeT getWires() const = 0;
     virtual WireId getWireByName(IdStringList name) const = 0;
@@ -1176,6 +1177,8 @@ template <typename R> struct ArchAPI : BaseCtx
 // This contains the relevant range types for the default implementations of Arch functions
 struct BaseArchRanges
 {
+    // Bels
+    using CellBelPinRangeT = std::array<IdString, 1>;
     // Attributes
     using BelAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
     using WireAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
@@ -1239,6 +1242,11 @@ template <typename R> struct BaseArch : ArchAPI<R>
     virtual typename R::BelAttrsRangeT getBelAttrs(BelId bel) const override
     {
         return empty_if_possible<typename R::BelAttrsRangeT>();
+    }
+
+    virtual typename R::CellBelPinRangeT getBelPinsForCellPin(CellInfo *cell_info, IdString pin) const override
+    {
+        return return_if_match<std::array<IdString, 1>, typename R::CellBelPinRangeT>({pin});
     }
 
     // Wire methods

--- a/common/router1.cc
+++ b/common/router1.cc
@@ -144,7 +144,7 @@ struct Router1
         int user_idx = arc.user_idx;
 
         auto src_wire = ctx->getNetinfoSourceWire(net_info);
-        auto dst_wire = ctx->getNetinfoSinkWire(net_info, net_info->users[user_idx]);
+        auto dst_wire = ctx->getNetinfoSinkWire(net_info, net_info->users[user_idx], 0);
 
         arc_queue_insert(arc, src_wire, dst_wire);
     }
@@ -302,7 +302,7 @@ struct Router1
             log_assert(src_wire != WireId());
 
             for (int user_idx = 0; user_idx < int(net_info->users.size()); user_idx++) {
-                auto dst_wire = ctx->getNetinfoSinkWire(net_info, net_info->users[user_idx]);
+                auto dst_wire = ctx->getNetinfoSinkWire(net_info, net_info->users[user_idx], 0);
                 log_assert(dst_wire != WireId());
 
                 arc_key arc;
@@ -375,7 +375,7 @@ struct Router1
                           ctx->nameOf(dst_to_arc.at(src_wire).net_info), dst_to_arc.at(src_wire).user_idx);
 
             for (int user_idx = 0; user_idx < int(net_info->users.size()); user_idx++) {
-                auto dst_wire = ctx->getNetinfoSinkWire(net_info, net_info->users[user_idx]);
+                auto dst_wire = ctx->getNetinfoSinkWire(net_info, net_info->users[user_idx], 0);
 
                 if (dst_wire == WireId())
                     log_error("No wire found for port %s on destination cell %s.\n",
@@ -443,7 +443,7 @@ struct Router1
         int user_idx = arc.user_idx;
 
         auto src_wire = ctx->getNetinfoSourceWire(net_info);
-        auto dst_wire = ctx->getNetinfoSinkWire(net_info, net_info->users[user_idx]);
+        auto dst_wire = ctx->getNetinfoSinkWire(net_info, net_info->users[user_idx], 0);
         ripup_flag = false;
 
         if (ctx->debug) {
@@ -934,7 +934,7 @@ bool Context::checkRoutedDesign() const
 
         std::unordered_map<WireId, int> dest_wires;
         for (int user_idx = 0; user_idx < int(net_info->users.size()); user_idx++) {
-            auto dst_wire = ctx->getNetinfoSinkWire(net_info, net_info->users[user_idx]);
+            auto dst_wire = ctx->getNetinfoSinkWire(net_info, net_info->users[user_idx], 0);
             log_assert(dst_wire != WireId());
             dest_wires[dst_wire] = user_idx;
 

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -150,7 +150,7 @@ struct Router2
 
             for (size_t j = 0; j < ni->users.size(); j++) {
                 auto &usr = ni->users.at(j);
-                WireId src_wire = ctx->getNetinfoSourceWire(ni), dst_wire = ctx->getNetinfoSinkWire(ni, usr);
+                WireId src_wire = ctx->getNetinfoSourceWire(ni), dst_wire = ctx->getNetinfoSinkWire(ni, usr, 0);
                 nets.at(i).src_wire = src_wire;
                 if (ni->driver.cell == nullptr)
                     src_wire = dst_wire;
@@ -405,7 +405,7 @@ struct Router2
     void reserve_wires_for_arc(NetInfo *net, size_t i)
     {
         WireId src = ctx->getNetinfoSourceWire(net);
-        WireId sink = ctx->getNetinfoSinkWire(net, net->users.at(i));
+        WireId sink = ctx->getNetinfoSinkWire(net, net->users.at(i), 0);
         if (sink == WireId())
             return;
         std::unordered_set<WireId> rsv;
@@ -479,7 +479,7 @@ struct Router2
         auto &usr = net->users.at(i);
         ROUTE_LOG_DBG("Routing arc %d of net '%s' (%d, %d) -> (%d, %d)\n", int(i), ctx->nameOf(net), ad.bb.x0, ad.bb.y0,
                       ad.bb.x1, ad.bb.y1);
-        WireId src_wire = ctx->getNetinfoSourceWire(net), dst_wire = ctx->getNetinfoSinkWire(net, usr);
+        WireId src_wire = ctx->getNetinfoSourceWire(net), dst_wire = ctx->getNetinfoSinkWire(net, usr, 0);
         if (src_wire == WireId())
             ARC_LOG_ERR("No wire found for port %s on source cell %s.\n", ctx->nameOf(net->driver.port),
                         ctx->nameOf(net->driver.cell));
@@ -726,7 +726,7 @@ struct Router2
             if (check_arc_routing(net, i))
                 continue;
             auto &usr = net->users.at(i);
-            WireId dst_wire = ctx->getNetinfoSinkWire(net, usr);
+            WireId dst_wire = ctx->getNetinfoSinkWire(net, usr, 0);
             // Case of arcs that were pre-routed strongly (e.g. clocks)
             if (net->wires.count(dst_wire) && net->wires.at(dst_wire).strength > STRENGTH_STRONG)
                 return ARC_SUCCESS;
@@ -751,7 +751,7 @@ struct Router2
                     if (res2 != ARC_SUCCESS)
                         log_error("Failed to route arc %d of net '%s', from %s to %s.\n", int(i), ctx->nameOf(net),
                                   ctx->nameOfWire(ctx->getNetinfoSourceWire(net)),
-                                  ctx->nameOfWire(ctx->getNetinfoSinkWire(net, net->users.at(i))));
+                                  ctx->nameOfWire(ctx->getNetinfoSinkWire(net, net->users.at(i), 0)));
                 }
             }
         }
@@ -803,7 +803,7 @@ struct Router2
         // Skip routes with no source
         if (src == WireId())
             return true;
-        WireId dst = ctx->getNetinfoSinkWire(net, usr);
+        WireId dst = ctx->getNetinfoSinkWire(net, usr, 0);
         // Skip routes where the destination is already bound
         if (dst == WireId() || ctx->getBoundWireNet(dst) == net)
             return true;

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -869,7 +869,7 @@ void timing_analysis(Context *ctx, bool print_histogram, bool print_fmax, bool p
                 log_info("               Sink %s.%s\n", sink_cell->name.c_str(ctx), sink->port.c_str(ctx));
                 if (ctx->verbose) {
                     auto driver_wire = ctx->getNetinfoSourceWire(net);
-                    auto sink_wire = ctx->getNetinfoSinkWire(net, *sink);
+                    auto sink_wire = ctx->getNetinfoSinkWire(net, *sink, 0);
                     log_info("                 prediction: %f ns estimate: %f ns\n",
                              ctx->getDelayNS(ctx->predictDelay(net, *sink)),
                              ctx->getDelayNS(ctx->estimateDelay(driver_wire, sink_wire)));

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -13,6 +13,7 @@ The contents of `ArchRanges` is as follows:
 |`TileBelsRangeT`           | `BelId`                          |
 |`BelAttrsRangeT`           | std::pair<IdString, std::string> |
 |`BelPinsRangeT`            | `IdString`                       |
+|`CellBelPinRangeT`         | `IdString`                       |
 |`AllWiresRangeT`           | `WireId`                         |
 |`DownhillPipRangeT`        | `PipId`                          |
 |`UphillPipRangeT`          | `PipId`                          |
@@ -243,6 +244,12 @@ Return the type (input/output/inout) of the given bel pin.
 ### BelPinsRangeT getBelPins(BelId bel) const
 
 Return a list of all pins on that bel.
+
+### CellBelPinRangeT getBelPinsForCellPin(CellInfo *cell_info, IdString pin) const
+
+Return the list of bel pin names that a given cell pin should be routed to. In most cases there will be a single bel pin for each cell pin; and output pins must _always_ have only one bel pin associated with them.
+
+*BaseArch default: returns a one-element array containing `pin`*
 
 Wire Methods
 ------------

--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -660,6 +660,7 @@ struct ArchRanges
     using TileBelsRangeT = BelRange;
     using BelAttrsRangeT = std::vector<std::pair<IdString, std::string>>;
     using BelPinsRangeT = IdStringRange;
+    using CellBelPinRangeT = std::array<IdString, 1>;
     // Wires
     using AllWiresRangeT = WireRange;
     using DownhillPipRangeT = DownhillPipRange;
@@ -865,6 +866,8 @@ struct Arch : ArchAPI<ArchRanges>
 
         return str_range;
     }
+
+    std::array<IdString, 1> getBelPinsForCellPin(CellInfo *cell_info, IdString pin) const override { return {pin}; }
 
     // -------------------------------------------------
 

--- a/generic/arch.cc
+++ b/generic/arch.cc
@@ -339,6 +339,8 @@ std::vector<IdString> Arch::getBelPins(BelId bel) const
     return ret;
 }
 
+std::array<IdString, 1> Arch::getBelPinsForCellPin(CellInfo *cell_info, IdString pin) const { return {pin}; }
+
 // ---------------------------------------------------------------
 
 WireId Arch::getWireByName(IdStringList name) const

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -124,6 +124,7 @@ struct ArchRanges
     using TileBelsRangeT = const std::vector<BelId> &;
     using BelAttrsRangeT = const std::map<IdString, std::string> &;
     using BelPinsRangeT = std::vector<IdString>;
+    using CellBelPinRangeT = std::array<IdString, 1>;
     // Wires
     using AllWiresRangeT = const std::vector<WireId> &;
     using DownhillPipRangeT = const std::vector<PipId> &;
@@ -241,6 +242,7 @@ struct Arch : ArchAPI<ArchRanges>
     WireId getBelPinWire(BelId bel, IdString pin) const override;
     PortType getBelPinType(BelId bel, IdString pin) const override;
     std::vector<IdString> getBelPins(BelId bel) const override;
+    std::array<IdString, 1> getBelPinsForCellPin(CellInfo *cell_info, IdString pin) const override;
 
     WireId getWireByName(IdStringList name) const override;
     IdStringList getWireName(WireId wire) const override;

--- a/gowin/arch.cc
+++ b/gowin/arch.cc
@@ -822,6 +822,8 @@ std::vector<IdString> Arch::getBelPins(BelId bel) const
     return ret;
 }
 
+std::array<IdString, 1> Arch::getBelPinsForCellPin(CellInfo *cell_info, IdString pin) const { return {pin}; }
+
 // ---------------------------------------------------------------
 
 WireId Arch::getWireByName(IdStringList name) const

--- a/gowin/arch.h
+++ b/gowin/arch.h
@@ -251,6 +251,7 @@ struct ArchRanges
     using TileBelsRangeT = const std::vector<BelId> &;
     using BelAttrsRangeT = const std::map<IdString, std::string> &;
     using BelPinsRangeT = std::vector<IdString>;
+    using CellBelPinRangeT = std::array<IdString, 1>;
     // Wires
     using AllWiresRangeT = const std::vector<WireId> &;
     using DownhillPipRangeT = const std::vector<PipId> &;
@@ -375,6 +376,7 @@ struct Arch : BaseArch<ArchRanges>
     WireId getBelPinWire(BelId bel, IdString pin) const override;
     PortType getBelPinType(BelId bel, IdString pin) const override;
     std::vector<IdString> getBelPins(BelId bel) const override;
+    std::array<IdString, 1> getBelPinsForCellPin(CellInfo *cell_info, IdString pin) const override;
 
     WireId getWireByName(IdStringList name) const override;
     IdStringList getWireName(WireId wire) const override;

--- a/nexus/global.cc
+++ b/nexus/global.cc
@@ -53,7 +53,7 @@ struct NexusGlobalRouter
 
         // Lookup source and destination wires
         WireId src = ctx->getNetinfoSourceWire(net);
-        WireId dst = ctx->getNetinfoSinkWire(net, net->users.at(user_idx));
+        WireId dst = ctx->getNetinfoSinkWire(net, net->users.at(user_idx), 0);
 
         if (src == WireId())
             log_error("Net '%s' has an invalid source port %s.%s\n", ctx->nameOf(net), ctx->nameOf(net->driver.cell),


### PR DESCRIPTION
This adds a new Arch API to request the range of bel pin(s) that correspond to a cell pin and provides a trivial implementation for all arches. It is primarily a RFC to work out the kinds of changes that the router etc would need to use such an API at this stage.

Outstanding issues: 
 - [ ] actually find a use case for multiple cell->bel pin mappings and test (possibly Nexus BRAM to start with)
 - [ ] should we create a new Id type for bel pins instead of using `IdString? Profiling suggests that the time to lookup bel pin to wire is <1% of runtime and there is plenty of other low hanging fruit - but this would improve type safety as it would be impossible to accidentally use a cell pin as a bel pin without going through the new API. Downside is increased complexity.
 - [ ] should we have a "N of M" API as proposed at https://github.com/SymbiFlow/nextpnr/pull/195#discussion_r566258705 for LUT permuation, etc, or is there an alternative way of dealing with this that doesn't add complexity to paths that don't need it?

Fixes #560