### PR TITLE
Only depend on Abseil in threaded builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,8 +274,10 @@ foreach (family ${ARCH})
     # Include the family-specific CMakeFile
     include(${family}/family.cmake)
     foreach (target ${family_targets})
-        target_link_libraries(${target} PRIVATE absl::flat_hash_map)
-        target_link_libraries(${target} PRIVATE absl::flat_hash_set)
+        if (USE_THREADS)
+            target_link_libraries(${target} PRIVATE absl::flat_hash_map)
+            target_link_libraries(${target} PRIVATE absl::flat_hash_set)
+        endif()
 
         # Include family-specific source files to all family targets and set defines appropriately
         target_include_directories(${target} PRIVATE ${family}/ ${CMAKE_CURRENT_BINARY_DIR}/generated/)

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -27,7 +27,9 @@
  */
 
 #include "router2.h"
+#if !defined(NPNR_DISABLE_THREADS)
 #include <absl/container/flat_hash_map.h>
+#endif
 #include <algorithm>
 #include <boost/container/flat_map.hpp>
 #include <chrono>
@@ -191,7 +193,11 @@ struct Router2
         }
     }
 
+#if defined(NPNR_DISABLE_THREADS)
+    std::unordered_map<WireId, int> wire_to_idx;
+#else
     absl::flat_hash_map<WireId, int> wire_to_idx;
+#endif
     std::vector<PerWireData> flat_wires;
 
     PerWireData &wire_data(WireId w) { return flat_wires[wire_to_idx.at(w)]; }


### PR DESCRIPTION
Abseil has a hard dependency on threads (not just in the build system but in many places in the base libraries), so there is no way to use it on WASI at the moment. Assuming that Abseil will only be used for speed and not because it provides a richer API, I suggest this workaround.

Fixes #616. 