### PR TITLE
New cluster API

### DIFF
--- a/common/arch_api.h
+++ b/common/arch_api.h
@@ -142,8 +142,8 @@ template <typename R> struct ArchAPI : BaseCtx
     // Cluster methods
     virtual CellInfo *getClusterRootCell(ClusterId cluster) const = 0;
     virtual ArcBounds getClusterBounds(ClusterId cluster) const = 0;
-    virtual Loc getClusterOffset(CellInfo *cell) const = 0;
-    virtual bool isClusterStrict(CellInfo *cell) const = 0;
+    virtual Loc getClusterOffset(const CellInfo *cell) const = 0;
+    virtual bool isClusterStrict(const CellInfo *cell) const = 0;
     virtual bool getClusterPlacement(ClusterId cluster, BelId root_bel,
                                      std::vector<std::pair<CellInfo *, BelId>> &placement) const = 0;
     // Flow methods

--- a/common/arch_api.h
+++ b/common/arch_api.h
@@ -139,6 +139,13 @@ template <typename R> struct ArchAPI : BaseCtx
     virtual typename R::CellTypeRangeT getCellTypes() const = 0;
     virtual typename R::BelBucketRangeT getBelBuckets() const = 0;
     virtual typename R::BucketBelRangeT getBelsInBucket(BelBucketId bucket) const = 0;
+    // Cluster methods
+    virtual CellInfo *getClusterRootCell(ClusterId cluster) const = 0;
+    virtual ArcBounds getClusterBounds(ClusterId cluster) const = 0;
+    virtual Loc getClusterOffset(ClusterId cluster, CellInfo *cell) const = 0;
+    virtual bool isClusterStrict(CellInfo *cell) const = 0;
+    virtual bool getClusterPlacement(ClusterId cluster, BelId root_bel,
+                                     std::vector<std::pair<CellInfo *, BelId>> &placement) const = 0;
     // Flow methods
     virtual bool pack() = 0;
     virtual bool place() = 0;

--- a/common/arch_api.h
+++ b/common/arch_api.h
@@ -142,7 +142,7 @@ template <typename R> struct ArchAPI : BaseCtx
     // Cluster methods
     virtual CellInfo *getClusterRootCell(ClusterId cluster) const = 0;
     virtual ArcBounds getClusterBounds(ClusterId cluster) const = 0;
-    virtual Loc getClusterOffset(ClusterId cluster, CellInfo *cell) const = 0;
+    virtual Loc getClusterOffset(CellInfo *cell) const = 0;
     virtual bool isClusterStrict(CellInfo *cell) const = 0;
     virtual bool getClusterPlacement(ClusterId cluster, BelId root_bel,
                                      std::vector<std::pair<CellInfo *, BelId>> &placement) const = 0;

--- a/common/base_arch.h
+++ b/common/base_arch.h
@@ -428,7 +428,7 @@ template <typename R> struct BaseArch : ArchAPI<R>
                     return result;
                 });
                 BelId child_bel = this->getBelByLocation(child_loc);
-                if (child_bel == BelId() || !this->isValidBelForCellType(child->type, root_bel))
+                if (child_bel == BelId() || !this->isValidBelForCellType(child->type, child_bel))
                     return false;
                 placement.emplace_back(child, child_bel);
             }

--- a/common/base_arch.h
+++ b/common/base_arch.h
@@ -393,13 +393,13 @@ template <typename R> struct BaseArch : ArchAPI<R>
         });
     }
 
-    virtual Loc getClusterOffset(CellInfo *cell) const override
+    virtual Loc getClusterOffset(const CellInfo *cell) const override
     {
         return if_using_basecluster<Loc>(cell,
                                          [](const BaseClusterInfo *c) { return Loc(c->constr_x, c->constr_y, 0); });
     }
 
