### PR TITLE
Use new timing engine for criticality

### DIFF
--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -552,6 +552,10 @@ struct DelayPair
     {
         return {min_delay + other.min_delay, max_delay + other.max_delay};
     }
+    DelayPair operator-(const DelayPair &other) const
+    {
+        return {min_delay - other.min_delay, max_delay - other.max_delay};
+    }
 };
 
 // four-quadrant, min and max rise and fall delay
@@ -575,6 +579,7 @@ struct DelayQuad
     DelayPair delayPair() const { return DelayPair(minDelay(), maxDelay()); };
 
     DelayQuad operator+(const DelayQuad &other) const { return {rise + other.rise, fall + other.fall}; }
+    DelayQuad operator-(const DelayQuad &other) const { return {rise - other.rise, fall - other.fall}; }
 };
 
 struct ClockConstraint;

--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -241,6 +241,7 @@ class SAPlacer
         auto saplace_start = std::chrono::high_resolution_clock::now();
 
         // Invoke timing analysis to obtain criticalities
+        tmg.setup_only = true;
         if (!cfg.budgetBased)
             tmg.setup();
 

--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -78,7 +78,7 @@ class SAPlacer
 
   public:
     SAPlacer(Context *ctx, Placer1Cfg cfg)
-            : ctx(ctx), fast_bels(ctx, /*check_bel_available=*/false, cfg.minBelsForGridPick), cfg(cfg)
+            : ctx(ctx), fast_bels(ctx, /*check_bel_available=*/false, cfg.minBelsForGridPick), cfg(cfg), tmg(ctx)
     {
         for (auto bel : ctx->getBels()) {
             Loc loc = ctx->getBelLocation(bel);
@@ -242,7 +242,7 @@ class SAPlacer
 
         // Invoke timing analysis to obtain criticalities
         if (!cfg.budgetBased)
-            get_criticalities(ctx, &net_crit);
+            tmg.setup();
 
         // Calculate costs after initial placement
         setup_costs();
@@ -379,7 +379,7 @@ class SAPlacer
 
             // Invoke timing analysis to obtain criticalities
             if (!cfg.budgetBased && cfg.timing_driven)
-                get_criticalities(ctx, &net_crit);
+                tmg.run();
             // Need to rebuild costs after criticalities change
             setup_costs();
             // Reset incremental bounds
@@ -836,11 +836,9 @@ class SAPlacer
             double delay = ctx->getDelayNS(ctx->predictDelay(net, net->users.at(user)));
             return std::min(10.0, std::exp(delay - ctx->getDelayNS(net->users.at(user).budget) / 10));
         } else {
-            auto crit = net_crit.find(net->name);
-            if (crit == net_crit.end() || crit->second.criticality.empty())
-                return 0;
+            float crit = tmg.get_criticality(CellPortKey(net->users.at(user)));
             double delay = ctx->getDelayNS(ctx->predictDelay(net, net->users.at(user)));
-            return delay * std::pow(crit->second.criticality.at(user), crit_exp);
+            return delay * std::pow(crit, crit_exp);
         }
     }
 
@@ -1216,9 +1214,6 @@ class SAPlacer
     wirelen_t last_wirelen_cost, curr_wirelen_cost;
     double last_timing_cost, curr_timing_cost;
 
-    // Criticality data from timing analysis
-    NetCriticalityMap net_crit;
-
     Context *ctx;
     float temp = 10;
     float crit_exp = 8;
@@ -1235,6 +1230,8 @@ class SAPlacer
     bool require_legal = true;
     const int legalise_dia = 4;
     Placer1Cfg cfg;
+
+    TimingAnalyser tmg;
 };
 
 Placer1Cfg::Placer1Cfg(Context *ctx)

