### PR TITLE
cmake: Don't enable any -Werror flags without opt-in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ if (MSVC)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /W4 /wd4100 /wd4244 /wd4125 /wd4800 /wd4456 /wd4458 /wd4305 /wd4459 /wd4121 /wd4996 /wd4127")
 else()
     # N.B. the -Wno-array-bounds is to work around a false positive in GCC 9
-    set(WARN_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-array-bounds -Werror=sign-compare -Werror=return-type")
+    set(WARN_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-array-bounds")
     if (WERROR)
         set(WARN_FLAGS "${WARN_FLAGS} -Werror")
     endif()


### PR DESCRIPTION
Depending on the exact compiler and/or libc this can still [cause issues](https://github.com/YoWASP/nextpnr/runs/1983657117?check_suite_focus=true) similar to the ones that arise from blanket enabling `-Werror`:

```
ccache /usr/bin/ccache /home/whitequark/Projects/yowasp/nextpnr/wasi-sdk-11.0/bin/clang++ -DARCHNAME=ecp5 -DARCH_ECP5 -DBOOST_AC_DISABLE_THREADS -DBOOST_EXCEPTION_DISABLE -DBOOST_NO_CXX11_HDR_MUTEX -DBOOST_NO_EXCEPTIONS -DBOOST_SP_NO_ATOMIC_ACCESS -DEXTERNAL_CHIPDB_ROOT=\"/share\" -DMAIN_EXECUTABLE -DNEXTPNR_NAMESPACE=nextpnr_ecp5 -DNO_GUI -DNO_PYTHON -DNPNR_DISABLE_THREADS -DWITH_HEAP -I/home/whitequark/Projects/yowasp/nextpnr/nextpnr-src/common -I/home/whitequark/Projects/yowasp/nextpnr/nextpnr-src/json -I/home/whitequark/Projects/yowasp/nextpnr/nextpnr-src/frontend -I/home/whitequark/Projects/yowasp/nextpnr/nextpnr-src/3rdparty/json11 -I/home/whitequark/Projects/yowasp/nextpnr/nextpnr-src/3rdparty/pybind11/include -I/home/whitequark/Projects/yowasp/nextpnr/boost_1_75_0 -I/home/whitequark/Projects/yowasp/nextpnr/eigen-prefix/include/eigen3 -I/home/whitequark/Projects/yowasp/nextpnr/nextpnr-src/ecp5 -I/home/whitequark/Projects/yowasp/nextpnr/nextpnr-build/generated --sysroot /home/whitequark/Projects/yowasp/nextpnr/wasi-sdk-11.0/share/wasi-sysroot -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-array-bounds -Werror=sign-compare -Werror=return-type -fPIC -O3 -g -pipe -std=gnu++14 -o CMakeFiles/nextpnr-ecp5.dir/common/svg.cc.obj -c /home/whitequark/Projects/yowasp/nextpnr/nextpnr-src/common/svg.cc
In file included from /home/whitequark/Projects/yowasp/nextpnr/nextpnr-src/common/embed.cc:5:
In file included from /home/whitequark/Projects/yowasp/nextpnr/boost_1_75_0/boost/iostreams/device/mapped_file.hpp:20:
In file included from /home/whitequark/Projects/yowasp/nextpnr/boost_1_75_0/boost/iostreams/close.hpp:19:
In file included from /home/whitequark/Projects/yowasp/nextpnr/boost_1_75_0/boost/iostreams/detail/adapter/non_blocking_adapter.hpp:12:
In file included from /home/whitequark/Projects/yowasp/nextpnr/boost_1_75_0/boost/iostreams/read.hpp:17:
/home/whitequark/Projects/yowasp/nextpnr/boost_1_75_0/boost/iostreams/char_traits.hpp:65:51: error: comparison of integers of different signs: 'std::wint_t' (aka 'int') and 'unsigned int' [-Werror,-Wsign-compare]
    static bool is_good(std::wint_t c) { return c != WEOF && c != WWOULD_BLOCK; }
                                                ~ ^  ~~~~
/home/whitequark/Projects/yowasp/nextpnr/boost_1_75_0/boost/iostreams/char_traits.hpp:66:50: error: comparison of integers of different signs: 'std::wint_t' (aka 'int') and 'unsigned int' [-Werror,-Wsign-compare]
    static bool is_eof(std::wint_t c) { return c == WEOF; }
                                               ~ ^  ~~~~
2 errors generated.
```

Fixes #600.