### PR TITLE
Initial inverter logic for FPGA interchange

### DIFF
--- a/.github/ci/build_interchange.sh
+++ b/.github/ci/build_interchange.sh
@@ -26,7 +26,7 @@ popd
 RAPIDWRIGHT_PATH="`pwd`/RapidWright"
 INTERCHANGE_SCHEMA_PATH="`pwd`/3rdparty/fpga-interchange-schema/interchange"
 PYTHON_INTERCHANGE_PATH="`pwd`/python-fpga-interchange"
-PYTHON_INTERCHANGE_TAG="v0.0.2"
+PYTHON_INTERCHANGE_TAG="v0.0.3"
 
 # Install python-fpga-interchange libraries
 git clone -b $PYTHON_INTERCHANGE_TAG https://github.com/SymbiFlow/python-fpga-interchange.git $PYTHON_INTERCHANGE_PATH

--- a/common/property.h
+++ b/common/property.h
@@ -78,7 +78,7 @@ struct Property
             result.push_back(c == S1);
         return result;
     }
-    std::string as_string() const
+    const std::string &as_string() const
     {
         NPNR_ASSERT(is_string);
         return str;

--- a/fpga_interchange/arch.cc
+++ b/fpga_interchange/arch.cc
@@ -1747,6 +1747,37 @@ bool Arch::checkPipAvail(PipId pip) const { return checkPipAvailForNet(pip, null
 
 std::string Arch::get_chipdb_hash() const { return chipdb_hash; }
 
+bool Arch::is_inverting(PipId pip) const
+{
+    auto &tile_type = loc_info(chip_info, pip);
+    auto &pip_info = tile_type.pip_data[pip.index];
+    if (pip_info.site == -1) {
+        // FIXME: Some routing pips are inverters, but this is missing from
+        // the chipdb.
+        return false;
+    }
+
+    auto &bel_data = tile_type.bel_data[pip_info.bel];
+
+    // Is a fixed inverter if the non_inverting_pin is another pin.
+    return bel_data.non_inverting_pin != pip_info.extra_data && bel_data.inverting_pin == pip_info.extra_data;
+}
+
+bool Arch::can_invert(PipId pip) const
+{
+    auto &tile_type = loc_info(chip_info, pip);
+    auto &pip_info = tile_type.pip_data[pip.index];
+    if (pip_info.site == -1) {
+        return false;
+    }
+
+    auto &bel_data = tile_type.bel_data[pip_info.bel];
+
+    // Can optionally invert if this pip is both the non_inverting_pin and
+    // inverting pin.
+    return bel_data.non_inverting_pin == pip_info.extra_data && bel_data.inverting_pin == pip_info.extra_data;
+}
+
 // Instance constraint templates.
 template void Arch::ArchConstraints::bindBel(Arch::ArchConstraints::TagState *, const Arch::ConstraintRange);
 template void Arch::ArchConstraints::unbindBel(Arch::ArchConstraints::TagState *, const Arch::ConstraintRange);

--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -34,6 +34,7 @@
 #include "relptr.h"
 
 #include "arch_iterators.h"
+#include "cell_parameters.h"
 #include "chipdb.h"
 #include "dedicated_interconnect.h"
 #include "lookahead.h"
@@ -1045,6 +1046,7 @@ struct Arch : ArchAPI<ArchRanges>
     Lookahead lookahead;
     mutable RouteNodeStorage node_storage;
     mutable SiteRoutingCache site_routing_cache;
+    CellParameters cell_parameters;
 
     std::string chipdb_hash;
     std::string get_chipdb_hash() const;

--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -1028,6 +1028,12 @@ struct Arch : ArchAPI<ArchRanges>
         return wire_data.site != -1;
     }
 
+    // Does this pip always invert its signal?
+    bool is_inverting(PipId pip) const;
+
+    // Can this pip optional invert its signal?
+    bool can_invert(PipId pip) const;
+
     void merge_constant_nets();
     void report_invalid_bel(BelId bel, CellInfo *cell) const;
 

--- a/fpga_interchange/cell_parameters.cc
+++ b/fpga_interchange/cell_parameters.cc
@@ -1,0 +1,222 @@
+/*
+ *  nextpnr -- Next Generation Place and Route
+ *
+ *  Copyright (C) 2021  Symbiflow Authors
+ *
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "cell_parameters.h"
+
+#include <limits>
+
+#include "DeviceResources.capnp.h"
+#include "context.h"
+#include "log.h"
+#include "nextpnr_assertions.h"
+
+NEXTPNR_NAMESPACE_BEGIN
+
+CellParameters::CellParameters()
+        // 1'b0
+        : verilog_binary_re("([1-9][0-9]*)'b([01]+)$"),
+          // 8'hF
+          verilog_hex_re("([1-9][0-9]*)'h([0-9a-fA-F]+)$"),
+          // 0b10
+          c_binary_re("0b([01]+)$"),
+          // 0xF
+          c_hex_re("0x([0-9a-fA-F]+)$")
+{
+}
+
+void CellParameters::init(const Context *ctx)
+{
+    for (const CellParameterPOD &cell_parameter : ctx->chip_info->cell_map->cell_parameters) {
+        IdString cell_type(cell_parameter.cell_type);
+        IdString parameter(cell_parameter.parameter);
+        auto result = parameters.emplace(std::make_pair(cell_type, parameter), &cell_parameter);
+        NPNR_ASSERT(result.second);
+    }
+}
+
+static bool parse_int(const std::string &data, int64_t *result)
+{
+    NPNR_ASSERT(result != nullptr);
+    try {
+        *result = boost::lexical_cast<int64_t>(data);
+        return true;
+    } catch (boost::bad_lexical_cast &e) {
+        return false;
+    }
+}
+
+DynamicBitarray<> CellParameters::parse_int_like(const Context *ctx, IdString cell_type, IdString parameter,
+                                                 const Property &property) const
+{
+    const CellParameterPOD *definition = parameters.at(std::make_pair(cell_type, parameter));
+    DeviceResources::Device::ParameterFormat format;
+    format = static_cast<DeviceResources::Device::ParameterFormat>(definition->format);
+
+    DynamicBitarray<> result;
+    switch (format) {
+    case DeviceResources::Device::ParameterFormat::BOOLEAN:
+        result.resize(1);
+        if (property.is_string) {
+            if (property.as_string() == "TRUE" || property.as_string() == "1") {
+                result.set(0, true);
+            } else if (property.as_string() == "FALSE" || property.as_string() == "0") {
+                result.set(0, false);
+            } else {
+                log_error("Property value %s not expected for BOOLEAN type.\n", property.c_str());
+            }
+        } else {
+            if (property.intval == 1) {
+                result.set(0, true);
+            } else if (property.intval == 0) {
+                result.set(0, false);
+            } else {
+                log_error("Property value %lu not expected for BOOLEAN type.\n", property.intval);
+            }
+        }
+
+        return result;
+    case DeviceResources::Device::ParameterFormat::INTEGER:
+        if (property.is_string) {
+            char *endptr;
+            std::uintmax_t value = strtoumax(property.c_str(), &endptr, /*base=*/10);
+            if (endptr != (property.c_str() + property.size())) {
+                log_error("Property value %s not expected for INTEGER type.\n", property.c_str());
+            }
+
+            return DynamicBitarray<>::to_bitarray(value);
+        } else {
+            return DynamicBitarray<>::to_bitarray(property.intval);
+        }
+        break;
+    case DeviceResources::Device::ParameterFormat::VERILOG_BINARY:
+        if (property.is_string) {
+            std::smatch m;
+            if (!std::regex_match(property.as_string(), m, verilog_binary_re)) {
+                log_error("Property value %s not expected for VERILOG_BINARY type.\n", property.c_str());
+            }
+
+            int64_t width;
+            if (!parse_int(m[1], &width)) {
+                log_error("Failed to parse width from property value %s of type VERILOG_BINARY.\n", property.c_str());
+            }
+            if (width < 0) {
+                log_error("Expected width to be positive for property value %s\n", property.c_str());
+            }
+
+            return DynamicBitarray<>::parse_binary_bitstring(width, m[2]);
+        } else {
+            return DynamicBitarray<>::to_bitarray(property.intval);
+        }
+        break;
+    case DeviceResources::Device::ParameterFormat::VERILOG_HEX:
+        if (property.is_string) {
+            std::smatch m;
+            if (!std::regex_match(property.as_string(), m, verilog_hex_re)) {
+                log_error("Property value %s not expected for VERILOG_HEX type.\n", property.c_str());
+            }
+
+            int64_t width;
+            if (!parse_int(m[1], &width)) {
+                log_error("Failed to parse width from property value %s of type VERILOG_HEX.\n", property.c_str());
+            }
+            if (width < 0) {
+                log_error("Expected width to be positive for property value %s\n", property.c_str());
+            }
+
+            return DynamicBitarray<>::parse_hex_bitstring(width, m[2]);
+        } else {
+            return DynamicBitarray<>::to_bitarray(property.intval);
+        }
+        break;
+    case DeviceResources::Device::ParameterFormat::C_BINARY:
+        if (property.is_string) {
+            std::smatch m;
+            if (!std::regex_match(property.as_string(), m, c_binary_re)) {
+                log_error("Property value %s not expected for C_BINARY type.\n", property.c_str());
+            }
+
+            return DynamicBitarray<>::parse_binary_bitstring(/*width=*/-1, m[1]);
+        } else {
+            return DynamicBitarray<>::to_bitarray(property.intval);
+        }
+        break;
+    case DeviceResources::Device::ParameterFormat::C_HEX:
+        if (property.is_string) {
+            std::smatch m;
+            if (!std::regex_match(property.as_string(), m, c_hex_re)) {
+                log_error("Property value %s not expected for C_HEX type.\n", property.c_str());
+            }
+
+            return DynamicBitarray<>::parse_hex_bitstring(/*width=*/-1, m[1]);
+        } else {
+            return DynamicBitarray<>::to_bitarray(property.intval);
+        }
+        break;
+    default:
+        log_error("Format %d is not int-like\n", definition->format);
+    }
+
+    // Unreachable!
+    NPNR_ASSERT(false);
+}
+
+bool CellParameters::compare_property(const Context *ctx, IdString cell_type, IdString parameter,
+                                      const Property &property, IdString value_to_compare) const
+{
+    const CellParameterPOD *definition = parameters.at(std::make_pair(cell_type, parameter));
+    DeviceResources::Device::ParameterFormat format;
+    format = static_cast<DeviceResources::Device::ParameterFormat>(definition->format);
+
+    switch (format) {
+    case DeviceResources::Device::ParameterFormat::STRING:
+        return value_to_compare.c_str(ctx) == property.as_string();
+    case DeviceResources::Device::ParameterFormat::FLOATING_POINT:
+        // Note: Comparing floating point is pretty weird
+        log_warning("Doing direct comparisions on floating points values is pretty weird, double check this.  Cell "
+                    "type %s parameter %s\n",
+                    cell_type.c_str(ctx), parameter.c_str(ctx));
+        return value_to_compare.c_str(ctx) == property.as_string();
+    case DeviceResources::Device::ParameterFormat::BOOLEAN:
+    case DeviceResources::Device::ParameterFormat::INTEGER:
+    case DeviceResources::Device::ParameterFormat::VERILOG_BINARY:
+    case DeviceResources::Device::ParameterFormat::VERILOG_HEX:
+    case DeviceResources::Device::ParameterFormat::C_BINARY:
+    case DeviceResources::Device::ParameterFormat::C_HEX: {
+        if (property.is_string) {
+            // Given that string presentations should be equivalent if
+            // formatted consistently, this should work most and or all of
+            // the time.  If there are important exceptions, revisit this.
+            return property.as_string() == value_to_compare.c_str(ctx);
+        } else {
+            int64_t int_to_compare;
+            if (!parse_int(value_to_compare.c_str(ctx), &int_to_compare)) {
+                log_error("Comparision failed, to compare value %s is not int-like\n", value_to_compare.c_str(ctx));
+            }
+
+            return property.intval == int_to_compare;
+        }
+    }
+    }
+
+    // Unreachable!
+    NPNR_ASSERT(false);
+}
+
+NEXTPNR_NAMESPACE_END