-    virtual bool isClusterStrict(CellInfo *cell) const override { return true; }
+    virtual bool isClusterStrict(const CellInfo *cell) const override { return true; }
 
     virtual bool getClusterPlacement(ClusterId cluster, BelId root_bel,
                                      std::vector<std::pair<CellInfo *, BelId>> &placement) const override

--- a/common/base_clusterinfo.h
+++ b/common/base_clusterinfo.h
@@ -1,0 +1,44 @@
+/*
+ *  nextpnr -- Next Generation Place and Route
+ *
+ *  Copyright (C) 2021  gatecat <gatecat@ds0.me>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#ifndef BASE_CLUSTERINFO_H
+#define BASE_CLUSTERINFO_H
+
+#include "idstring.h"
+#include "nextpnr_namespaces.h"
+
+NEXTPNR_NAMESPACE_BEGIN
+
+struct CellInfo;
+
+// The 'legacy' cluster data, used for existing arches and to provide a basic implementation for arches without complex
+// clustering requirements
+struct BaseClusterInfo
+{
+    std::vector<CellInfo *> constr_children;
+    const int UNCONSTR = INT_MIN;
+    int constr_x = UNCONSTR;   // this.x - parent.x
+    int constr_y = UNCONSTR;   // this.y - parent.y
+    int constr_z = UNCONSTR;   // this.z - parent.z
+    bool constr_abs_z = false; // parent.z := 0
+};
+
+NEXTPNR_NAMESPACE_END
+
+#endif /* BASE_ARCH_H */

--- a/common/base_clusterinfo.h
+++ b/common/base_clusterinfo.h
@@ -32,10 +32,9 @@ struct CellInfo;
 struct BaseClusterInfo
 {
     std::vector<CellInfo *> constr_children;
-    const int UNCONSTR = INT_MIN;
-    int constr_x = UNCONSTR;   // this.x - parent.x
-    int constr_y = UNCONSTR;   // this.y - parent.y
-    int constr_z = UNCONSTR;   // this.z - parent.z
+    int constr_x = 0;          // this.x - parent.x
+    int constr_y = 0;          // this.y - parent.y
+    int constr_z = 0;          // this.z - parent.z
     bool constr_abs_z = false; // parent.z := 0
 };
 

--- a/common/base_clusterinfo.h
+++ b/common/base_clusterinfo.h
@@ -23,6 +23,8 @@
 #include "idstring.h"
 #include "nextpnr_namespaces.h"
 
+#include <vector>
+
 NEXTPNR_NAMESPACE_BEGIN
 
 struct CellInfo;

--- a/common/basectx.cc
+++ b/common/basectx.cc
@@ -152,25 +152,6 @@ void BaseCtx::archInfoToAttributes()
             ci->attrs[id("NEXTPNR_BEL")] = getCtx()->getBelName(ci->bel).str(getCtx());
             ci->attrs[id("BEL_STRENGTH")] = (int)ci->belStrength;
         }
