### PR TITLE
interchange: Place entire IO macro based on routeability

### DIFF
--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -1152,6 +1152,7 @@ struct Arch : ArchAPI<ArchRanges>
     const DefaultCellConnsPOD *get_default_conns(IdString cell_type) const;
     void pack_default_conns();
 
+    dict<IdString, std::vector<CellInfo *>> macro_to_cells;
     void expand_macros();
 };
 

--- a/fpga_interchange/archdefs.h
+++ b/fpga_interchange/archdefs.h
@@ -120,6 +120,7 @@ struct ArchCellInfo
     dict<IdString, std::vector<IdString>> cell_bel_pins;
     dict<IdString, std::vector<IdString>> masked_cell_bel_pins;
     pool<IdString> const_ports;
+    IdString macro_parent = IdString();
     LutCell lut_cell;
 };
 

--- a/fpga_interchange/dedicated_interconnect.cc
+++ b/fpga_interchange/dedicated_interconnect.cc
@@ -87,7 +87,10 @@ bool DedicatedInterconnect::check_routing(BelId src_bel, IdString src_bel_pin, B
 
     WireNode wire_node;
     wire_node.wire = src_wire;
-    wire_node.state = IN_SOURCE_SITE;
+    if (src_wire.tile == dst_wire.tile && src_wire_data.site == dst_wire_data.site)
+        wire_node.state = IN_SINK_SITE;
+    else
+        wire_node.state = IN_SOURCE_SITE;
     wire_node.depth = 0;
 
     nodes_to_expand.push_back(wire_node);


### PR DESCRIPTION
This is needed to support UltraScale+ input buffers which are split between an `INBUF` and a `IBUFCTRL`, both in the same site with dedicated routing between the two that must be used.

![Screenshot from 2021-06-30 11-49-17](https://user-images.githubusercontent.com/78621419/123948449-51c4ae80-d999-11eb-9bf9-de8f366ac7e5.png)