--- a/fpga_interchange/cell_parameters.h
+++ b/fpga_interchange/cell_parameters.h
@@ -1,0 +1,55 @@
+/*
+ *  nextpnr -- Next Generation Place and Route
+ *
+ *  Copyright (C) 2021  Symbiflow Authors
+ *
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#ifndef CELL_PARAMETERS_H
+#define CELL_PARAMETERS_H
+
+#include <regex>
+
+#include "chipdb.h"
+#include "dynamic_bitarray.h"
+#include "hash_table.h"
+#include "nextpnr_namespaces.h"
+#include "property.h"
+
+NEXTPNR_NAMESPACE_BEGIN
+
+struct Context;
+
+struct CellParameters
+{
+    CellParameters();
+    void init(const Context *ctx);
+    DynamicBitarray<> parse_int_like(const Context *ctx, IdString cell_type, IdString parameter,
+                                     const Property &property) const;
+    bool compare_property(const Context *ctx, IdString cell_type, IdString parameter, const Property &property,
+                          IdString value_to_compare) const;
+
+    HashTables::HashMap<std::pair<IdString, IdString>, const CellParameterPOD *> parameters;
+
+    std::regex verilog_binary_re;
+    std::regex verilog_hex_re;
+    std::regex c_binary_re;
+    std::regex c_hex_re;
+};
+
+NEXTPNR_NAMESPACE_END
+
+#endif /* CELL_PARAMETERS_H */

