### PR TITLE
Add missing includes to fix WASI build

### DIFF
--- a/common/nextpnr.cc
+++ b/common/nextpnr.cc
@@ -18,6 +18,10 @@
  */
 
 #if defined(__wasm)
+#include <typeinfo>
+#include <exception>
+#include "log.h"
+
 extern "C" {
 // FIXME: WASI does not currently support exceptions.
 void *__cxa_allocate_exception(size_t thrown_size) throw() { return malloc(thrown_size); }

--- a/common/nextpnr_assertions.h
+++ b/common/nextpnr_assertions.h
@@ -22,6 +22,7 @@
 #define NEXTPNR_ASSERTIONS_H
 
 #include <stdexcept>
+#include <string>
 
 #include "nextpnr_namespaces.h"
 


### PR DESCRIPTION
These were omitted in #621 (some because they are not exercised in non-WASI builds, some because libstdc++ is not very hygienic with headers).