--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -139,9 +139,11 @@ template <typename T> struct EquationSystem
 class HeAPPlacer
 {
   public:
-    HeAPPlacer(Context *ctx, PlacerHeapCfg cfg) : ctx(ctx), cfg(cfg), fast_bels(ctx, /*check_bel_available=*/true, -1)
+    HeAPPlacer(Context *ctx, PlacerHeapCfg cfg)
+            : ctx(ctx), cfg(cfg), fast_bels(ctx, /*check_bel_available=*/true, -1), tmg(ctx)
     {
         Eigen::initParallel();
+        tmg.setup();
     }
 
     bool place()
@@ -269,7 +271,7 @@ class HeAPPlacer
 
             // Update timing weights
             if (cfg.timing_driven)
-                get_criticalities(ctx, &net_crit);
+                tmg.run();
 
             if (legal_hpwl < best_hpwl) {
                 best_hpwl = legal_hpwl;
@@ -355,6 +357,8 @@ class HeAPPlacer
     FastBels fast_bels;
     std::unordered_map<IdString, std::tuple<int, int>> bel_types;
 
+    TimingAnalyser tmg;
+
     struct BoundingBox
     {
         // Actual bounding box
@@ -391,8 +395,6 @@ class HeAPPlacer
 
     // Performance counting
     double solve_time = 0, cl_time = 0, sl_time = 0;
-
-    NetCriticalityMap net_crit;
 
     // Place cells with the BEL attribute set to constrain them
     void place_constraints()
@@ -736,11 +738,9 @@ class HeAPPlacer
                                            std::max<double>(1, (yaxis ? cfg.hpwl_scale_y : cfg.hpwl_scale_x) *
                                                                        std::abs(o_pos - this_pos)));
 
-                    if (user_idx != -1 && net_crit.count(ni->name)) {
-                        auto &nc = net_crit.at(ni->name);
-                        if (user_idx < int(nc.criticality.size()))
-                            weight *= (1.0 + cfg.timingWeight *
-                                                     std::pow(nc.criticality.at(user_idx), cfg.criticalityExponent));
+                    if (user_idx != -1) {
+                        weight *= (1.0 + cfg.timingWeight * std::pow(tmg.get_criticality(CellPortKey(port)),
+                                                                     cfg.criticalityExponent));
                     }
 
                     // If cell 0 is not fixed, it will stamp +w on its equation and -w on the other end's equation,

--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -143,6 +143,7 @@ class HeAPPlacer
             : ctx(ctx), cfg(cfg), fast_bels(ctx, /*check_bel_available=*/true, -1), tmg(ctx)
     {
         Eigen::initParallel();
+        tmg.setup_only = true;
         tmg.setup();
     }
 

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -34,16 +34,19 @@ void TimingAnalyser::setup()
 {
     init_ports();
     get_cell_delays();
-    get_route_delays();
     topo_sort();
     setup_port_domains();
+    run();
+}
+
+void TimingAnalyser::run()
+{
     reset_times();
+    get_route_delays();
     walk_forward();
     walk_backward();
     compute_slack();
     compute_criticality();
-    print_fmax();
-    print_report();
 }
 
 void TimingAnalyser::init_ports()

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -174,7 +174,7 @@ void TimingAnalyser::topo_sort()
         }
     }
     bool no_loops = topo.sort();
-    if (!no_loops) {
+    if (!no_loops && verbose_mode) {
         log_info("Found %d combinational loops:\n", int(topo.loops.size()));
         int i = 0;
         for (auto &loop : topo.loops) {
@@ -463,10 +463,12 @@ void TimingAnalyser::compute_criticality()
         auto &pd = ports.at(p);
         for (auto &pdp : pd.domain_pairs) {
             auto &dp = domain_pairs.at(pdp.first);
-            pdp.second.criticality =
+            float crit =
                     1.0f - (float(pdp.second.setup_slack) - float(dp.worst_setup_slack)) / float(-dp.worst_setup_slack);
-            NPNR_ASSERT(pdp.second.criticality >= -0.00001f && pdp.second.criticality <= 1.00001f);
-            pd.worst_crit = std::max(pd.worst_crit, pdp.second.criticality);
+            crit = std::min(crit, 1.0f);
+            crit = std::max(crit, 0.0f);
+            pdp.second.criticality = crit;
+            pd.worst_crit = std::max(pd.worst_crit, crit);
         }
     }
 }

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -39,6 +39,7 @@ void TimingAnalyser::setup()
     reset_times();
     walk_forward();
     walk_backward();
+    print_fmax();
 }
 
 void TimingAnalyser::init_ports()
@@ -383,6 +384,26 @@ void TimingAnalyser::walk_backward()
                 }
             }
         }
+    }
+}
+
+void TimingAnalyser::print_fmax()
+{
+    // Temporary testing code for comparison only
+    std::unordered_map<int, double> domain_fmax;
+    for (auto p : topological_order) {
+        auto &pd = ports.at(p);
+        for (auto &req : pd.required) {
+            if (pd.arrival.count(req.first)) {
+                auto &arr = pd.arrival.at(req.first);
+                double fmax = 1000.0 / (arr.value.maxDelay() - req.second.value.minDelay());
+                if (!domain_fmax.count(req.first) || domain_fmax.at(req.first) > fmax)
+                    domain_fmax[req.first] = fmax;
+            }
+        }
+    }
+    for (auto &fm : domain_fmax) {
+        log_info("Domain %s Worst Fmax %.02f\n", ctx->nameOf(domains.at(fm.first).key.clock), fm.second);
     }
 }
 

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -140,8 +140,13 @@ void TimingAnalyser::get_route_delays()
 {
     for (auto net : sorted(ctx->nets)) {
         NetInfo *ni = net.second;
-        for (auto &usr : ni->users)
+        if (ni->driver.cell == nullptr || ni->driver.cell->bel == BelId())
+            continue;
+        for (auto &usr : ni->users) {
+            if (usr.cell->bel == BelId())
+                continue;
             ports.at(CellPortKey(usr)).route_delay = DelayPair(ctx->getNetinfoRouteDelay(ni, usr));
+        }
     }
 }
 

