### PR TITLE
interchange: arch: do not allow site pips within sites

### DIFF
--- a/fpga_interchange/arch.cc
+++ b/fpga_interchange/arch.cc
@@ -1805,12 +1805,6 @@ bool Arch::checkPipAvailForNet(PipId pip, NetInfo *net) const
                     NPNR_ASSERT(src_wire_data.site == pip_data.site);
                     valid_pip = true;
                 }
-
-                if (dst_wire_data.site == bel_data.site && src_wire_data.site == bel_data.site) {
-                    // This is site pip for the same site as the driver, allow
-                    // this site pip.
-                    valid_pip = true;
-                }
             }
         }
 

--- a/fpga_interchange/arch.cc
+++ b/fpga_interchange/arch.cc
@@ -1776,15 +1776,15 @@ bool Arch::checkPipAvailForNet(PipId pip, NetInfo *net) const
         }
     }
 
+    auto tile_status_iter = tileStatus.find(pip.tile);
+
     if (pip_data.pseudo_cell_wires.size() > 0) {
         // FIXME: This pseudo pip check is incomplete, because constraint
         // failures will not be detected.  However the current FPGA
         // interchange schema does not provide a cell type to place.
-        auto iter = tileStatus.find(pip.tile);
-        if (iter != tileStatus.end()) {
-            if (!iter->second.pseudo_pip_model.checkPipAvail(getCtx(), pip)) {
-                return false;
-            }
+        if (tile_status_iter != tileStatus.end() &&
+            !tile_status_iter->second.pseudo_pip_model.checkPipAvail(getCtx(), pip)) {
+            return false;
         }
     }
 
@@ -1797,12 +1797,16 @@ bool Arch::checkPipAvailForNet(PipId pip, NetInfo *net) const
 
         bool valid_pip = false;
         if (pip.tile == net->driver.cell->bel.tile) {
-            const BelInfoPOD &bel_data = tile_type.bel_data[net->driver.cell->bel.index];
-            if (bel_data.site == pip_data.site) {
-                // Only allow site pips or output site ports.
-                if (dst_wire_data.site == -1) {
-                    // Allow output site port from this site.
-                    NPNR_ASSERT(src_wire_data.site == pip_data.site);
+            if (tile_status_iter == tileStatus.end()) {
+                // there is no tile status and nothing blocks the validity of this PIP
+                valid_pip = true;
+            } else {
+                const BelInfoPOD &bel_data = tile_type.bel_data[net->driver.cell->bel.index];
+                const SiteRouter &site_router = get_site_status(tile_status_iter->second, bel_data);
+
+                const auto& pips = site_router.valid_pips;
+                auto result = std::find(pips.begin(), pips.end(), pip);
+                if (result != pips.end()) {
                     valid_pip = true;
                 }
             }

--- a/fpga_interchange/site_router.h
+++ b/fpga_interchange/site_router.h
@@ -38,6 +38,7 @@ struct SiteRouter
     SiteRouter(int16_t site) : site(site), dirty(false), site_ok(true) {}
 
     std::unordered_set<CellInfo *> cells_in_site;
+    std::vector<PipId> valid_pips;
     const int16_t site;
 
     mutable bool dirty;


### PR DESCRIPTION
During general routing, the only site pips that can be allowed are those which connect a site wire to the routing interface. Or, in more general terms, all the PIPs connecting a driver to the routing interface.

This patch though might be too restrictive when dealing with architectures that require more than one site PIPs to route from a driver within a site to the routing interface (which is something that should be allowed in the interchange).

After all, backtracking to validate a path might still be required, as https://github.com/YosysHQ/nextpnr/pull/695 is not enough to cover the faulty edge-cases, where a series of PIPs were used to completely route thru a site.