-        if (ci->constr_x != ci->UNCONSTR)
-            ci->attrs[id("CONSTR_X")] = ci->constr_x;
-        if (ci->constr_y != ci->UNCONSTR)
-            ci->attrs[id("CONSTR_Y")] = ci->constr_y;
-        if (ci->constr_z != ci->UNCONSTR) {
-            ci->attrs[id("CONSTR_Z")] = ci->constr_z;
-            ci->attrs[id("CONSTR_ABS_Z")] = ci->constr_abs_z ? 1 : 0;
-        }
-        if (ci->constr_parent != nullptr)
-            ci->attrs[id("CONSTR_PARENT")] = ci->constr_parent->name.str(this);
-        if (!ci->constr_children.empty()) {
-            std::string constr = "";
-            for (auto &item : ci->constr_children) {
-                if (!constr.empty())
-                    constr += std::string(";");
-                constr += item->name.c_str(this);
-            }
-            ci->attrs[id("CONSTR_CHILDREN")] = constr;
-        }
     }
     for (auto &net : getCtx()->nets) {
         auto ni = net.second.get();
@@ -203,48 +184,6 @@ void BaseCtx::attributesToArchInfo()
 
             BelId b = getCtx()->getBelByNameStr(val->second.as_string());
             getCtx()->bindBel(b, ci, strength);
-        }
-
-        val = ci->attrs.find(id("CONSTR_PARENT"));
-        if (val != ci->attrs.end()) {
-            auto parent = cells.find(id(val->second.str));
-            if (parent != cells.end())
-                ci->constr_parent = parent->second.get();
-            else
-                continue;
-        }
-
-        val = ci->attrs.find(id("CONSTR_X"));
-        if (val != ci->attrs.end())
-            ci->constr_x = val->second.as_int64();
-
-        val = ci->attrs.find(id("CONSTR_Y"));
-        if (val != ci->attrs.end())
-            ci->constr_y = val->second.as_int64();
-
-        val = ci->attrs.find(id("CONSTR_Z"));
-        if (val != ci->attrs.end())
-            ci->constr_z = val->second.as_int64();
-
-        val = ci->attrs.find(id("CONSTR_ABS_Z"));
-        if (val != ci->attrs.end())
-            ci->constr_abs_z = val->second.as_int64() == 1;
-
-        val = ci->attrs.find(id("CONSTR_PARENT"));
-        if (val != ci->attrs.end()) {
-            auto parent = cells.find(id(val->second.as_string()));
-            if (parent != cells.end())
-                ci->constr_parent = parent->second.get();
-        }
-        val = ci->attrs.find(id("CONSTR_CHILDREN"));
-        if (val != ci->attrs.end()) {
-            std::vector<std::string> strs;
-            auto children = val->second.as_string();
-            boost::split(strs, children, boost::is_any_of(";"));
-            for (auto val : strs) {
-                if (cells.count(id(val.c_str())))
-                    ci->constr_children.push_back(cells.find(id(val.c_str()))->second.get());
-            }
         }
     }
     for (auto &net : getCtx()->nets) {

--- a/common/nextpnr_types.cc
+++ b/common/nextpnr_types.cc
@@ -44,26 +44,9 @@ void CellInfo::unsetParam(IdString name) { params.erase(name); }
 void CellInfo::setAttr(IdString name, Property value) { attrs[name] = value; }
 void CellInfo::unsetAttr(IdString name) { attrs.erase(name); }
 
-bool CellInfo::isConstrained(bool include_abs_z_constr) const
-{
-    return constr_parent != nullptr || !constr_children.empty() || (include_abs_z_constr && constr_abs_z);
-}
-
 bool CellInfo::testRegion(BelId bel) const
 {
     return region == nullptr || !region->constr_bels || region->bels.count(bel);
-}
-Loc CellInfo::getConstrainedLoc(Loc parent_loc) const
-{
-    NPNR_ASSERT(constr_parent != nullptr);
-    Loc cloc = parent_loc;
-    if (constr_x != UNCONSTR)
-        cloc.x += constr_x;
-    if (constr_y != UNCONSTR)
-        cloc.y += constr_y;
-    if (constr_z != UNCONSTR)
-        cloc.z = constr_abs_z ? constr_z : (parent_loc.z + constr_z);
-    return cloc;
 }
 
 NEXTPNR_NAMESPACE_END

--- a/common/nextpnr_types.h
+++ b/common/nextpnr_types.h
@@ -165,15 +165,8 @@ struct CellInfo : ArchCellInfo
     BelId bel;
     PlaceStrength belStrength = STRENGTH_NONE;
 
-    // placement constraints
-    CellInfo *constr_parent = nullptr;
-    std::vector<CellInfo *> constr_children;
-    const int UNCONSTR = INT_MIN;
-    int constr_x = UNCONSTR;   // this.x - parent.x
-    int constr_y = UNCONSTR;   // this.y - parent.y
-    int constr_z = UNCONSTR;   // this.z - parent.z
-    bool constr_abs_z = false; // parent.z := 0
-    // parent.[xyz] := 0 when (constr_parent == nullptr)
+    // cell is part of a cluster if != ClusterId
+    ClusterId cluster;
 
     Region *region = nullptr;
 

--- a/common/nextpnr_types.h
+++ b/common/nextpnr_types.h
@@ -178,14 +178,8 @@ struct CellInfo : ArchCellInfo
     void unsetParam(IdString name);
     void setAttr(IdString name, Property value);
     void unsetAttr(IdString name);
-
-    // return true if the cell has placement constraints (optionally excluding the case where the only case is an
-    // absolute z constraint)
-    bool isConstrained(bool include_abs_z_constr = true) const;
     // check whether a bel complies with the cell's region constraint
     bool testRegion(BelId bel) const;
-    // get the constrained location for this cell given a provisional location for its parent
-    Loc getConstrainedLoc(Loc parent_loc) const;
 };
 
 enum TimingPortClass