--- a/fpga_interchange/chipdb.h
+++ b/fpga_interchange/chipdb.h
@@ -34,7 +34,7 @@ NEXTPNR_NAMESPACE_BEGIN
  * kExpectedChipInfoVersion
  */
 
-static constexpr int32_t kExpectedChipInfoVersion = 3;
+static constexpr int32_t kExpectedChipInfoVersion = 4;
 
 // Flattened site indexing.
 //
@@ -71,6 +71,15 @@ NPNR_PACKED_STRUCT(struct BelInfoPOD {
     int8_t lut_element;
 
     RelPtr<int32_t> pin_map; // Index into CellMapPOD::cell_bel_map
+
+    // If this BEL is a site routing BEL with inverting pins, these values
+    // will be [0, num_bel_wires).  If this BEL is either not a site routing
+    // BEL or this site routing has no inversion capabilities, then these will
+    // both be -1.
+    int8_t non_inverting_pin;
+    int8_t inverting_pin;
+
+    int16_t padding;
 });
 
 enum BELCategory
@@ -261,6 +270,10 @@ NPNR_PACKED_STRUCT(struct ConstantsPOD {
 
     // Name to use for the global VCC constant net
     int32_t vcc_net_name; // constid
+
+    // If a choice is available, which constant net should be used?
+    // Can be ''/0 if either constant net are equivilent.
+    int32_t best_constant_net; // constid
 });
 
 NPNR_PACKED_STRUCT(struct ChipInfoPOD {
@@ -314,6 +327,14 @@ inline const SiteInstInfoPOD &site_inst_info(const ChipInfoPOD *chip_info, int32
 {
     return chip_info->sites[chip_info->tiles[tile].sites[site]];
 }
+
+enum SyntheticType
+{
+    NOT_SYNTH = 0,
+    SYNTH_SIGNAL = 1,
+    SYNTH_GND = 2,
+    SYNTH_VCC = 3,
+};
 
 NEXTPNR_NAMESPACE_END
 

--- a/fpga_interchange/chipdb.h
+++ b/fpga_interchange/chipdb.h
@@ -34,7 +34,7 @@ NEXTPNR_NAMESPACE_BEGIN
  * kExpectedChipInfoVersion
  */
 
-static constexpr int32_t kExpectedChipInfoVersion = 2;
+static constexpr int32_t kExpectedChipInfoVersion = 3;
 
 // Flattened site indexing.
 //
@@ -198,6 +198,14 @@ NPNR_PACKED_STRUCT(struct CellConstraintPOD {
     RelSlice<int32_t> states; // State indicies
 });
 
+// Cell parameters metadata
+NPNR_PACKED_STRUCT(struct CellParameterPOD {
+    int32_t cell_type;     // constid
+    int32_t parameter;     // constid
+    int32_t format;        // ParameterFormat enum
+    int32_t default_value; // constid
+});
+
 NPNR_PACKED_STRUCT(struct CellBelMapPOD {
     RelSlice<CellBelPinPOD> common_pins;
     RelSlice<ParameterPinsPOD> parameter_pins;
@@ -218,6 +226,7 @@ NPNR_PACKED_STRUCT(struct CellMapPOD {
     RelSlice<CellBelMapPOD> cell_bel_map;
 
     RelSlice<LutCellPOD> lut_cells;
+    RelSlice<CellParameterPOD> cell_parameters;
 });
 
 NPNR_PACKED_STRUCT(struct PackagePinPOD {

--- a/fpga_interchange/site_arch.h
+++ b/fpga_interchange/site_arch.h
@@ -289,6 +289,12 @@ struct SiteArch
     inline SiteWire getPipSrcWire(const SitePip &site_pip) const NPNR_ALWAYS_INLINE;
     inline SiteWire getPipDstWire(const SitePip &site_pip) const NPNR_ALWAYS_INLINE;
 
+    // Does this site pip always invert its signal?
+    inline bool isInverting(const SitePip &site_pip) const NPNR_ALWAYS_INLINE;
+
+    // Can this site pip optional invert its signal?
+    inline bool canInvert(const SitePip &site_pip) const NPNR_ALWAYS_INLINE;
+
     inline SitePipDownhillRange getPipsDownhill(const SiteWire &site_wire) const NPNR_ALWAYS_INLINE;
     inline SitePipUphillRange getPipsUphill(const SiteWire &site_wire) const NPNR_ALWAYS_INLINE;
     SiteWireRange getWires() const;
@@ -341,6 +347,7 @@ struct SiteArch
     void archcheck();
 
     bool is_pip_synthetic(const SitePip &pip) const NPNR_ALWAYS_INLINE;
+    SyntheticType pip_synthetic_type(const SitePip &pip) const NPNR_ALWAYS_INLINE;
 };
 
 struct SitePipDownhillIterator

--- a/fpga_interchange/site_router.cc
+++ b/fpga_interchange/site_router.cc
@@ -92,18 +92,16 @@ bool check_initial_wires(const Context *ctx, SiteInformation *site_info)
     return true;
 }
 
-bool is_invalid_site_port(const SiteArch *ctx, const SiteNetInfo *net, const SitePip &pip)
+static bool is_invalid_site_port(const SiteArch *ctx, const SiteNetInfo *net, const SitePip &pip)
 {
-    if (ctx->is_pip_synthetic(pip)) {
-        // FIXME: Not all synthetic pips are for constant networks.
-        // FIXME: Need to mark if synthetic site ports are for the GND or VCC
-        // network, and only allow the right one.  Otherwise site router
-        // could route a VCC on a GND only net (or equiv).
+    SyntheticType type = ctx->pip_synthetic_type(pip);
+    if (type == SYNTH_GND) {
         IdString gnd_net_name(ctx->ctx->chip_info->constants->gnd_net_name);
+        return net->net->name != gnd_net_name;
+    } else if (type == SYNTH_VCC) {
         IdString vcc_net_name(ctx->ctx->chip_info->constants->vcc_net_name);
-        return net->net->name != gnd_net_name && net->net->name != vcc_net_name;
+        return net->net->name != vcc_net_name;
     } else {
-        // All non-synthetic site ports are valid
         return false;
     }
 }
@@ -310,6 +308,8 @@ struct SiteExpansionLoop
     std::vector<SitePip>::const_iterator solution_begin(size_t idx) const { return solution.solution_begin(idx); }
 
     std::vector<SitePip>::const_iterator solution_end(size_t idx) const { return solution.solution_end(idx); }
+    bool solution_inverted(size_t idx) const { return solution.solution_inverted(idx); }
+    bool solution_can_invert(size_t idx) const { return solution.solution_can_invert(idx); }
 };
 
 void print_current_state(const SiteArch *site_arch)
@@ -363,6 +363,8 @@ struct PossibleSolutions
     SiteNetInfo *net = nullptr;
     std::vector<SitePip>::const_iterator pips_begin;
     std::vector<SitePip>::const_iterator pips_end;
+    bool inverted = false;
+    bool can_invert = false;
 };
 
 bool test_solution(SiteArch *ctx, SiteNetInfo *net, std::vector<SitePip>::const_iterator pips_begin,
@@ -567,6 +569,12 @@ bool route_site(SiteArch *ctx, SiteRoutingCache *site_routing_cache, RouteNodeSt
 
     for (const auto *expansion : expansions) {
         for (size_t idx = 0; idx < expansion->num_solutions(); ++idx) {
+            if (expansion->solution_inverted(idx)) {
+                // FIXME: May prefer an inverted solution if constant net
+                // type.
+                continue;
+            }
+
             SiteWire wire = expansion->solution_sink(idx);
             auto begin = expansion->solution_begin(idx);
             auto end = expansion->solution_end(idx);
@@ -580,6 +588,8 @@ bool route_site(SiteArch *ctx, SiteRoutingCache *site_routing_cache, RouteNodeSt
             solution.net = ctx->wire_to_nets.at(wire).net;
             solution.pips_begin = begin;
             solution.pips_end = end;
+            solution.inverted = expansion->solution_inverted(idx);
+            solution.can_invert = expansion->solution_can_invert(idx);
 
             for (auto iter = begin; iter != end; ++iter) {
                 NPNR_ASSERT(ctx->getPipDstWire(*iter) == wire);

--- a/fpga_interchange/site_routing_cache.h
+++ b/fpga_interchange/site_routing_cache.h
@@ -40,6 +40,8 @@ struct SiteRoutingSolution
         solution_offsets.clear();
         solution_storage.clear();
         solution_sinks.clear();
+        inverted.clear();
+        can_invert.clear();
     }
 
     size_t num_solutions() const { return solution_sinks.size(); }
@@ -58,9 +60,15 @@ struct SiteRoutingSolution
         return solution_storage.begin() + solution_offsets.at(solution + 1);
     }
 
+    bool solution_inverted(size_t solution) const { return inverted.at(solution) != 0; }
+
+    bool solution_can_invert(size_t solution) const { return can_invert.at(solution) != 0; }
+
     std::vector<size_t> solution_offsets;
     std::vector<SitePip> solution_storage;
     std::vector<SiteWire> solution_sinks;
+    std::vector<uint8_t> inverted;
+    std::vector<uint8_t> can_invert;
 };
 
 struct SiteRoutingKey


### PR DESCRIPTION
Initial version of inverter logic.

For now just implements some inspection capabilities, and the site router (for now) avoids inverted paths.

PR extends #639.  This requires a new release of the `python-fpga-interchange` lib, which hasn't been cut yet.