### PR TITLE
interchange: pseudo pips: fix illegal tile pseudo PIPs

### DIFF
--- a/fpga_interchange/site_router.h
+++ b/fpga_interchange/site_router.h
@@ -39,6 +39,7 @@ struct SiteRouter
 
     std::unordered_set<CellInfo *> cells_in_site;
     std::vector<PipId> valid_pips;
+    HashTables::HashSet<std::pair<IdString, int32_t>, PairHash> lut_thrus;
     const int16_t site;
 
     mutable bool dirty;


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR fixes https://github.com/SymbiFlow/python-fpga-interchange/issues/76. It allows to store site LUT-thrus that are used during site routing, so that, during the general routing step, the pseudo tile PIPs are correctly blocked by the lut equation.