--- a/common/timing_opt.cc
+++ b/common/timing_opt.cc
@@ -182,8 +182,7 @@ class TimingOptimiser
                     CellInfo *bound = ctx->getBoundBelCell(bel);
                     if (bound == nullptr) {
                         free_bels_at_loc.push_back(bel);
-                    } else if (bound->belStrength <= STRENGTH_WEAK && bound->constr_parent == nullptr &&
-                               bound->constr_children.empty()) {
+                    } else if (bound->belStrength <= STRENGTH_WEAK && bound->cluster == ClusterId()) {
                         bound_bels_at_loc.push_back(bel);
                     }
                 }
@@ -378,7 +377,7 @@ class TimingOptimiser
         if (front_net != nullptr && front_net->driver.cell != nullptr) {
             auto front_cell = front_net->driver.cell;
             if (front_cell->belStrength <= STRENGTH_WEAK && cfg.cellTypes.count(front_cell->type) &&
-                front_cell->constr_parent == nullptr && front_cell->constr_children.empty()) {
+                front_cell->cluster == ClusterId()) {
                 path_cells.push_back(front_cell->name);
             }
         }
@@ -392,7 +391,7 @@ class TimingOptimiser
             if (std::find(path_cells.begin(), path_cells.end(), port->cell->name) != path_cells.end())
                 continue;
             if (port->cell->belStrength > STRENGTH_WEAK || !cfg.cellTypes.count(port->cell->type) ||
-                port->cell->constr_parent != nullptr || !port->cell->constr_children.empty())
+                port->cell->cluster != ClusterId())
                 continue;
             if (ctx->debug)
                 log_info("        can move\n");

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -736,13 +736,13 @@ Gets the root cell of a cluster, which is used as a datum point when placing the
 
 Gets an approximate bounding box of the cluster. This is intended for area allocation in the placer and is permitted to occasionally give incorrect estimates, for example due to irregularities in the fabric depending on cluster placement. `getClusterPlacement` should always be used to get exact locations.
 
-### Loc getClusterOffset(CellInfo \*cell) const
+### Loc getClusterOffset(const CellInfo \*cell) const
 
 Gets the approximate offset of a cell within its cluster, relative to the root cell. This is intended for global placement usage and is permitted to occasionally give incorrect estimates, for example due to irregularities in the fabric depending on cluster placement. `getClusterPlacement` should always be used to get exact locations.
 
 The returned x and y coordinates, when added to the root location of the cluster, should give an approximate location where `cell` will end up placed at.
 
-### bool isClusterStrict(CellInfo *cell) const
+### bool isClusterStrict(const CellInfo *cell) const
 
 Returns `true` if the cell **must** be placed according to the cluster; for example typical carry chains, and dedicated IO routing. Returns `false` if the cell can be split from the cluster if placement desires, at the expense of a less optimal result (for example dedicated LUT-FF paths where general routing can also be used).
 

