### PR TITLE
HeAP: Skip high-strength cells in both cell loops

### DIFF
--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -1322,6 +1322,10 @@ class HeAPPlacer
                     continue;
                 }
 
+                if (cell.belStrength > STRENGTH_STRONG) {
+                    continue;
+                }
+
                 // Transfer chain extents to the actual chains structure
                 ChainExtent *ce = nullptr;
                 if (p->chain_root.count(cell_name)) {


### PR DESCRIPTION
I found this a while ago working on the ECP5 DSP but since it looks like this is the only other placer-related change it probably makes sense to PR it separately. Currently the CutSpreader `init()` has two loops over `p->cell_locs`, the first skips fixed cells and cells with high `belStrength`, but the second only skips fixed cells. As far as I could tell this is just an omission; if my design has some user-placed cells inside a cellGroup (using a manual `bel` attribute) then nextpnr throws an out of range exception without this change.