### PR TITLE
interchange: Fix handling of constants in macros

### DIFF
--- a/fpga_interchange/arch.cc
+++ b/fpga_interchange/arch.cc
@@ -754,8 +754,8 @@ bool Arch::getBudgetOverride(const NetInfo *net_info, const PortRef &sink, delay
 bool Arch::pack()
 {
     decode_lut_cells();
-    merge_constant_nets();
     expand_macros();
+    merge_constant_nets();
     pack_ports();
     pack_default_conns();
     pack_cluster();


### PR DESCRIPTION
This is needed for UltraScale+ clock buffer macros, which contain constant sources in some cases that must be folded.