--- a/docs/netlist.md
+++ b/docs/netlist.md
@@ -23,11 +23,7 @@ Other structures used by these basic structures include:
  - `ports` is a map from port name `IdString` to `PortInfo` structures for each cell port
  - `bel` and `belStrength` contain the ID of the Bel the cell is placed onto; and placement strength of the cell; if placed. Placement/ripup should always be done by `Arch::bindBel` and `Arch::unbindBel` rather than by manipulating these fields.
  - `params` and `attrs` store parameters and attributes - from the input JSON or assigned in flows to add metadata - by mapping from parameter name `IdString` to `Property`.
- - The `constr_` fields are for relative constraints:
-    - `constr_parent` is a reference to the cell this cell is constrained with respect to; or `nullptr` if not relatively constrained. If not `nullptr`, this cell should be in the parent's `constr_children`.
-    - `constr_children` is a list of cells relatively constrained to this one. All children should have `constr_parent == this`. 
-    - `constr_x` and `constr_y` are absolute (`constr_parent == nullptr`) or relative (`constr_parent != nullptr`) tile coordinate constraints. If set to `UNCONSTR` then the cell is not constrained in this axis (defaults to `UNCONSTR`)
-    - `constr_z` is an absolute (`constr_abs_z`) or relative (`!constr_abs_z`) 'Z-axis' (index inside tile, e.g. logic cell) constraint
+ - `cluster` is used to specify that the cell is inside a placement cluster, with the details of the placement within the cluster provided by the architecture.
  - `region` is a reference to a `Region` if the cell is constrained to a placement region (e.g. for partial reconfiguration or out-of-context flows) or `nullptr` otherwise.
 
 ## NetInfo

--- a/ecp5/archdefs.h
+++ b/ecp5/archdefs.h
@@ -23,6 +23,7 @@
 
 #include <boost/functional/hash.hpp>
 
+#include "base_clusterinfo.h"
 #include "idstring.h"
 #include "nextpnr_namespaces.h"
 
@@ -148,7 +149,9 @@ struct ArchNetInfo
     bool is_global = false;
 };
 
