### PR TITLE
cmake: Use IPO only if supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_policy(SET CMP0079 NEW)
 # Enable IPO support.
 cmake_policy(SET CMP0069 NEW)
 include(CheckIPOSupported)
-check_ipo_supported()
+check_ipo_supported(RESULT ipo_supported)
 
 option(BUILD_GUI "Build GUI" OFF)
 option(BUILD_PYTHON "Build Python Integration" ON)
@@ -19,8 +19,9 @@ option(STATIC_BUILD "Create static build" OFF)
 option(EXTERNAL_CHIPDB "Create build with pre-built chipdb binaries" OFF)
 option(WERROR "pass -Werror to compiler (used for CI)" OFF)
 option(PROFILER "Link against libprofiler" OFF)
-
-set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+if(ipo_supported)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()
 
 if(WIN32 OR EXTERNAL_CHIPDB)
     set(BBASM_MODE "binary")


### PR DESCRIPTION
Based on the CMake docs:

> Set <result> variable to YES if IPO is supported by the compiler and NO otherwise. If this option is not given then the command will issue a fatal error if IPO is not supported.

I think this should fix the WASM issue but haven't actually tested (is there an easy way to test locally?)