### PR TITLE
interchange: fix site-thru pip legality

### DIFF
--- a/fpga_interchange/site_router.cc
+++ b/fpga_interchange/site_router.cc
@@ -245,7 +245,7 @@ struct SiteExpansionLoop
                         if (!parent_node->can_leave_site()) {
                             // This path has already left the site once, don't leave it again!
                             if (verbose_site_router(ctx)) {
-                                log_info("Pip %s is not a valid for this path because it has already left the site\n",
+                                log_info("%s is not a valid PIP for this path because it has already left the site\n",
                                          ctx->nameOfPip(pip));
                             }
                             continue;
@@ -258,7 +258,7 @@ struct SiteExpansionLoop
                             // don't enter it again!
                             if (verbose_site_router(ctx)) {
                                 log_info(
-                                        "Pip %s is not a valid for this path because it has already entered the site\n",
+                                        "%s is not a valid PIP for this path because it has already entered the site\n",
                                         ctx->nameOfPip(pip));
                             }
                             continue;
@@ -280,7 +280,7 @@ struct SiteExpansionLoop
                 if (!node->is_valid_node()) {
                     if (verbose_site_router(ctx)) {
                         log_info(
-                                "Pip %s is not a valid for this path because it has left the site after entering it.\n",
+                                "%s is not a valid PIP for this path because it has left the site after entering it.\n",
                                 ctx->nameOfPip(pip));
                     }
                     continue;

--- a/fpga_interchange/site_router.cc
+++ b/fpga_interchange/site_router.cc
@@ -157,6 +157,7 @@ struct SiteExpansionLoop
                 NPNR_ASSERT((*parent)->wire.type == SiteWire::SITE_WIRE);
                 NPNR_ASSERT(node->can_leave_site());
                 node->mark_left_site();
+                node->mark_left_site_after_entering();
             } else if (wire.type == SiteWire::SITE_PORT_SOURCE) {
                 // This is a backward walk, so this is considered entering
                 // the site.
@@ -171,6 +172,7 @@ struct SiteExpansionLoop
                     // the site.
                     NPNR_ASSERT(node->can_leave_site());
                     node->mark_left_site();
+                    node->mark_left_site_after_entering();
                 } else {
                     NPNR_ASSERT((*parent)->wire.type == SiteWire::SITE_PORT_SOURCE);
                     NPNR_ASSERT(node->can_enter_site());
@@ -274,6 +276,16 @@ struct SiteExpansionLoop
                 }
 
                 auto node = new_node(wire, pip, &parent_node);
+
+                if (!node->is_valid_node()) {
+                    if (verbose_site_router(ctx)) {
+                        log_info(
+                                "Pip %s is not a valid for this path because it has left the site after entering it.\n",
+                                ctx->nameOfPip(pip));
+                    }
+                    continue;
+                }
+
                 if (targets.count(wire)) {
                     completed_routes.push_back(node.get_index());
                     max_depth = std::max(max_depth, node->depth);

--- a/fpga_interchange/site_routing_storage.h
+++ b/fpga_interchange/site_routing_storage.h
@@ -45,13 +45,24 @@ struct RouteNode
         LEFT_SITE = 0,
         // Has this path entered the site?
         ENTERED_SITE = 1,
+        // Has this path left the site after entering it?
+        // This node should be discarded as being part of an illegal path
+        // which allows entering and exiting a site, situation that needs
+        // to be handled with a tile PIP.
+        LEFT_SITE_AFTER_ENTERING = 2,
     };
 
     bool has_left_site() const { return (flags & (1 << LEFT_SITE)) != 0; }
 
+    bool has_left_site_after_entering() const { return (flags & (1 << LEFT_SITE_AFTER_ENTERING)) != 0; }
+
     bool can_leave_site() const { return !has_left_site(); }
 
+    bool is_valid_node() const { return !has_left_site_after_entering(); }
+
     void mark_left_site() { flags |= (1 << LEFT_SITE); }
+
+    void mark_left_site_after_entering() { flags |= (has_entered_site() << LEFT_SITE_AFTER_ENTERING); }
 
     bool has_entered_site() const { return (flags & (1 << ENTERED_SITE)) != 0; }
 


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This is an attempt at solving the issue described in this comment: https://github.com/SymbiFlow/python-fpga-interchange/issues/76#issuecomment-832759322.

Basically, a site-thru PIP should not be allowed in the cases where the a BEL is not in the same site of the site-thru PIP. The change in this PR is rather strict, as if a net has multiple sinks in different sites, the PIP is automatically considered illegal, even though the actual sink BEL of that connection resides in the same site.

cc @gatecat 