### PR TITLE
Replace DelayInfo with DelayPair and DelayQuad

### DIFF
--- a/common/arch_pybindings_shared.h
+++ b/common/arch_pybindings_shared.h
@@ -103,7 +103,7 @@ fn_wrapper_1a<Context, decltype(&Context::getPipSrcWire), &Context::getPipSrcWir
               conv_from_str<PipId>>::def_wrap(ctx_cls, "getPipSrcWire");
 fn_wrapper_1a<Context, decltype(&Context::getPipDstWire), &Context::getPipDstWire, conv_to_str<WireId>,
               conv_from_str<PipId>>::def_wrap(ctx_cls, "getPipDstWire");
-fn_wrapper_1a<Context, decltype(&Context::getPipDelay), &Context::getPipDelay, pass_through<DelayInfo>,
+fn_wrapper_1a<Context, decltype(&Context::getPipDelay), &Context::getPipDelay, pass_through<DelayQuad>,
               conv_from_str<PipId>>::def_wrap(ctx_cls, "getPipDelay");
 
 fn_wrapper_0a<Context, decltype(&Context::getChipName), &Context::getChipName, pass_through<std::string>>::def_wrap(

--- a/common/nextpnr.cc
+++ b/common/nextpnr.cc
@@ -656,9 +656,9 @@ void Context::check() const
 void BaseCtx::addClock(IdString net, float freq)
 {
     std::unique_ptr<ClockConstraint> cc(new ClockConstraint());
-    cc->period = getCtx()->getDelayFromNS(1000 / freq);
-    cc->high = getCtx()->getDelayFromNS(500 / freq);
-    cc->low = getCtx()->getDelayFromNS(500 / freq);
+    cc->period = DelayPair(getCtx()->getDelayFromNS(1000 / freq));
+    cc->high = DelayPair(getCtx()->getDelayFromNS(500 / freq));
+    cc->low = DelayPair(getCtx()->getDelayFromNS(500 / freq));
     if (!net_aliases.count(net)) {
         log_warning("net '%s' does not exist in design, ignoring clock constraint\n", net.c_str(this));
     } else {

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -556,6 +556,41 @@ struct Property
 inline bool operator==(const Property &a, const Property &b) { return a.is_string == b.is_string && a.str == b.str; }
 inline bool operator!=(const Property &a, const Property &b) { return a.is_string != b.is_string || a.str != b.str; }
 
+// minimum and maximum delay
+struct DelayPair
+{
+    DelayPair(){};
+    explicit DelayPair(delay_t delay) : min_delay(delay), max_delay(delay){};
+    DelayPair(delay_t min_delay, delay_t max_delay) : min_delay(min_delay), max_delay(max_delay){};
+    delay_t minDelay() const { return min_delay; };
+    delay_t maxDelay() const { return max_delay; };
+    delay_t min_delay, max_delay;
+    DelayPair operator+(const DelayPair &other) const
+    {
+        return {min_delay + other.min_delay, max_delay + other.max_delay};
+    }
+};
+
+// four-quadrant, min and max rise and fall delay
+struct DelayQuad
+{
+    DelayPair rise, fall;
+    explicit DelayQuad(delay_t delay) : rise(delay), fall(delay){};
+    DelayQuad(delay_t min_delay, delay_t max_delay) : rise(min_delay, max_delay), fall(min_delay, max_delay){};
+    DelayQuad(DelayPair rise, DelayPair fall) : rise(rise), fall(fall){};
+    DelayQuad(delay_t min_rise, delay_t max_rise, delay_t min_fall, delay_t max_fall)
+            : rise(min_rise, max_rise), fall(min_fall, max_fall){};
+
+    delay_t minRiseDelay() const { return rise.minDelay(); };
+    delay_t maxRiseDelay() const { return rise.maxDelay(); };
+    delay_t minFallDelay() const { return fall.minDelay(); };
+    delay_t maxFallDelay() const { return fall.maxDelay(); };
+    delay_t minDelay() const { return std::min<delay_t>(rise.minDelay(), fall.minDelay()); };
+    delay_t maxDelay() const { return std::max<delay_t>(rise.maxDelay(), fall.maxDelay()); };
+
+    DelayQuad operator+(const DelayQuad &other) const { return {rise + other.rise, fall + other.fall}; }
+};
+
 struct ClockConstraint;
 
 struct NetInfo : ArchNetInfo

--- a/common/pybindings.cc
+++ b/common/pybindings.cc
@@ -139,6 +139,31 @@ PYBIND11_EMBEDDED_MODULE(MODULE_NAME, m)
             .value("STRENGTH_USER", STRENGTH_USER)
             .export_values();
 
+    py::class_<DelayPair>(m, "DelayPair")
+            .def(py::init<>())
+            .def(py::init<delay_t>())
+            .def(py::init<delay_t, delay_t>())
+            .def_readwrite("min_delay", &DelayPair::min_delay)
+            .def_readwrite("max_delay", &DelayPair::max_delay)
+            .def("minDelay", &DelayPair::minDelay)
+            .def("maxDelay", &DelayPair::maxDelay);
+
+    py::class_<DelayQuad>(m, "DelayQuad")
+            .def(py::init<>())
+            .def(py::init<delay_t>())
+            .def(py::init<delay_t, delay_t>())
+            .def(py::init<delay_t, delay_t, delay_t, delay_t>())
+            .def(py::init<DelayPair, DelayPair>())
+            .def_readwrite("rise", &DelayQuad::rise)
+            .def_readwrite("fall", &DelayQuad::fall)
+            .def("minDelay", &DelayQuad::minDelay)
+            .def("minRiseDelay", &DelayQuad::minRiseDelay)
+            .def("minFallDelay", &DelayQuad::minFallDelay)
+            .def("maxDelay", &DelayQuad::maxDelay)
+            .def("maxRiseDelay", &DelayQuad::maxRiseDelay)
+            .def("maxFallDelay", &DelayQuad::maxFallDelay)
+            .def("delayPair", &DelayQuad::delayPair);
+
     typedef std::unordered_map<IdString, Property> AttrMap;
     typedef std::unordered_map<IdString, PortInfo> PortMap;
     typedef std::unordered_map<IdString, IdString> IdIdMap;

--- a/common/sdf.cc
+++ b/common/sdf.cc
@@ -231,19 +231,19 @@ void Context::writeSDF(std::ostream &out, bool cvc_mode) const
     wr.program = "nextpnr";
 
     const double delay_scale = 1000;
-    // Convert from DelayInfo to SDF-friendly RiseFallDelay
-    auto convert_delay = [&](const DelayInfo &dly) {
+    // Convert from DelayQuad to SDF-friendly RiseFallDelay
+    auto convert_delay = [&](const DelayQuad &dly) {
         RiseFallDelay rf;
-        rf.rise.min = getDelayNS(dly.minRaiseDelay()) * delay_scale;
-        rf.rise.typ = getDelayNS((dly.minRaiseDelay() + dly.maxRaiseDelay()) / 2) * delay_scale; // fixme: typ delays?
-        rf.rise.max = getDelayNS(dly.maxRaiseDelay()) * delay_scale;
+        rf.rise.min = getDelayNS(dly.minRiseDelay()) * delay_scale;
+        rf.rise.typ = getDelayNS((dly.minRiseDelay() + dly.maxRiseDelay()) / 2) * delay_scale; // fixme: typ delays?
+        rf.rise.max = getDelayNS(dly.maxRiseDelay()) * delay_scale;
         rf.fall.min = getDelayNS(dly.minFallDelay()) * delay_scale;
         rf.fall.typ = getDelayNS((dly.minFallDelay() + dly.maxFallDelay()) / 2) * delay_scale; // fixme: typ delays?
         rf.fall.max = getDelayNS(dly.maxFallDelay()) * delay_scale;
         return rf;
     };
 
-    auto convert_setuphold = [&](const DelayInfo &setup, const DelayInfo &hold) {
+    auto convert_setuphold = [&](const DelayPair &setup, const DelayPair &hold) {
         RiseFallDelay rf;
         rf.rise.min = getDelayNS(setup.minDelay()) * delay_scale;
         rf.rise.typ = getDelayNS((setup.minDelay() + setup.maxDelay()) / 2) * delay_scale; // fixme: typ delays?
@@ -273,7 +273,7 @@ void Context::writeSDF(std::ostream &out, bool cvc_mode) const
                         continue;
                     if (other.second.type == PORT_OUT)
                         continue;
-                    DelayInfo dly;
+                    DelayQuad dly;
                     if (!getCellDelay(ci, other.first, port.first, dly))
                         continue;
                     IOPath iop;
@@ -323,8 +323,8 @@ void Context::writeSDF(std::ostream &out, bool cvc_mode) const
             ic.from.port = ni->driver.port.str(this);
             ic.to.cell = usr.cell->name.str(this);
             ic.to.port = usr.port.str(this);
-            // FIXME: min/max routing delay - or at least constructing DelayInfo here
-            ic.delay = convert_delay(getDelayFromNS(getDelayNS(getNetinfoRouteDelay(ni, usr))));
+            // FIXME: min/max routing delay
+            ic.delay = convert_delay(DelayQuad(getNetinfoRouteDelay(ni, usr)));
             wr.conn.push_back(ic);
         }
     }

--- a/common/timing_opt.cc
+++ b/common/timing_opt.cc
@@ -328,7 +328,7 @@ class TimingOptimiser
                     if (!net_crit.count(pn->name) || net_crit.at(pn->name).criticality.empty())
                         continue;
                     int ccount;
-                    DelayInfo combDelay;
+                    DelayQuad combDelay;
                     TimingPortClass tpclass = ctx->getPortTimingClass(cell, port.first, ccount);
                     if (tpclass != TMG_COMB_INPUT)
                         continue;
@@ -367,7 +367,7 @@ class TimingOptimiser
                     if (!net_crit.count(pn->name) || net_crit.at(pn->name).criticality.empty())
                         continue;
                     int ccount;
-                    DelayInfo combDelay;
+                    DelayQuad combDelay;
                     TimingPortClass tpclass = ctx->getPortTimingClass(cell, port.first, ccount);
                     if (tpclass != TMG_COMB_OUTPUT && tpclass != TMG_REGISTER_OUTPUT)
                         continue;

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -43,21 +43,6 @@ With the exception of `ArchNetInfo` and `ArchCellInfo`, the following types shou
 
 A scalar type that is used to  represent delays. May be an integer or float type.
 
-### DelayInfo
-
-A struct representing the delay across a timing arc. Must provide a `+` operator for getting the combined delay of two arcs, and the following methods to access concrete timings:
-
-```
-delay_t minRaiseDelay() const { return delay; }
-delay_t maxRaiseDelay() const { return delay; }
-
-delay_t minFallDelay() const { return delay; }
-delay_t maxFallDelay() const { return delay; }
-
-delay_t minDelay() const { return delay; }
-delay_t maxDelay() const { return delay; }
-```
-
 ### BelId
 
 A type representing a bel name. `BelId()` must construct a unique null-value. Must provide `==`, `!=`, and `<` operators and a specialization for `std::hash<BelId>`.
@@ -332,7 +317,7 @@ will make the given wire available.
 
 *BaseArch default: returns `getBoundWireNet(wire)`*
 
-### DelayInfo getWireDelay(WireId wire) const
+### DelayQuad getWireDelay(WireId wire) const
 
 Get the delay for a wire.
 
@@ -448,7 +433,7 @@ Get the destination wire for a pip.
 Bi-directional switches (transfer gates) are modeled using two
 anti-parallel pips.
 
-### DelayInfo getPipDelay(PipId pip) const
+### DelayQuad getPipDelay(PipId pip) const
 
 Get the delay for a pip.
 
@@ -541,9 +526,9 @@ actual penalty used is a multiple of this value (i.e. a weighted version of this
 
 Convert an `delay_t` to an actual real-world delay in nanoseconds.
 
-### DelayInfo getDelayFromNS(float v) const
+### delay_t getDelayFromNS(float v) const
 
-Convert a real-world delay in nanoseconds to a DelayInfo with equal min/max rising/falling values.
+Convert a real-world delay in nanoseconds to a `delay_t`.
 
 ### uint32\_t getDelayChecksum(delay\_t v) const
 
@@ -609,7 +594,7 @@ Return the decal and X/Y position for the graphics representing a group.
 Cell Delay Methods
 ------------------
 
-### bool getCellDelay(const CellInfo \*cell, IdString fromPort, IdString toPort, DelayInfo &delay) const
+### bool getCellDelay(const CellInfo \*cell, IdString fromPort, IdString toPort, DelayQuad &delay) const
 
 Returns the delay for the specified path through a cell in the `&delay` argument. The method returns
 false if there is no timing relationship from `fromPort` to `toPort`.

--- a/docs/generic.md
+++ b/docs/generic.md
@@ -22,7 +22,7 @@ so named arguments may be used.
 
 Adds a wire with a name, type (for user purposes only, ignored by all nextpnr code other than the UI) to the FPGA description. x and y give a nominal location of the wire for delay estimation purposes. Delay estimates are important for router performance (as the router uses an A* type algorithm), even if timing is not of importance.
 
-### addPip(IdString name, IdString type, IdString srcWire, IdString dstWire, DelayInfo delay, Loc loc);
+### addPip(IdString name, IdString type, IdString srcWire, IdString dstWire, float delay, Loc loc);
 
 Adds a pip (programmable connection between two named wires). Pip delays that correspond to delay estimates are important for router performance (as the router uses an A* type algorithm), even if timing is otherwise not of importance.
 
@@ -77,16 +77,16 @@ Set the timing class of a port on a particular cell to a clock input.
 _NOTE: All cell timing functions apply to an individual named cell and not a cell type. This is because
 cell-specific configuration might affect timing, e.g. whether or not the register is used for a slice._
 
-### void addCellTimingDelay(IdString cell, IdString fromPort, IdString toPort, DelayInfo delay);
+### void addCellTimingDelay(IdString cell, IdString fromPort, IdString toPort, float delay);
 
 Specify the combinational delay between two ports of a cell, and set the timing class of
  those ports as combinational input/output.
 
-### void addCellTimingSetupHold(IdString cell, IdString port, IdString clock, DelayInfo setup, DelayInfo hold);
+### void addCellTimingSetupHold(IdString cell, IdString port, IdString clock, float setup, float hold);
 
 Specify setup and hold timings for a port of a cell, and set the timing class of that port as register input.
 
-### void addCellTimingClockToOut(IdString cell, IdString port, IdString clock, DelayInfo clktoq);
+### void addCellTimingClockToOut(IdString cell, IdString port, IdString clock, float clktoq);
 
 Specify clock-to-out time for a port of a cell, and set the timing class of that port as register output.
 

--- a/ecp5/archdefs.h
+++ b/ecp5/archdefs.h
@@ -28,28 +28,6 @@ NEXTPNR_NAMESPACE_BEGIN
 
 typedef int delay_t;
 
-struct DelayInfo
-{
-    delay_t min_delay = 0, max_delay = 0;
-
-    delay_t minRaiseDelay() const { return min_delay; }
-    delay_t maxRaiseDelay() const { return max_delay; }
-
-    delay_t minFallDelay() const { return min_delay; }
-    delay_t maxFallDelay() const { return max_delay; }
-
-    delay_t minDelay() const { return min_delay; }
-    delay_t maxDelay() const { return max_delay; }
-
-    DelayInfo operator+(const DelayInfo &other) const
-    {
-        DelayInfo ret;
-        ret.min_delay = this->min_delay + other.min_delay;
-        ret.max_delay = this->max_delay + other.max_delay;
-        return ret;
-    }
-};
-
 // -----------------------------------------------------------------------
 
 // https://bugreports.qt.io/browse/QTBUG-80789

--- a/fpga_interchange/arch.cc
+++ b/fpga_interchange/arch.cc
@@ -686,7 +686,7 @@ delay_t Arch::predictDelay(const NetInfo *net_info, const PortRef &sink) const
     return 0;
 }
 
-bool Arch::getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const
+bool Arch::getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const
 {
     // FIXME: Implement when adding timing-driven place and route.
     return false;

--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -1127,12 +1127,7 @@ struct Arch : ArchAPI<ArchRanges>
         return w2n == wire_to_net.end() ? nullptr : w2n->second;
     }
 
-    DelayInfo getWireDelay(WireId wire) const override
-    {
-        DelayInfo delay;
-        delay.delay = 0;
-        return delay;
-    }
+    DelayQuad getWireDelay(WireId wire) const override { return DelayQuad(0); }
 
     TileWireRange get_tile_wire_range(WireId wire) const
     {
@@ -1279,7 +1274,7 @@ struct Arch : ArchAPI<ArchRanges>
         return canonical_wire(chip_info, pip.tile, loc_info(chip_info, pip).pip_data[pip.index].dst_index);
     }
 
-    DelayInfo getPipDelay(PipId pip) const override { return DelayInfo(); }
+    DelayQuad getPipDelay(PipId pip) const override { return DelayQuad(0); }
 
     DownhillPipRange getPipsDownhill(WireId wire) const override
     {
@@ -1333,12 +1328,7 @@ struct Arch : ArchAPI<ArchRanges>
     delay_t getDelayEpsilon() const override { return 20; }
     delay_t getRipupDelayPenalty() const override { return 120; }
     float getDelayNS(delay_t v) const override { return v * 0.001; }
-    DelayInfo getDelayFromNS(float ns) const override
-    {
-        DelayInfo del;
-        del.delay = delay_t(ns * 1000);
-        return del;
-    }
+    delay_t getDelayFromNS(float ns) const override { return delay_t(ns * 1000); }
     uint32_t getDelayChecksum(delay_t v) const override { return v; }
     bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const override;
 
@@ -1363,7 +1353,7 @@ struct Arch : ArchAPI<ArchRanges>
 
     // Get the delay through a cell from one port to another, returning false
     // if no path exists. This only considers combinational delays, as required by the Arch API
-    bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const override;
+    bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const override;
     // Get the port class, also setting clockInfoCount to the number of TimingClockingInfos associated with a port
     TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const override;
     // Get the TimingClockingInfo of a port

--- a/fpga_interchange/archdefs.h
+++ b/fpga_interchange/archdefs.h
@@ -28,27 +28,6 @@ NEXTPNR_NAMESPACE_BEGIN
 
 typedef int delay_t;
 
-struct DelayInfo
-{
-    delay_t delay = 0;
-
-    delay_t minRaiseDelay() const { return delay; }
-    delay_t maxRaiseDelay() const { return delay; }
-
-    delay_t minFallDelay() const { return delay; }
-    delay_t maxFallDelay() const { return delay; }
-
-    delay_t minDelay() const { return delay; }
-    delay_t maxDelay() const { return delay; }
-
-    DelayInfo operator+(const DelayInfo &other) const
-    {
-        DelayInfo ret;
-        ret.delay = this->delay + other.delay;
-        return ret;
-    }
-};
-
 // -----------------------------------------------------------------------
 
 struct BelId

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -41,7 +41,7 @@ struct PipInfo
     std::map<IdString, std::string> attrs;
     NetInfo *bound_net;
     WireId srcWire, dstWire;
-    DelayInfo delay;
+    delay_t delay;
     DecalXY decalxy;
     Loc loc;
 };
@@ -113,7 +113,7 @@ NEXTPNR_NAMESPACE_BEGIN
 struct CellTiming
 {
     std::unordered_map<IdString, TimingPortClass> portClasses;
-    std::unordered_map<CellDelayKey, DelayInfo> combDelays;
+    std::unordered_map<CellDelayKey, DelayQuad> combDelays;
     std::unordered_map<IdString, std::vector<TimingClockingInfo>> clockingInfo;
 };
 
@@ -177,7 +177,7 @@ struct Arch : ArchAPI<ArchRanges>
     std::unordered_map<IdString, CellTiming> cellTiming;
 
     void addWire(IdStringList name, IdString type, int x, int y);
-    void addPip(IdStringList name, IdString type, IdStringList srcWire, IdStringList dstWire, DelayInfo delay, Loc loc);
+    void addPip(IdStringList name, IdString type, IdStringList srcWire, IdStringList dstWire, delay_t delay, Loc loc);
 
     void addBel(IdStringList name, IdString type, Loc loc, bool gb, bool hidden);
     void addBelInput(IdStringList bel, IdString name, IdStringList wire);
@@ -203,9 +203,9 @@ struct Arch : ArchAPI<ArchRanges>
     void setDelayScaling(double scale, double offset);
 
     void addCellTimingClock(IdString cell, IdString port);
-    void addCellTimingDelay(IdString cell, IdString fromPort, IdString toPort, DelayInfo delay);
-    void addCellTimingSetupHold(IdString cell, IdString port, IdString clock, DelayInfo setup, DelayInfo hold);
-    void addCellTimingClockToOut(IdString cell, IdString port, IdString clock, DelayInfo clktoq);
+    void addCellTimingDelay(IdString cell, IdString fromPort, IdString toPort, delay_t delay);
+    void addCellTimingSetupHold(IdString cell, IdString port, IdString clock, delay_t setup, delay_t hold);
+    void addCellTimingClockToOut(IdString cell, IdString port, IdString clock, delay_t clktoq);
 
     void clearCellBelPinMap(IdString cell, IdString cell_pin);
     void addCellBelPinMapping(IdString cell, IdString cell_pin, IdString bel_pin);
@@ -260,7 +260,7 @@ struct Arch : ArchAPI<ArchRanges>
     NetInfo *getBoundWireNet(WireId wire) const override;
     WireId getConflictingWireWire(WireId wire) const override { return wire; }
     NetInfo *getConflictingWireNet(WireId wire) const override;
-    DelayInfo getWireDelay(WireId wire) const override { return DelayInfo(); }
+    DelayQuad getWireDelay(WireId wire) const override { return DelayQuad(0); }
     const std::vector<WireId> &getWires() const override;
     const std::vector<BelPin> &getWireBelPins(WireId wire) const override;
 
@@ -279,7 +279,7 @@ struct Arch : ArchAPI<ArchRanges>
     Loc getPipLocation(PipId pip) const override;
     WireId getPipSrcWire(PipId pip) const override;
     WireId getPipDstWire(PipId pip) const override;
-    DelayInfo getPipDelay(PipId pip) const override;
+    DelayQuad getPipDelay(PipId pip) const override;
     const std::vector<PipId> &getPipsDownhill(WireId wire) const override;
     const std::vector<PipId> &getPipsUphill(WireId wire) const override;
 
@@ -297,12 +297,7 @@ struct Arch : ArchAPI<ArchRanges>
     delay_t getRipupDelayPenalty() const override { return 0.015; }
     float getDelayNS(delay_t v) const override { return v; }
 
-    DelayInfo getDelayFromNS(float ns) const override
-    {
-        DelayInfo del;
-        del.delay = ns;
-        return del;
-    }
+    delay_t getDelayFromNS(float ns) const override { return ns; }
 
     uint32_t getDelayChecksum(delay_t v) const override { return 0; }
     bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const override;
@@ -350,7 +345,7 @@ struct Arch : ArchAPI<ArchRanges>
     DecalXY getPipDecal(PipId pip) const override;
     DecalXY getGroupDecal(GroupId group) const override;
 
-    bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const override;
+    bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const override;
     // Get the port class, also setting clockInfoCount to the number of TimingClockingInfos associated with a port
     TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const override;
     // Get the TimingClockingInfo of a port

--- a/generic/arch_pybindings.cc
+++ b/generic/arch_pybindings.cc
@@ -60,8 +60,6 @@ void arch_wrap_python(py::module &m)
 
     py::class_<BelPin>(m, "BelPin").def_readwrite("bel", &BelPin::bel).def_readwrite("pin", &BelPin::pin);
 
-    py::class_<DelayInfo>(m, "DelayInfo").def("maxDelay", &DelayInfo::maxDelay).def("minDelay", &DelayInfo::minDelay);
-
     fn_wrapper_1a<Context, decltype(&Context::getBelType), &Context::getBelType, conv_to_str<IdString>,
                   conv_from_str<BelId>>::def_wrap(ctx_cls, "getBelType");
     fn_wrapper_1a<Context, decltype(&Context::checkBelAvail), &Context::checkBelAvail, pass_through<bool>,
@@ -126,10 +124,10 @@ void arch_wrap_python(py::module &m)
                   conv_from_str<PipId>>::def_wrap(ctx_cls, "getPipSrcWire");
     fn_wrapper_1a<Context, decltype(&Context::getPipDstWire), &Context::getPipDstWire, conv_to_str<WireId>,
                   conv_from_str<PipId>>::def_wrap(ctx_cls, "getPipDstWire");
-    fn_wrapper_1a<Context, decltype(&Context::getPipDelay), &Context::getPipDelay, pass_through<DelayInfo>,
+    fn_wrapper_1a<Context, decltype(&Context::getPipDelay), &Context::getPipDelay, pass_through<DelayQuad>,
                   conv_from_str<PipId>>::def_wrap(ctx_cls, "getPipDelay");
 
-    fn_wrapper_1a<Context, decltype(&Context::getDelayFromNS), &Context::getDelayFromNS, pass_through<DelayInfo>,
+    fn_wrapper_1a<Context, decltype(&Context::getDelayFromNS), &Context::getDelayFromNS, pass_through<delay_t>,
                   pass_through<double>>::def_wrap(ctx_cls, "getDelayFromNS");
 
     fn_wrapper_0a<Context, decltype(&Context::getChipName), &Context::getChipName, pass_through<std::string>>::def_wrap(
@@ -159,8 +157,8 @@ void arch_wrap_python(py::module &m)
                                                                                              "y"_a);
     fn_wrapper_6a_v<Context, decltype(&Context::addPip), &Context::addPip, conv_from_str<IdStringList>,
                     conv_from_str<IdString>, conv_from_str<IdStringList>, conv_from_str<IdStringList>,
-                    pass_through<DelayInfo>, pass_through<Loc>>::def_wrap(ctx_cls, "addPip", "name"_a, "type"_a,
-                                                                          "srcWire"_a, "dstWire"_a, "delay"_a, "loc"_a);
+                    pass_through<delay_t>, pass_through<Loc>>::def_wrap(ctx_cls, "addPip", "name"_a, "type"_a,
+                                                                        "srcWire"_a, "dstWire"_a, "delay"_a, "loc"_a);
 
     fn_wrapper_5a_v<Context, decltype(&Context::addBel), &Context::addBel, conv_from_str<IdStringList>,
                     conv_from_str<IdString>, pass_through<Loc>, pass_through<bool>,
@@ -215,16 +213,16 @@ void arch_wrap_python(py::module &m)
                                                                                 "port"_a);
     fn_wrapper_4a_v<Context, decltype(&Context::addCellTimingDelay), &Context::addCellTimingDelay,
                     conv_from_str<IdString>, conv_from_str<IdString>, conv_from_str<IdString>,
-                    pass_through<DelayInfo>>::def_wrap(ctx_cls, "addCellTimingDelay", "cell"_a, "fromPort"_a,
-                                                       "toPort"_a, "delay"_a);
+                    pass_through<delay_t>>::def_wrap(ctx_cls, "addCellTimingDelay", "cell"_a, "fromPort"_a, "toPort"_a,
+                                                     "delay"_a);
     fn_wrapper_5a_v<Context, decltype(&Context::addCellTimingSetupHold), &Context::addCellTimingSetupHold,
-                    conv_from_str<IdString>, conv_from_str<IdString>, conv_from_str<IdString>, pass_through<DelayInfo>,
-                    pass_through<DelayInfo>>::def_wrap(ctx_cls, "addCellTimingSetupHold", "cell"_a, "port"_a, "clock"_a,
-                                                       "setup"_a, "hold"_a);
+                    conv_from_str<IdString>, conv_from_str<IdString>, conv_from_str<IdString>, pass_through<delay_t>,
+                    pass_through<delay_t>>::def_wrap(ctx_cls, "addCellTimingSetupHold", "cell"_a, "port"_a, "clock"_a,
+                                                     "setup"_a, "hold"_a);
     fn_wrapper_4a_v<Context, decltype(&Context::addCellTimingClockToOut), &Context::addCellTimingClockToOut,
                     conv_from_str<IdString>, conv_from_str<IdString>, conv_from_str<IdString>,
-                    pass_through<DelayInfo>>::def_wrap(ctx_cls, "addCellTimingClockToOut", "cell"_a, "port"_a,
-                                                       "clock"_a, "clktoq"_a);
+                    pass_through<delay_t>>::def_wrap(ctx_cls, "addCellTimingClockToOut", "cell"_a, "port"_a, "clock"_a,
+                                                     "clktoq"_a);
 
     fn_wrapper_2a_v<Context, decltype(&Context::clearCellBelPinMap), &Context::clearCellBelPinMap,
                     conv_from_str<IdString>, conv_from_str<IdString>>::def_wrap(ctx_cls, "clearCellBelPinMap", "cell"_a,

--- a/generic/archdefs.h
+++ b/generic/archdefs.h
@@ -25,27 +25,6 @@ NEXTPNR_NAMESPACE_BEGIN
 
 typedef float delay_t;
 
-struct DelayInfo
-{
-    delay_t delay = 0;
-
-    delay_t minRaiseDelay() const { return delay; }
-    delay_t maxRaiseDelay() const { return delay; }
-
-    delay_t minFallDelay() const { return delay; }
-    delay_t maxFallDelay() const { return delay; }
-
-    delay_t minDelay() const { return delay; }
-    delay_t maxDelay() const { return delay; }
-
-    DelayInfo operator+(const DelayInfo &other) const
-    {
-        DelayInfo ret;
-        ret.delay = this->delay + other.delay;
-        return ret;
-    }
-};
-
 typedef IdStringList BelId;
 typedef IdStringList WireId;
 typedef IdStringList PipId;

--- a/gowin/arch_pybindings.cc
+++ b/gowin/arch_pybindings.cc
@@ -59,8 +59,6 @@ void arch_wrap_python(py::module &m)
 
     py::class_<BelPin>(m, "BelPin").def_readwrite("bel", &BelPin::bel).def_readwrite("pin", &BelPin::pin);
 
-    py::class_<DelayInfo>(m, "DelayInfo").def("maxDelay", &DelayInfo::maxDelay).def("minDelay", &DelayInfo::minDelay);
-
     fn_wrapper_1a<Context, decltype(&Context::getBelType), &Context::getBelType, conv_to_str<IdString>,
                   conv_from_str<BelId>>::def_wrap(ctx_cls, "getBelType");
     fn_wrapper_1a<Context, decltype(&Context::checkBelAvail), &Context::checkBelAvail, pass_through<bool>,
@@ -125,10 +123,10 @@ void arch_wrap_python(py::module &m)
                   conv_from_str<PipId>>::def_wrap(ctx_cls, "getPipSrcWire");
     fn_wrapper_1a<Context, decltype(&Context::getPipDstWire), &Context::getPipDstWire, conv_to_str<WireId>,
                   conv_from_str<PipId>>::def_wrap(ctx_cls, "getPipDstWire");
-    fn_wrapper_1a<Context, decltype(&Context::getPipDelay), &Context::getPipDelay, pass_through<DelayInfo>,
+    fn_wrapper_1a<Context, decltype(&Context::getPipDelay), &Context::getPipDelay, pass_through<DelayQuad>,
                   conv_from_str<PipId>>::def_wrap(ctx_cls, "getPipDelay");
 
-    fn_wrapper_1a<Context, decltype(&Context::getDelayFromNS), &Context::getDelayFromNS, pass_through<DelayInfo>,
+    fn_wrapper_1a<Context, decltype(&Context::getDelayFromNS), &Context::getDelayFromNS, pass_through<delay_t>,
                   pass_through<double>>::def_wrap(ctx_cls, "getDelayFromNS");
 
     fn_wrapper_0a<Context, decltype(&Context::getChipName), &Context::getChipName, pass_through<std::string>>::def_wrap(

--- a/gowin/archdefs.h
+++ b/gowin/archdefs.h
@@ -26,33 +26,6 @@ NEXTPNR_NAMESPACE_BEGIN
 
 typedef float delay_t;
 
-struct DelayInfo
-{
-    delay_t minRaise = 0;
-    delay_t minFall = 0;
-    delay_t maxRaise = 0;
-    delay_t maxFall = 0;
-
-    delay_t minRaiseDelay() const { return minRaise; }
-    delay_t maxRaiseDelay() const { return maxRaise; }
-
-    delay_t minFallDelay() const { return minFall; }
-    delay_t maxFallDelay() const { return maxFall; }
-
-    delay_t minDelay() const { return std::min(minFall, minRaise); }
-    delay_t maxDelay() const { return std::max(maxFall, maxRaise); }
-
-    DelayInfo operator+(const DelayInfo &other) const
-    {
-        DelayInfo ret;
-        ret.minRaise = this->minRaise + other.minRaise;
-        ret.maxRaise = this->maxRaise + other.maxRaise;
-        ret.minFall = this->minFall + other.minFall;
-        ret.maxFall = this->maxFall + other.maxFall;
-        return ret;
-    }
-};
-
 #ifndef Q_MOC_RUN
 enum ConstIds
 {

--- a/gui/designwidget.cc
+++ b/gui/designwidget.cc
@@ -652,11 +652,11 @@ void DesignWidget::onSelectionChanged(int num, const QItemSelection &, const QIt
             addProperty(attrsItem, QVariant::String, item.first.c_str(ctx), item.second.c_str());
         }
 
-        DelayInfo delay = ctx->getWireDelay(wire);
+        DelayQuad delay = ctx->getWireDelay(wire);
 
         QtProperty *delayItem = addSubGroup(topItem, "Delay");
-        addProperty(delayItem, QVariant::Double, "Min Raise", delay.minRaiseDelay());
-        addProperty(delayItem, QVariant::Double, "Max Raise", delay.maxRaiseDelay());
+        addProperty(delayItem, QVariant::Double, "Min Raise", delay.minRiseDelay());
+        addProperty(delayItem, QVariant::Double, "Max Raise", delay.maxRiseDelay());
         addProperty(delayItem, QVariant::Double, "Min Fall", delay.minFallDelay());
         addProperty(delayItem, QVariant::Double, "Max Fall", delay.maxFallDelay());
 
@@ -721,11 +721,11 @@ void DesignWidget::onSelectionChanged(int num, const QItemSelection &, const QIt
             addProperty(attrsItem, QVariant::String, item.first.c_str(ctx), item.second.c_str());
         }
 
-        DelayInfo delay = ctx->getPipDelay(pip);
+        DelayQuad delay = ctx->getPipDelay(pip);
 
         QtProperty *delayItem = addSubGroup(topItem, "Delay");
-        addProperty(delayItem, QVariant::Double, "Min Raise", delay.minRaiseDelay());
-        addProperty(delayItem, QVariant::Double, "Max Raise", delay.maxRaiseDelay());
+        addProperty(delayItem, QVariant::Double, "Min Raise", delay.minRiseDelay());
+        addProperty(delayItem, QVariant::Double, "Max Raise", delay.maxRiseDelay());
         addProperty(delayItem, QVariant::Double, "Min Fall", delay.minFallDelay());
         addProperty(delayItem, QVariant::Double, "Max Fall", delay.maxFallDelay());
     } else if (type == ElementType::NET) {

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -578,15 +578,13 @@ struct Arch : BaseArch<ArchRanges>
         return wire_to_net[wire.index];
     }
 
-    DelayInfo getWireDelay(WireId wire) const override
+    DelayQuad getWireDelay(WireId wire) const override
     {
-        DelayInfo delay;
         NPNR_ASSERT(wire != WireId());
         if (fast_part)
-            delay.delay = chip_info->wire_data[wire.index].fast_delay;
+            return DelayQuad(chip_info->wire_data[wire.index].fast_delay);
         else
-            delay.delay = chip_info->wire_data[wire.index].slow_delay;
-        return delay;
+            return DelayQuad(chip_info->wire_data[wire.index].slow_delay);
     }
 
     BelPinRange getWireBelPins(WireId wire) const override
@@ -739,15 +737,13 @@ struct Arch : BaseArch<ArchRanges>
         return wire;
     }
 
-    DelayInfo getPipDelay(PipId pip) const override
+    DelayQuad getPipDelay(PipId pip) const override
     {
-        DelayInfo delay;
         NPNR_ASSERT(pip != PipId());
         if (fast_part)
-            delay.delay = chip_info->pip_data[pip.index].fast_delay;
+            return DelayQuad(chip_info->pip_data[pip.index].fast_delay);
         else
-            delay.delay = chip_info->pip_data[pip.index].slow_delay;
-        return delay;
+            return DelayQuad(chip_info->pip_data[pip.index].slow_delay);
     }
 
     PipRange getPipsDownhill(WireId wire) const override
@@ -788,12 +784,7 @@ struct Arch : BaseArch<ArchRanges>
     delay_t getDelayEpsilon() const override { return 20; }
     delay_t getRipupDelayPenalty() const override { return 200; }
     float getDelayNS(delay_t v) const override { return v * 0.001; }
-    DelayInfo getDelayFromNS(float ns) const override
-    {
-        DelayInfo del;
-        del.delay = delay_t(ns * 1000);
-        return del;
-    }
+    delay_t getDelayFromNS(float ns) const override { return delay_t(ns * 1000); }
     uint32_t getDelayChecksum(delay_t v) const override { return v; }
     bool getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay_t &budget) const override;
 
@@ -818,10 +809,10 @@ struct Arch : BaseArch<ArchRanges>
 
     // Get the delay through a cell from one port to another, returning false
     // if no path exists. This only considers combinational delays, as required by the Arch API
-    bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const override;
+    bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const override;
     // get_cell_delay_internal is similar to the above, but without false path checks and including clock to out delays
     // for internal arch use only
-    bool get_cell_delay_internal(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const;
+    bool get_cell_delay_internal(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const;
     // Get the port class, also setting clockInfoCount to the number of TimingClockingInfos associated with a port
     TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const override;
     // Get the TimingClockingInfo of a port

--- a/ice40/archdefs.h
+++ b/ice40/archdefs.h
@@ -25,27 +25,6 @@ NEXTPNR_NAMESPACE_BEGIN
 
 typedef int delay_t;
 
-struct DelayInfo
-{
-    delay_t delay = 0;
-
-    delay_t minRaiseDelay() const { return delay; }
-    delay_t maxRaiseDelay() const { return delay; }
-
-    delay_t minFallDelay() const { return delay; }
-    delay_t maxFallDelay() const { return delay; }
-
-    delay_t minDelay() const { return delay; }
-    delay_t maxDelay() const { return delay; }
-
-    DelayInfo operator+(const DelayInfo &other) const
-    {
-        DelayInfo ret;
-        ret.delay = this->delay + other.delay;
-        return ret;
-    }
-};
-
 // -----------------------------------------------------------------------
 
 // https://bugreports.qt.io/browse/QTBUG-80789

--- a/ice40/pack.cc
+++ b/ice40/pack.cc
@@ -1085,17 +1085,17 @@ void set_period(Context *ctx, CellInfo *ci, IdString port, delay_t period)
     if (to == nullptr)
         return;
     if (to->clkconstr != nullptr) {
-        if (!equals_epsilon(to->clkconstr->period.delay, period))
+        if (!equals_epsilon(to->clkconstr->period.maxDelay(), period))
             log_warning("    Overriding derived constraint of %.1f MHz on net %s with user-specified constraint of "
                         "%.1f MHz.\n",
-                        MHz(ctx, to->clkconstr->period.delay), to->name.c_str(ctx), MHz(ctx, period));
+                        MHz(ctx, to->clkconstr->period.maxDelay()), to->name.c_str(ctx), MHz(ctx, period));
         return;
     }
     to->clkconstr = std::unique_ptr<ClockConstraint>(new ClockConstraint());
-    to->clkconstr->low.delay = period / 2;
-    to->clkconstr->high.delay = period / 2;
-    to->clkconstr->period.delay = period;
-    log_info("    Derived frequency constraint of %.1f MHz for net %s\n", MHz(ctx, to->clkconstr->period.delay),
+    to->clkconstr->low = DelayPair(period / 2);
+    to->clkconstr->high = DelayPair(period / 2);
+    to->clkconstr->period = DelayPair(period);
+    log_info("    Derived frequency constraint of %.1f MHz for net %s\n", MHz(ctx, to->clkconstr->period.maxDelay()),
              to->name.c_str(ctx));
 };
 bool get_period(Context *ctx, CellInfo *ci, IdString port, delay_t &period)
@@ -1105,7 +1105,7 @@ bool get_period(Context *ctx, CellInfo *ci, IdString port, delay_t &period)
     NetInfo *from = ci->ports.at(port).net;
     if (from == nullptr || from->clkconstr == nullptr)
         return false;
-    period = from->clkconstr->period.delay;
+    period = from->clkconstr->period.maxDelay();
     return true;
 };
 

--- a/machxo2/arch.h
+++ b/machxo2/arch.h
@@ -509,7 +509,7 @@ struct Arch : BaseArch<ArchRanges>
         return IdStringList(ids);
     }
 
-    DelayInfo getWireDelay(WireId wire) const override { return DelayInfo(); }
+    DelayQuad getWireDelay(WireId wire) const override { return DelayQuad(0); }
 
     WireRange getWires() const override
     {
@@ -582,14 +582,7 @@ struct Arch : BaseArch<ArchRanges>
         return wire;
     }
 
-    DelayInfo getPipDelay(PipId pip) const override
-    {
-        DelayInfo delay;
-
-        delay.delay = 0.01;
-
-        return delay;
-    }
+    DelayQuad getPipDelay(PipId pip) const override { return DelayQuad(0); }
 
     PipRange getPipsDownhill(WireId wire) const override
     {
@@ -633,12 +626,7 @@ struct Arch : BaseArch<ArchRanges>
     delay_t getRipupDelayPenalty() const override { return 0.015; }
     float getDelayNS(delay_t v) const override { return v; }
 
-    DelayInfo getDelayFromNS(float ns) const override
-    {
-        DelayInfo del;
-        del.delay = ns;
-        return del;
-    }
+    delay_t getDelayFromNS(float ns) const override { return ns; }
 
     uint32_t getDelayChecksum(delay_t v) const override { return v; }
 

--- a/machxo2/archdefs.h
+++ b/machxo2/archdefs.h
@@ -26,27 +26,6 @@ NEXTPNR_NAMESPACE_BEGIN
 
 typedef float delay_t;
 
-struct DelayInfo
-{
-    delay_t delay = 0;
-
-    delay_t minRaiseDelay() const { return delay; }
-    delay_t maxRaiseDelay() const { return delay; }
-
-    delay_t minFallDelay() const { return delay; }
-    delay_t maxFallDelay() const { return delay; }
-
-    delay_t minDelay() const { return delay; }
-    delay_t maxDelay() const { return delay; }
-
-    DelayInfo operator+(const DelayInfo &other) const
-    {
-        DelayInfo ret;
-        ret.delay = this->delay + other.delay;
-        return ret;
-    }
-};
-
 enum ConstIds
 {
     ID_NONE

--- a/nexus/archdefs.h
+++ b/nexus/archdefs.h
@@ -25,27 +25,6 @@ NEXTPNR_NAMESPACE_BEGIN
 
 typedef int delay_t;
 
-struct DelayInfo
-{
-    delay_t min_delay = 0, max_delay = 0;
-
-    delay_t minRaiseDelay() const { return min_delay; }
-    delay_t maxRaiseDelay() const { return max_delay; }
-
-    delay_t minFallDelay() const { return min_delay; }
-    delay_t maxFallDelay() const { return max_delay; }
-
-    delay_t minDelay() const { return min_delay; }
-    delay_t maxDelay() const { return max_delay; }
-
-    DelayInfo operator+(const DelayInfo &other) const
-    {
-        DelayInfo ret;
-        ret.min_delay = this->min_delay + other.min_delay;
-        ret.max_delay = this->max_delay + other.max_delay;
-        return ret;
-    }
-};
 // https://bugreports.qt.io/browse/QTBUG-80789
 
 #ifndef Q_MOC_RUN

--- a/nexus/pack.cc
+++ b/nexus/pack.cc
@@ -1862,9 +1862,12 @@ struct NexusPacker
                 return;
             }
             to->clkconstr = std::unique_ptr<ClockConstraint>(new ClockConstraint());
-            to->clkconstr->low = ctx->getDelayFromNS(ctx->getDelayNS(from->clkconstr->low.min_delay) / ratio);
-            to->clkconstr->high = ctx->getDelayFromNS(ctx->getDelayNS(from->clkconstr->high.min_delay) / ratio);
-            to->clkconstr->period = ctx->getDelayFromNS(ctx->getDelayNS(from->clkconstr->period.min_delay) / ratio);
+            to->clkconstr->low =
+                    DelayPair(ctx->getDelayFromNS(ctx->getDelayNS(from->clkconstr->low.min_delay) / ratio));
+            to->clkconstr->high =
+                    DelayPair(ctx->getDelayFromNS(ctx->getDelayNS(from->clkconstr->high.min_delay) / ratio));
+            to->clkconstr->period =
+                    DelayPair(ctx->getDelayFromNS(ctx->getDelayNS(from->clkconstr->period.min_delay) / ratio));
             log_info("    Derived frequency constraint of %.1f MHz for net %s\n", MHz(to->clkconstr->period.min_delay),
                      to->name.c_str(ctx));
             changed_nets.insert(to->name);


### PR DESCRIPTION
This replaces the arch-specific DelayInfo structure with new DelayPair (min/max only) and DelayQuad (min/max for both rise and fall) structures that form part of common code.

This further reduces the amount of arch-specific code; and also provides useful data structures for timing analysis improvements that are on my TODO list, as things become easier when you don't have to worry about whether a particular arch's `DelayInfo` supports min/max delays - any timing rewrite would be adding DelayPair and DelayQuad types for its own use so we might as well use them everywhere.

While there may be a small performance cost to arches that didn't separate the rise/fall cases (arches that aren't currently separating the min/max cases just need to be fixed...) in DelayInfo, my expectation is that inlining will mean this doesn't make much difference.