### PR TITLE
mistral: Make RBF compression optional

### DIFF
--- a/mistral/bitstream.cc
+++ b/mistral/bitstream.cc
@@ -34,6 +34,8 @@ struct MistralBitgen
         ctx->init_base_bitstream();
         // Default options
         cv->opt_b_set(CycloneV::ALLOW_DEVICE_WIDE_OUTPUT_ENABLE_DIS, true);
+        if (!ctx->setting<bool>("compress_rbf", false))
+            cv->opt_b_set(CycloneV::COMPRESSION_DIS, true);
         cv->opt_n_set(CycloneV::CRC_DIVIDE_ORDER, 8);
         cv->opt_b_set(CycloneV::CVP_CONF_DONE_EN, true);
         cv->opt_b_set(CycloneV::DEVICE_WIDE_RESET_EN, true);
@@ -42,7 +44,10 @@ struct MistralBitgen
         cv->opt_b_set(CycloneV::NCEO_DIS, true);
         cv->opt_b_set(CycloneV::OCT_DONE_DIS, true);
         cv->opt_r_set(CycloneV::OPT_A, 0x1dff);
-        cv->opt_r_set(CycloneV::OPT_B, 0xffffff402dffffffULL);
+        if (!ctx->setting<bool>("compress_rbf", false))
+            cv->opt_r_set(CycloneV::OPT_B, 0xffffff40adffffffULL);
+        else
+            cv->opt_r_set(CycloneV::OPT_B, 0xffffff402dffffffULL);
         cv->opt_b_set(CycloneV::RELEASE_CLEARS_BEFORE_TRISTATES_DIS, true);
         cv->opt_b_set(CycloneV::RETRY_CONFIG_ON_ERROR_EN, true);
         cv->opt_r_set(CycloneV::START_UP_CLOCK, 0x3F);

--- a/mistral/main.cc
+++ b/mistral/main.cc
@@ -51,6 +51,7 @@ po::options_description MistralCommandHandler::getArchOptions()
     specific.add_options()("device", po::value<std::string>(), "device name (e.g. 5CSEBA6U23I7)");
     specific.add_options()("qsf", po::value<std::string>(), "path to QSF constraints file");
     specific.add_options()("rbf", po::value<std::string>(), "RBF bitstream to write");
+    specific.add_options()("compress-rbf", "generate compressed bitstream");
 
     return specific;
 }
@@ -82,6 +83,8 @@ std::unique_ptr<Context> MistralCommandHandler::createContext(std::unordered_map
     chipArgs.mistral_root = vm["mistral"].as<std::string>();
     chipArgs.device = vm["device"].as<std::string>();
     auto ctx = std::unique_ptr<Context>(new Context(chipArgs));
+    if (vm.count("compress-rbf"))
+        ctx->settings[ctx->id("compress_rbf")] = Property::State::S1;
     return ctx;
 }
 


### PR DESCRIPTION
This is required for JTAG programming to work, which doesn't support compression - see https://github.com/trabucayre/openFPGALoader/issues/86#issuecomment-849342654

cc @Ravenslofty @trabucayre