### PR TITLE
Increase vCPU to 5 because of cirrus resource limit change.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 task:
   name: build-test-ubuntu2004
   container:
-    cpu: 4
+    cpu: 5
     memory: 20
     dockerfile: .cirrus/Dockerfile.ubuntu20.04
 


### PR DESCRIPTION
Cirrus CI now requires that RAM (in GiB) be less than 4*vCPU.

Example failure: https://cirrus-ci.com/task/5969551172042752