### PR TITLE
Preserve ArchArgs and reinit Context when applicable in GUI, fixes  #737

### DIFF
--- a/common/command.cc
+++ b/common/command.cc
@@ -475,15 +475,6 @@ int CommandHandler::exec()
 
 void CommandHandler::load_json(Context *ctx, std::string filename)
 {
-    ctx->cells.clear();
-    ctx->nets.clear();
-    ctx->net_aliases.clear();
-    ctx->ports.clear();
-    ctx->hierarchy.clear();
-    ctx->settings.erase(ctx->id("pack"));
-    ctx->settings.erase(ctx->id("place"));
-    ctx->settings.erase(ctx->id("route"));
-
     setupContext(ctx);
     setupArchContext(ctx);
     {

--- a/common/context.h
+++ b/common/context.h
@@ -37,7 +37,11 @@ struct Context : Arch, DeterministicRNG
     // Should we disable printing of the location of nets in the critical path?
     bool disable_critical_path_source_print = false;
 
-    Context(ArchArgs args) : Arch(args) { BaseCtx::as_ctx = this; }
+    ArchArgs arch_args;
+
+    Context(ArchArgs args) : Arch(args) { BaseCtx::as_ctx = this; arch_args = args; }
+
+    ArchArgs getArchArgs() { return arch_args; }
 
     // --------------------------------------------------------------
 

--- a/gui/basewindow.cc
+++ b/gui/basewindow.cc
@@ -365,6 +365,11 @@ void BaseMainWindow::open_json()
     QString fileName = QFileDialog::getOpenFileName(this, QString("Open JSON"), QString(), QString("*.json"));
     if (!fileName.isEmpty()) {
         disableActions();
+        if (ctx->settings.find(ctx->id("synth")) == ctx->settings.end()) {
+            ArchArgs chipArgs = ctx->getArchArgs();
+            ctx = std::unique_ptr<Context>(new Context(chipArgs));
+            Q_EMIT contextChanged(ctx.get());
+        }
         handler->load_json(ctx.get(), fileName.toStdString());
         Q_EMIT updateTreeView();
         log("Loading design successful.\n");
@@ -523,7 +528,7 @@ void BaseMainWindow::place() { Q_EMIT task->place(timing_driven); }
 
 void BaseMainWindow::disableActions()
 {
-    actionLoadJSON->setEnabled(false);
+    actionLoadJSON->setEnabled(true);
     actionPack->setEnabled(false);
     actionAssignBudget->setEnabled(false);
     actionPlace->setEnabled(false);


### PR DESCRIPTION
In case we already have at least some design loaded, we reinitialize whole context on loading new JSON file.
Also remove cleanup code which was not enough anyway to make this properly working/