### PR TITLE
Update root CMake with some additional features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ option(COVERAGE "Add code coverage info" OFF)
 option(STATIC_BUILD "Create static build" OFF)
 option(EXTERNAL_CHIPDB "Create build with pre-built chipdb binaries" OFF)
 option(WERROR "pass -Werror to compiler (used for CI)" OFF)
+option(PROFILER "Link against libprofiler" OFF)
 
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 
@@ -237,6 +238,9 @@ set(EXTRA_LIB_DEPS)
 if (USE_THREADS)
     list(APPEND EXTRA_LIB_DEPS absl::flat_hash_map)
     list(APPEND EXTRA_LIB_DEPS absl::flat_hash_set)
+endif()
+if(PROFILER)
+    list(APPEND EXTRA_LIB_DEPS profiler)
 endif()
 
 foreach (family ${ARCH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ project(nextpnr CXX C)
 # Allow family.cmake add additional dependencies to gui_${family}.
 cmake_policy(SET CMP0079 NEW)
 
+# Enable IPO support.
+cmake_policy(SET CMP0069 NEW)
+include(CheckIPOSupported)
+check_ipo_supported()
+
 option(BUILD_GUI "Build GUI" OFF)
 option(BUILD_PYTHON "Build Python Integration" ON)
 option(BUILD_TESTS "Build tests" OFF)
@@ -13,6 +18,8 @@ option(COVERAGE "Add code coverage info" OFF)
 option(STATIC_BUILD "Create static build" OFF)
 option(EXTERNAL_CHIPDB "Create build with pre-built chipdb binaries" OFF)
 option(WERROR "pass -Werror to compiler (used for CI)" OFF)
+
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 
 if(WIN32 OR EXTERNAL_CHIPDB)
     set(BBASM_MODE "binary")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(nextpnr CXX C)
 
+# Allow family.cmake add additional dependencies to gui_${family}.
+cmake_policy(SET CMP0079 NEW)
+
 option(BUILD_GUI "Build GUI" OFF)
 option(BUILD_PYTHON "Build Python Integration" ON)
 option(BUILD_TESTS "Build tests" OFF)
@@ -223,6 +226,12 @@ else()
     set(BBASM_ENDIAN_FLAG "--le")
 endif()
 
+set(EXTRA_LIB_DEPS)
+if (USE_THREADS)
+    list(APPEND EXTRA_LIB_DEPS absl::flat_hash_map)
+    list(APPEND EXTRA_LIB_DEPS absl::flat_hash_set)
+endif()
+
 foreach (family ${ARCH})
     message(STATUS "Configuring architecture: ${family}")
     string(TOUPPER ${family} ufamily)
@@ -276,10 +285,9 @@ foreach (family ${ARCH})
     # Include the family-specific CMakeFile
     include(${family}/family.cmake)
     foreach (target ${family_targets})
-        if (USE_THREADS)
-            target_link_libraries(${target} PRIVATE absl::flat_hash_map)
-            target_link_libraries(${target} PRIVATE absl::flat_hash_set)
-        endif()
+        foreach(lib_dep ${EXTRA_LIB_DEPS})
+            target_link_libraries(${target} PRIVATE ${lib_dep})
+        endforeach()
 
         # Include family-specific source files to all family targets and set defines appropriately
         target_include_directories(${target} PRIVATE ${family}/ ${CMAKE_CURRENT_BINARY_DIR}/generated/)

--- a/fpga_interchange/family.cmake
+++ b/fpga_interchange/family.cmake
@@ -30,3 +30,8 @@ foreach (target ${family_targets})
     target_link_libraries(${target} PRIVATE fpga_interchange_capnp)
     target_link_libraries(${target} PRIVATE z)
 endforeach()
+
+if(BUILD_GUI)
+    target_link_libraries(gui_${family} fpga_interchange_capnp)
+    target_link_libraries(gui_${family} z)
+endif()

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -40,3 +40,7 @@ endif()
 
 target_compile_definitions(gui_${family} PRIVATE NEXTPNR_NAMESPACE=nextpnr_${family} ARCH_${ufamily} ARCHNAME=${family} QT_NO_KEYWORDS)
 target_link_libraries(gui_${family} Qt5::Widgets)
+
+foreach(lib_dep ${EXTRA_LIB_DEPS})
+    target_link_libraries(gui_${family} ${lib_dep})
+endforeach()


### PR DESCRIPTION
 - Allow `gui_${family}` library to be linked against libraries that expose headers.  This is important if `archdefs`/etc use headers
 - Enable IPO on builds
 - Allow optional linking against `libprofiler`.