### PR TITLE
mistral: Use MLABs as if they're LABs (for now)

### DIFF
--- a/mistral/arch.cc
+++ b/mistral/arch.cc
@@ -71,7 +71,10 @@ Arch::Arch(ArchArgs args)
             for (CycloneV::block_type_t bel : cyclonev->pos_get_bels(pos)) {
                 switch (bel) {
                 case CycloneV::block_type_t::LAB:
-                    create_lab(x, y);
+                    create_lab(x, y, /*is_mlab=*/false);
+                    break;
+                case CycloneV::block_type_t::MLAB:
+                    create_lab(x, y, /*is_mlab=*/true);
                     break;
                 default:
                     continue;

--- a/mistral/arch.h
+++ b/mistral/arch.h
@@ -58,6 +58,8 @@ struct ALMInfo
 
 struct LABInfo
 {
+    // LAB or MLAB?
+    bool is_mlab;
     std::array<ALMInfo, 10> alms;
     //  Control set wires
     std::array<WireId, 3> clk_wires, ena_wires;
@@ -457,9 +459,9 @@ struct Arch : BaseArch<ArchRanges>
         return WireId(cyclonev->pnode_to_rnode(CycloneV::pnode(bt, x, y, port, bi, pi)));
     }
 
-    void create_lab(int x, int y);    // lab.cc
-    void create_gpio(int x, int y);   // io.cc
-    void create_clkbuf(int x, int y); // globals.cc
+    void create_lab(int x, int y, bool is_mlab); // lab.cc
+    void create_gpio(int x, int y);              // io.cc
+    void create_clkbuf(int x, int y);            // globals.cc
 
     // -------------------------------------------------
 


### PR DESCRIPTION
Much of this is just mechanically replacing hardcoded `CycloneV::LAB`.

This reduces routing time for attosoc by quite a bit, presumably due to the ALMs being closer together.