### PR TITLE
interchange: arch: move macro expansion step before ios packing

### DIFF
--- a/fpga_interchange/arch.cc
+++ b/fpga_interchange/arch.cc
@@ -755,9 +755,9 @@ bool Arch::pack()
 {
     decode_lut_cells();
     merge_constant_nets();
+    expand_macros();
     pack_ports();
     pack_default_conns();
-    expand_macros();
     pack_cluster();
     return true;
 }


### PR DESCRIPTION
This enables instantiating IO macros