--- a/common/timing.h
+++ b/common/timing.h
@@ -127,11 +127,26 @@ struct TimingAnalyser
     TimingAnalyser(Context *ctx) : ctx(ctx){};
     void setup();
 
+    bool setup_only = false;
+
   private:
     void init_ports();
     void get_cell_delays();
     void topo_sort();
     void setup_port_domains();
+
+    void reset_times();
+
+    void walk_forward();
+
+    const DelayPair init_delay{std::numeric_limits<delay_t>::max(), std::numeric_limits<delay_t>::lowest()};
+
+    // Set arrival/required times if more/less than the current value
+    void set_arrival_time(CellPortKey target, domain_id_t domain, DelayPair arrival, int path_length,
+                          CellPortKey prev = CellPortKey());
+    void set_required_time(CellPortKey target, domain_id_t domain, DelayPair required, int path_length,
+                           CellPortKey prev = CellPortKey());
+
     // To avoid storing the domain tag structure (which could get large when considering more complex constrained tag
     // cases), assign each domain an ID and use that instead
     // An arrival or required time entry. Stores both the min/max delays; and the traversal to reach them for critical

--- a/common/timing.h
+++ b/common/timing.h
@@ -141,6 +141,7 @@ struct TimingAnalyser
     }
 
     bool setup_only = false;
+    bool verbose_mode = false;
 
   private:
     void init_ports();

--- a/common/timing.h
+++ b/common/timing.h
@@ -45,6 +45,7 @@ struct CellPortKey
         }
     };
     inline bool operator==(const CellPortKey &other) const { return (cell == other.cell) && (port == other.port); }
