### PR TITLE
Fix variable name in bits.h for MSVC builds

### DIFF
--- a/common/bits.h
+++ b/common/bits.h
@@ -51,7 +51,7 @@ struct Bits
 #if defined(__GNUC__) || defined(__clang__)
         return __builtin_popcount(x);
 #elif defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
-        return __popcnt(v);
+        return __popcnt(x);
 #else
         return generic_popcount(x);
 #endif
@@ -63,7 +63,7 @@ struct Bits
         return __builtin_ctz(x);
 #elif defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
         unsigned long result;
-        _BitScanForward(&result, v);
+        _BitScanForward(&result, x);
         return result;
 #else
         return generic_ctz(x);


### PR DESCRIPTION
Fixed the variable name for windows MSVC builds. I didn't test this build locally but [the log](https://github.com/davidcorrigan714/nextpnr-actions-prototype/runs/2472076784?check_suite_focus=true#step:13:2729) on the GitHub action I've been running seems pretty conclusive this is the culprit.