### PR TITLE
Fix bug where DedicateInterconnect incorrectly allows some placements.

### DIFF
--- a/fpga_interchange/dedicated_interconnect.h
+++ b/fpga_interchange/dedicated_interconnect.h
@@ -137,7 +137,7 @@ struct DedicatedInterconnect
 
     void find_dedicated_interconnect();
     void print_dedicated_interconnect() const;
-    bool check_routing(BelId src_bel, IdString src_bel_pin, BelId dst_bel, IdString dst_bel_pin) const;
+    bool check_routing(BelId src_bel, IdString src_bel_pin, BelId dst_bel, IdString dst_bel_pin, bool site_only) const;
     void expand_sink_bel(BelId bel, IdString pin, WireId wire);
     void expand_source_bel(BelId bel, IdString pin, WireId wire);
 


### PR DESCRIPTION
This occurs when the driver pin and sink pin are part of the same site,
but not reachable with site routing only.