### PR TITLE
Gowin DFF fixes

### DIFF
--- a/gowin/archdefs.h
+++ b/gowin/archdefs.h
@@ -57,6 +57,8 @@ struct ArchCellInfo
 {
     // Is the flip-flop of this slice used
     bool ff_used;
+    // The type of this flip-flop
+    IdString ff_type;
     // Is a slice type primitive
     bool is_slice;
     // Only packing rule for slice type primitives is a single clock per tile


### PR DESCRIPTION
Under the old generic target, only plain simple DFF were supported, but the new target supports all sorts of exotic reset modes and it turns out this was not tested very well at all.

This fix makes sure that no two DFF of different types can occupy the same slice.

There is at least 1 more bug of this kind, so feel free to leave this open, or merge and I'll make new PRs as I fix more bugs.