+    inline bool operator!=(const CellPortKey &other) const { return (cell != other.cell) || (port != other.port); }
     inline bool operator<(const CellPortKey &other) const
     {
         return cell == other.cell ? port < other.port : cell < other.cell;
@@ -145,6 +146,12 @@ struct TimingAnalyser
     void compute_criticality();
 
     void print_fmax();
+    void print_report();
+
+    // get the N most failing endpoints for a given domain pair
+    std::vector<CellPortKey> get_failing_eps(domain_id_t domain_pair, int count);
+    // print the critical path for an endpoint and domain pair
+    void print_critical_path(CellPortKey endpoint, domain_id_t domain_pair);
 
     const DelayPair init_delay{std::numeric_limits<delay_t>::max(), std::numeric_limits<delay_t>::lowest()};
 

--- a/common/timing.h
+++ b/common/timing.h
@@ -127,6 +127,10 @@ struct TimingAnalyser
   public:
     TimingAnalyser(Context *ctx) : ctx(ctx){};
     void setup();
+    void run();
+    void print_report();
+
+    float get_criticality(CellPortKey port) const { return ports.at(port).worst_crit; }
 
     bool setup_only = false;
 
@@ -146,8 +150,6 @@ struct TimingAnalyser
     void compute_criticality();
 
     void print_fmax();
-    void print_report();
-
     // get the N most failing endpoints for a given domain pair
     std::vector<CellPortKey> get_failing_eps(domain_id_t domain_pair, int count);
     // print the critical path for an endpoint and domain pair

--- a/common/timing.h
+++ b/common/timing.h
@@ -24,6 +24,128 @@
 
 NEXTPNR_NAMESPACE_BEGIN
 
+struct CellPortKey
+{
+    IdString cell, port;
+    struct Hash
+    {
+        inline std::size_t operator()(const CellPortKey &arg) const noexcept
+        {
+            std::size_t seed = std::hash<IdString>()(arg.cell);
+            seed ^= std::hash<IdString>()(arg.port) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+            return seed;
+        }
+    };
+    inline bool operator==(const CellPortKey &other) const { return (cell == other.cell) && (port == other.port); }
+};
+
+struct NetPortKey
+{
+    IdString net;
+    size_t idx;
+    static const size_t DRIVER_IDX = std::numeric_limits<size_t>::max();
+
+    inline bool is_driver() const { return (idx == DRIVER_IDX); }
+    inline size_t user_idx() const
+    {
+        NPNR_ASSERT(idx != DRIVER_IDX);
+        return idx;
+    }
+
+    struct Hash
+    {
+        std::size_t operator()(const NetPortKey &arg) const noexcept
+        {
+            std::size_t seed = std::hash<IdString>()(arg.net);
+            seed ^= std::hash<size_t>()(arg.idx) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+            return seed;
+        }
+    };
+    inline bool operator==(const NetPortKey &other) const { return (net == other.net) && (idx == other.idx); }
+};
+
+struct ClockDomainKey
+{
+    IdString clock;
+    ClockEdge edge;
+    // probably also need something here to deal with constraints
+    inline bool is_async() const { return clock == IdString(); }
+
+    struct Hash
+    {
+        std::size_t operator()(const ClockDomainKey &arg) const noexcept
+        {
+            std::size_t seed = std::hash<IdString>()(arg.clock);
+            seed ^= std::hash<int>()(int(arg.edge)) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+            return seed;
+        }
+    };
+    inline bool operator==(const ClockDomainKey &other) const { return (clock == other.clock) && (edge == other.edge); }
+};
+
+struct TimingAnalyser
+{
+  public:
+    TimingAnalyser(Context *ctx) : ctx(ctx){};
+
+  private:
+    // To avoid storing the domain tag structure (which could get large when considering more complex constrained tag
+    // cases), assign each domain an ID and use that instead
+    typedef int domain_id_t;
+    // An arrival or required time entry. Stores both the min/max delays; and the traversal to reach them for critical
+    // path reporting
+    struct ArrivReqTime
+    {
+        DelayPair value;
+        CellPortKey bwd_min, bwd_max;
+        int path_length;
+    };
+    // Data per port-domain tuple
+    struct PortDomainData
+    {
+        ArrivReqTime arrival, required;
+        delay_t setup_slack = std::numeric_limits<delay_t>::max(), hold_slack = std::numeric_limits<delay_t>::max();
+        delay_t budget = std::numeric_limits<delay_t>::max();
+        int max_path_length = 0;
+        float criticality = 0;
+    };
+
+    // A cell timing arc, used to cache cell timings and reduce the number of potentially-expensive Arch API calls
+    struct CellArc
+    {
+        enum ArcType
+        {
+            COMBINATIONAL,
+            SETUP,
+            HOLD,
+            CLK_TO_Q
+        } type;
+        IdString other_port;
+        DelayQuad value;
+        // Clock polarity, not used for combinational arcs
+        ClockEdge edge;
+    };
+
+    // Timing data for every cell port
+    struct PerPort
+    {
+        CellPortKey cell_port;
+        NetPortKey net_port;
+        // per domain timings
+        std::unordered_map<domain_id_t, PortDomainData> domains;
+        // cell timing arcs to (outputs)/from (inputs)  from this port
+        std::vector<CellArc> cell_arcs;
+        // routing delay into this port (input ports only)
+        DelayPair route_delay;
+    };
+
+    std::unordered_map<CellPortKey, PerPort, CellPortKey::Hash> ports;
+    std::unordered_map<ClockDomainKey, domain_id_t, ClockDomainKey::Hash> domain_to_id;
+    std::vector<ClockDomainKey> id_to_domain;
+
+    Context *ctx;
+};
+
 // Evenly redistribute the total path slack amongst all sinks on each path
 void assign_budget(Context *ctx, bool quiet = false);
 

--- a/common/timing.h
+++ b/common/timing.h
@@ -141,6 +141,9 @@ struct TimingAnalyser
     void walk_forward();
     void walk_backward();
 
+    void compute_slack();
+    void compute_criticality();
+
     void print_fmax();
 
     const DelayPair init_delay{std::numeric_limits<delay_t>::max(), std::numeric_limits<delay_t>::lowest()};
@@ -207,6 +210,8 @@ struct TimingAnalyser
         std::vector<CellArc> cell_arcs;
         // routing delay into this port (input ports only)
         DelayPair route_delay;
+        // worst criticality across domain pairs
+        float worst_crit;
     };
 
     struct PerDomain
@@ -221,6 +226,8 @@ struct TimingAnalyser
     {
         PerDomainPair(ClockDomainPairKey key) : key(key){};
         ClockDomainPairKey key;
+        DelayPair period;
+        delay_t worst_setup_slack, worst_hold_slack;
     };
 
     CellInfo *cell_info(const CellPortKey &key);

--- a/common/timing.h
+++ b/common/timing.h
@@ -132,6 +132,7 @@ struct TimingAnalyser
   private:
     void init_ports();
     void get_cell_delays();
