### PR TITLE
interchange: phys: do not output nets which have no users

### DIFF
--- a/fpga_interchange/fpga_interchange.cpp
+++ b/fpga_interchange/fpga_interchange.cpp
@@ -535,10 +535,21 @@ void FpgaInterchange::write_physical_netlist(const Context * ctx, const std::str
         phys_cell.setPhysType(PhysicalNetlist::PhysNetlist::PhysCellType::PORT);
     }
 
-    auto nets = phys_netlist.initPhysNets(ctx->nets.size());
+    int nets_to_remove = 0;
+    for(auto & net_pair : ctx->nets) {
+        auto &net = *net_pair.second;
+
+        if (net.users.empty())
+            nets_to_remove++;
+    }
+
+    auto nets = phys_netlist.initPhysNets(ctx->nets.size() - nets_to_remove);
     auto net_iter = nets.begin();
     for(auto & net_pair : ctx->nets) {
         auto &net = *net_pair.second;
+
+        if (net.users.empty())
+            continue;
 
         const CellInfo *driver_cell = net.driver.cell;
 


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This solves https://github.com/Xilinx/RapidWright/issues/196.

Nets which do not have any users should not be emitted, or otherwise the DCP generated out of a physical netlist with such nets will not be readable, producing the errors described in https://github.com/Xilinx/RapidWright/issues/196