### PR TITLE
Add "checkPipAvailForNet" to Arch API.

### DIFF
--- a/common/arch_api.h
+++ b/common/arch_api.h
@@ -93,6 +93,7 @@ template <typename R> struct ArchAPI : BaseCtx
     virtual void bindPip(PipId pip, NetInfo *net, PlaceStrength strength) = 0;
     virtual void unbindPip(PipId pip) = 0;
     virtual bool checkPipAvail(PipId pip) const = 0;
+    virtual bool checkPipAvailForNet(PipId pip, NetInfo *net) const = 0;
     virtual NetInfo *getBoundPipNet(PipId pip) const = 0;
     virtual WireId getConflictingPipWire(PipId pip) const = 0;
     virtual NetInfo *getConflictingPipNet(PipId pip) const = 0;

--- a/common/base_arch.h
+++ b/common/base_arch.h
@@ -243,6 +243,11 @@ template <typename R> struct BaseArch : ArchAPI<R>
         p2n_entry = nullptr;
     }
     virtual bool checkPipAvail(PipId pip) const override { return getBoundPipNet(pip) == nullptr; }
+    virtual bool checkPipAvailForNet(PipId pip, NetInfo *net) const override
+    {
+        NetInfo *bound_net = getBoundPipNet(pip);
+        return bound_net == nullptr || bound_net == net;
+    }
     virtual NetInfo *getBoundPipNet(PipId pip) const override
     {
         auto fnd = base_pip2net.find(pip);

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -588,7 +588,7 @@ struct Router2
             bool did_something = false;
             for (auto uh : ctx->getPipsUphill(flat_wires[cursor].w)) {
                 did_something = true;
-                if (!ctx->checkPipAvail(uh) && ctx->getBoundPipNet(uh) != net)
+                if (!ctx->checkPipAvailForNet(uh, net))
                     continue;
                 if (cpip != PipId() && cpip != uh)
                     continue; // don't allow multiple pips driving a wire with a net
@@ -675,18 +675,12 @@ struct Router2
 #else
                 if (is_bb && !hit_test_pip(ad.bb, ctx->getPipLocation(dh)))
                     continue;
-                if (!ctx->checkPipAvail(dh)) {
-                    NetInfo *bound_net = ctx->getBoundPipNet(dh);
-                    if (bound_net != net) {
-                        if (bound_net != nullptr) {
-                            ROUTE_LOG_DBG("Skipping pip %s because it is bound to net '%s' not net '%s'\n",
-                                          ctx->nameOfPip(dh), bound_net->name.c_str(ctx), net->name.c_str(ctx));
-                        } else {
-                            ROUTE_LOG_DBG("Skipping pip %s because it is reported not available\n", ctx->nameOfPip(dh));
-                        }
-
-                        continue;
-                    }
+                if (!ctx->checkPipAvailForNet(dh, net)) {
+                    ROUTE_LOG_DBG("Skipping pip %s because it is bound to net '%s' not net '%s'\n", ctx->nameOfPip(dh),
+                                  ctx->getBoundPipNet(dh) != nullptr ? ctx->getBoundPipNet(dh)->name.c_str(ctx)
+                                                                     : "<not a net>",
+                                  net->name.c_str(ctx));
+                    continue;
                 }
 #endif
                 // Evaluate score of next wire

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -398,6 +398,13 @@ pip to a net.
 
 *BaseArch default: returns `getBoundPipNet(pip) == nullptr`*
 
+### bool checkPipAvailForNet(PipId pip, NetInfo *net) const
+
+Returns true if the given pip is available to be bound to a net, or if the
+pip is already bound to that net.
+
+*BaseArch default: returns `getBoundPipNet(pip) == nullptr || getBoundPipNet(pip) == net`*
+
 ### NetInfo \*getBoundPipNet(PipId pip) const
 
 Return the net this pip is bound to.

--- a/fpga_interchange/arch.cc
+++ b/fpga_interchange/arch.cc
@@ -1587,7 +1587,7 @@ void Arch::bindWire(WireId wire, NetInfo *net, PlaceStrength strength)
     refreshUiWire(wire);
 }
 
-bool Arch::check_pip_avail_for_net(PipId pip, NetInfo *net) const
+bool Arch::checkPipAvailForNet(PipId pip, NetInfo *net) const
 {
     NPNR_ASSERT(pip != PipId());
     auto pip_iter = pip_to_net.find(pip);
@@ -1725,7 +1725,7 @@ bool Arch::check_pip_avail_for_net(PipId pip, NetInfo *net) const
     return true;
 }
 
-bool Arch::checkPipAvail(PipId pip) const { return check_pip_avail_for_net(pip, nullptr); }
+bool Arch::checkPipAvail(PipId pip) const { return checkPipAvailForNet(pip, nullptr); }
 
 Arch::~Arch() {}
 

--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -536,7 +536,7 @@ struct Arch : ArchAPI<ArchRanges>
     void unbindPip(PipId pip) final;
 
     bool checkPipAvail(PipId pip) const final;
-    bool check_pip_avail_for_net(PipId pip, NetInfo *) const;
+    bool checkPipAvailForNet(PipId pip, NetInfo *net) const final;
 
     NetInfo *getBoundPipNet(PipId pip) const final
     {

--- a/generic/arch.cc
+++ b/generic/arch.cc
@@ -450,6 +450,12 @@ void Arch::unbindPip(PipId pip)
 
 bool Arch::checkPipAvail(PipId pip) const { return pips.at(pip).bound_net == nullptr; }
 
+bool Arch::checkPipAvailForNet(PipId pip, NetInfo *net) const
+{
+    NetInfo *bound_net = pips.at(pip).bound_net;
+    return bound_net == nullptr || bound_net == net;
+}
+
 NetInfo *Arch::getBoundPipNet(PipId pip) const { return pips.at(pip).bound_net; }
 
 NetInfo *Arch::getConflictingPipNet(PipId pip) const { return pips.at(pip).bound_net; }

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -279,6 +279,7 @@ struct Arch : ArchAPI<ArchRanges>
     void bindPip(PipId pip, NetInfo *net, PlaceStrength strength) override;
     void unbindPip(PipId pip) override;
     bool checkPipAvail(PipId pip) const override;
+    bool checkPipAvailForNet(PipId pip, NetInfo *net) const override;
     NetInfo *getBoundPipNet(PipId pip) const override;
     WireId getConflictingPipWire(PipId pip) const override;
     NetInfo *getConflictingPipNet(PipId pip) const override;


### PR DESCRIPTION
This is important for distinguishing valid pseudo pips in the FPGA
interchange arch. This also avoids a double or triple lookup of
pip->net map.