### PR TITLE
interchange: Pin prjoxide commit in CI

### DIFF
--- a/.github/ci/build_interchange.sh
+++ b/.github/ci/build_interchange.sh
@@ -40,6 +40,8 @@ function get_dependencies {
         curl --proto '=https' -sSf https://sh.rustup.rs | sh -s -- -y
         git clone --recursive https://github.com/gatecat/prjoxide.git
         pushd prjoxide/libprjoxide
+        # TODO: use a tag instead of a commit, like python-fpga-interchange
+        git reset --hard ${PRJOXIDE_REVISION}
         PATH=$PATH:$HOME/.cargo/bin cargo install --path prjoxide --all-features
         popd
     else

--- a/.github/workflows/interchange_ci.yml
+++ b/.github/workflows/interchange_ci.yml
@@ -109,6 +109,7 @@ jobs:
         RAPIDWRIGHT_PATH: ${{ github.workspace }}/RapidWright
         PYTHON_INTERCHANGE_PATH: ${{ github.workspace }}/python-fpga-interchange
         PYTHON_INTERCHANGE_TAG: v0.0.7
+        PRJOXIDE_REVISION: a85135648c3ef2f7b3fd53ae2187ef6460e34b16
         DEVICE: ${{ matrix.device }}
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"


### PR DESCRIPTION
This way things can be merged into master that necessitate other changes without breaking the CI.

Ideally this would use tags long term but prjoxide isn't quite stable enough yet, this should suffice for now.

cc @acomodi 