+    void get_route_delays();
     void topo_sort();
     void setup_port_domains();
 

--- a/common/timing.h
+++ b/common/timing.h
@@ -140,6 +140,8 @@ struct TimingAnalyser
     void walk_forward();
     void walk_backward();
 
+    void print_fmax();
+
     const DelayPair init_delay{std::numeric_limits<delay_t>::max(), std::numeric_limits<delay_t>::lowest()};
 
     // Set arrival/required times if more/less than the current value

--- a/common/timing.h
+++ b/common/timing.h
@@ -138,6 +138,7 @@ struct TimingAnalyser
     void reset_times();
 
     void walk_forward();
+    void walk_backward();
 
     const DelayPair init_delay{std::numeric_limits<delay_t>::max(), std::numeric_limits<delay_t>::lowest()};
 

--- a/common/timing.h
+++ b/common/timing.h
@@ -45,6 +45,10 @@ struct CellPortKey
         }
     };
     inline bool operator==(const CellPortKey &other) const { return (cell == other.cell) && (port == other.port); }
+    inline bool operator<(const CellPortKey &other) const
+    {
+        return cell == other.cell ? port < other.port : cell < other.cell;
+    }
 };
 
 struct NetPortKey
@@ -104,6 +108,7 @@ struct TimingAnalyser
   private:
     void init_ports();
     void get_cell_delays();
+    void topo_sort();
     // To avoid storing the domain tag structure (which could get large when considering more complex constrained tag
     // cases), assign each domain an ID and use that instead
     typedef int domain_id_t;
@@ -153,6 +158,7 @@ struct TimingAnalyser
     {
         CellPortKey cell_port;
         NetPortKey net_port;
+        PortType type;
         // per domain timings
         std::unordered_map<domain_id_t, PortDomainData> domains;
         // cell timing arcs to (outputs)/from (inputs)  from this port
@@ -167,6 +173,8 @@ struct TimingAnalyser
     std::unordered_map<CellPortKey, PerPort, CellPortKey::Hash> ports;
     std::unordered_map<ClockDomainKey, domain_id_t, ClockDomainKey::Hash> domain_to_id;
     std::vector<ClockDomainKey> id_to_domain;
+
+    std::vector<CellPortKey> topological_order;
 
     Context *ctx;
 };

--- a/common/util.h
+++ b/common/util.h
@@ -263,6 +263,16 @@ template <typename T, typename C = std::less<T>> struct TopoSort
     }
 };
 
+template <typename T> struct reversed_range_t
+{
+    T &obj;
+    explicit reversed_range_t(T &obj) : obj(obj){};
+    auto begin() { return obj.rbegin(); }
+    auto end() { return obj.rend(); }
+};
+
+template <typename T> reversed_range_t<T> reversed_range(T &obj) { return reversed_range_t<T>(obj); }
+
 NEXTPNR_NAMESPACE_END
 
 #endif

--- a/nexus/post_place.cc
+++ b/nexus/post_place.cc
@@ -28,9 +28,9 @@ NEXTPNR_NAMESPACE_BEGIN
 struct NexusPostPlaceOpt
 {
     Context *ctx;
-    NetCriticalityMap net_crit;
+    TimingAnalyser tmg;
 
-    NexusPostPlaceOpt(Context *ctx) : ctx(ctx){};
+    NexusPostPlaceOpt(Context *ctx) : ctx(ctx), tmg(ctx){};
 
     inline bool is_constrained(CellInfo *cell)
     {
@@ -139,7 +139,7 @@ struct NexusPostPlaceOpt
 
     void operator()()
     {
-        get_criticalities(ctx, &net_crit);
+        tmg.setup();
         opt_lutffs();
     }
 


### PR DESCRIPTION
This implements most of a new timing analysis engine and currently uses it to replace the `get_criticalities` API. Signoff timing and budgets are not yet replaced and still use the old engine, in order to phase in the new engine.

This was expected to get an overall speedup with no change in Fmax. However, actual benchmarking (on admittedly few designs) show no speedup and a small but significant increase in Fmax - pointing most likely to a latent bug in how the old STA code was calculating criticality, it can't be a false increased Fmax because the unchanged old engine is still doing signoff.

The expected performance benefits of the new, cleaner approach may well be realised by switching from a large number of `unordered_map`s to `absl::flat_hash_map` once #607 is merged.

Longer term; the next steps after this PR are to replace the budget and signoff timing analysis code so that the legacy code can be fully removed; and then use the new cleaner base to implement some new features like false paths and cross-clock constraints.