-struct ArchCellInfo
+typedef IdString ClusterId;
+
+struct ArchCellInfo : BaseClusterInfo
 {
     struct
     {

--- a/ecp5/bitstream.cc
+++ b/ecp5/bitstream.cc
@@ -1171,7 +1171,7 @@ void write_bitstream(Context *ctx, std::string base_config_file, std::string tex
             tg.config.add_enum(dsp + ".RESETMODE", str_or_default(ci->params, ctx->id("RESETMODE"), "SYNC"));
 
             tg.config.add_enum(dsp + ".MODE", "MULT18X18D");
-            if (str_or_default(ci->params, ctx->id("REG_OUTPUT_CLK"), "NONE") == "NONE" && ci->constr_parent == nullptr)
+            if (str_or_default(ci->params, ctx->id("REG_OUTPUT_CLK"), "NONE") == "NONE" && ci->cluster == ClusterId())
                 tg.config.add_enum(dsp + ".CIBOUT_BYP", "ON");
 
             if (loc.z < 4)

--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -835,6 +835,19 @@ struct Arch : ArchAPI<ArchRanges>
         return get_site_status(tile_status, bel_data).checkSiteRouting(getCtx(), tile_status);
     }
 
+    // -------------------------------------------------
+
+    // TODO
+    CellInfo *getClusterRootCell(ClusterId cluster) const override { NPNR_ASSERT_FALSE("unimplemented"); }
+    ArcBounds getClusterBounds(ClusterId cluster) const override { NPNR_ASSERT_FALSE("unimplemented"); }
+    Loc getClusterOffset(const CellInfo *cell) const override { NPNR_ASSERT_FALSE("unimplemented"); }
+    bool isClusterStrict(const CellInfo *cell) const override { NPNR_ASSERT_FALSE("unimplemented"); }
+    bool getClusterPlacement(ClusterId cluster, BelId root_bel,
+                             std::vector<std::pair<CellInfo *, BelId>> &placement) const override
+    {
+        NPNR_ASSERT_FALSE("unimplemented");
+    }
+
     IdString get_bel_tiletype(BelId bel) const { return IdString(loc_info(chip_info, bel).name); }
 
     std::unordered_map<WireId, Loc> sink_locs, source_locs;

--- a/fpga_interchange/archdefs.h
+++ b/fpga_interchange/archdefs.h
@@ -98,6 +98,8 @@ struct BelBucketId
     bool operator<(const BelBucketId &other) const { return name < other.name; }
 };
 
+typedef IdString ClusterId;
+
 struct SiteExpansionLoop;
 
 struct ArchNetInfo

--- a/generic/arch.h
+++ b/generic/arch.h
@@ -362,6 +362,17 @@ struct Arch : ArchAPI<ArchRanges>
     bool isValidBelForCellType(IdString cell_type, BelId bel) const override { return cell_type == getBelType(bel); }
     bool isBelLocationValid(BelId bel) const override;
 
+    // TODO
+    CellInfo *getClusterRootCell(ClusterId cluster) const override { NPNR_ASSERT_FALSE("unimplemented"); }
+    ArcBounds getClusterBounds(ClusterId cluster) const override { NPNR_ASSERT_FALSE("unimplemented"); }
+    Loc getClusterOffset(const CellInfo *cell) const override { NPNR_ASSERT_FALSE("unimplemented"); }
+    bool isClusterStrict(const CellInfo *cell) const override { NPNR_ASSERT_FALSE("unimplemented"); }
+    bool getClusterPlacement(ClusterId cluster, BelId root_bel,
+                             std::vector<std::pair<CellInfo *, BelId>> &placement) const override
+    {
+        NPNR_ASSERT_FALSE("unimplemented");
+    }
+
     static const std::string defaultPlacer;
     static const std::vector<std::string> availablePlacers;
     static const std::string defaultRouter;

--- a/generic/archdefs.h
+++ b/generic/archdefs.h
@@ -34,6 +34,7 @@ typedef IdStringList PipId;
 typedef IdStringList GroupId;
 typedef IdStringList DecalId;
 typedef IdString BelBucketId;
+typedef IdString ClusterId;
 
 struct ArchNetInfo
 {

--- a/gowin/archdefs.h
+++ b/gowin/archdefs.h
@@ -21,6 +21,7 @@
 #ifndef GOWIN_ARCHDEFS_H
 #define GOWIN_ARCHDEFS_H
 
+#include "base_clusterinfo.h"
 #include "idstring.h"
 #include "nextpnr_namespaces.h"
 
@@ -56,7 +57,7 @@ struct ArchNetInfo
 
 struct NetInfo;
 
-struct ArchCellInfo
+struct ArchCellInfo : BaseClusterInfo
 {
     // Is the flip-flop of this slice used
     bool ff_used;

--- a/gowin/archdefs.h
+++ b/gowin/archdefs.h
@@ -48,6 +48,7 @@ typedef IdString PipId;
 typedef IdString GroupId;
 typedef IdString DecalId;
 typedef IdString BelBucketId;
+typedef IdString ClusterId;
 
 struct ArchNetInfo
 {

--- a/ice40/archdefs.h
+++ b/ice40/archdefs.h
@@ -22,6 +22,7 @@
 
 #include <boost/functional/hash.hpp>
 
+#include "base_clusterinfo.h"
 #include "idstring.h"
 #include "nextpnr_namespaces.h"
 
@@ -122,7 +123,7 @@ struct ArchNetInfo
 
 struct NetInfo;
 
-struct ArchCellInfo
+struct ArchCellInfo : BaseClusterInfo
 {
     union
     {
@@ -154,6 +155,7 @@ struct ArchCellInfo
 };
 
 typedef IdString BelBucketId;
+typedef IdString ClusterId;
 
 NEXTPNR_NAMESPACE_END
 

--- a/ice40/chains.cc
+++ b/ice40/chains.cc
@@ -292,12 +292,14 @@ class ChainConstrainer
             // Place carry chain
             chain.cells.at(0)->constr_abs_z = true;
             chain.cells.at(0)->constr_z = 0;
+            chain.cells.at(0)->cluster = chain.cells.at(0)->name;
+
             for (int i = 1; i < int(chain.cells.size()); i++) {
                 chain.cells.at(i)->constr_x = 0;
                 chain.cells.at(i)->constr_y = (i / 8);
                 chain.cells.at(i)->constr_z = i % 8;
                 chain.cells.at(i)->constr_abs_z = true;
-                chain.cells.at(i)->constr_parent = chain.cells.at(0);
+                chain.cells.at(i)->cluster = chain.cells.at(0)->name;
                 chain.cells.at(0)->constr_children.push_back(chain.cells.at(i));
             }
         }

--- a/machxo2/archdefs.h
+++ b/machxo2/archdefs.h
@@ -21,6 +21,7 @@
 #ifndef MACHXO2_ARCHDEFS_H
 #define MACHXO2_ARCHDEFS_H
 
+#include "base_clusterinfo.h"
 #include "idstring.h"
 #include "nextpnr_namespaces.h"
 
@@ -104,6 +105,7 @@ struct PipId
 typedef IdString GroupId;
 typedef IdString DecalId;
 typedef IdString BelBucketId;
+typedef IdString ClusterId;
 
 struct ArchNetInfo
 {
@@ -111,7 +113,7 @@ struct ArchNetInfo
 
 struct NetInfo;
 
-struct ArchCellInfo
+struct ArchCellInfo : BaseClusterInfo
 {
 };
 

--- a/nexus/archdefs.h
+++ b/nexus/archdefs.h
@@ -23,6 +23,7 @@
 #include <boost/functional/hash.hpp>
 #include <unordered_map>
 
+#include "base_clusterinfo.h"
 #include "idstring.h"
 #include "nextpnr_namespaces.h"
 
@@ -157,7 +158,9 @@ inline bool operator!=(const FFControlSet &a, const FFControlSet &b)
            (a.ce != b.ce);
 }
 
-struct ArchCellInfo
+typedef IdString ClusterId;
+
+struct ArchCellInfo : BaseClusterInfo
 {
     union
     {

--- a/nexus/post_place.cc
+++ b/nexus/post_place.cc
@@ -32,10 +32,7 @@ struct NexusPostPlaceOpt
 
     NexusPostPlaceOpt(Context *ctx) : ctx(ctx), tmg(ctx){};
 
-    inline bool is_constrained(CellInfo *cell)
-    {
-        return cell->constr_parent != nullptr || !cell->constr_children.empty();
-    }
+    inline bool is_constrained(CellInfo *cell) { return cell->cluster != ClusterId(); }
 
     bool swap_cell_placement(CellInfo *cell, BelId new_bel)
     {


### PR DESCRIPTION
This PR describes a new way of representing clusters to give considerably more flexibility to the architecture as to how cells are placed relative to each other; compared to the existing `constr_{x, y, z}` approach.

In particular, this approach can enable architectures to represent:
 - carry chains with discontinuities in the relative coordinates, for example due to clocking rows
 - IO-IOLOGIC connectivity which may be better defined by the routing graph than by relative coordinates
 - intra-site dedicated routing where the `z` coordinates aren't meaningful, and using bel names or routing to define constraints makes more sense.

Currently this PR only contains the API specification and not any implementation. I'd really appreciate some feedback before I start working on implementation, including a default implementation similar to the existing API for current arches.

cc @acomodi @kowalewskijan @mkurc-ant for any thoughts?