### PR TITLE
interchange: reduce run-time to check dedicated interconnect

### DIFF
--- a/.github/workflows/interchange_ci.yml
+++ b/.github/workflows/interchange_ci.yml
@@ -114,7 +114,7 @@ jobs:
       env:
         RAPIDWRIGHT_PATH: ${{ github.workspace }}/RapidWright
         PYTHON_INTERCHANGE_PATH: ${{ github.workspace }}/python-fpga-interchange
-        PYTHON_INTERCHANGE_TAG: v0.0.15
+        PYTHON_INTERCHANGE_TAG: v0.0.16
         PRJOXIDE_REVISION: 1bf30dee9c023c4c66cfc44fd0bc28addd229c89
         DEVICE: ${{ matrix.device }}
       run: |

--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -855,7 +855,7 @@ struct Arch : ArchAPI<ArchRanges>
         const CellInfo *cell = tile_status.boundcells[bel.index];
 
         if (cell != nullptr) {
-            if (cell->cluster == ClusterId() && !dedicated_interconnect.isBelLocationValid(bel, cell))
+            if (!dedicated_interconnect.isBelLocationValid(bel, cell))
                 return false;
 
             if (io_port_types.count(cell->type)) {

--- a/fpga_interchange/arch_pack_clusters.cc
+++ b/fpga_interchange/arch_pack_clusters.cc
@@ -193,6 +193,8 @@ bool Arch::getClusterPlacement(ClusterId cluster, BelId root_bel,
     const Context *ctx = getCtx();
     const Cluster &packed_cluster = clusters.at(cluster);
 
+    auto &cluster_data = cluster_info(chip_info, packed_cluster.index);
+
     CellInfo *root_cell = getClusterRootCell(cluster);
     if (!ctx->isValidBelForCellType(root_cell->type, root_bel))
         return false;
@@ -205,8 +207,6 @@ bool Arch::getClusterPlacement(ClusterId cluster, BelId root_bel,
             next_bel = root_bel;
         } else {
             // Find next chained cluster node
-            auto &cluster_data = cluster_info(chip_info, packed_cluster.index);
-
             IdString next_bel_pin(cluster_data.chainable_ports[0].bel_source);
             WireId next_bel_pin_wire = ctx->getBelPinWire(next_bel, next_bel_pin);
             next_bel = BelId();
@@ -256,7 +256,8 @@ bool Arch::getClusterPlacement(ClusterId cluster, BelId root_bel,
                 WireId bel_pin_wire = ctx->getBelPinWire(next_bel, bel_pin);
 
                 ExpansionDirection direction = port_type == PORT_IN ? CLUSTER_UPHILL_DIR : CLUSTER_DOWNHILL_DIR;
-                pool<BelId> cluster_bels = find_cluster_bels(ctx, bel_pin_wire, direction);
+                pool<BelId> cluster_bels =
+                        find_cluster_bels(ctx, bel_pin_wire, direction, (bool)cluster_data.out_of_site_clusters);
 
                 if (cluster_bels.size() == 0)
                     continue;

--- a/fpga_interchange/chipdb.h
+++ b/fpga_interchange/chipdb.h
@@ -421,6 +421,7 @@ NPNR_PACKED_STRUCT(struct ClusterPOD {
     RelSlice<uint32_t> root_cell_types;
     RelSlice<ChainablePortPOD> chainable_ports;
     RelSlice<ClusterCellPortPOD> cluster_cells_map;
+    uint32_t out_of_site_clusters;
 });
 
 NPNR_PACKED_STRUCT(struct ChipInfoPOD {

--- a/fpga_interchange/chipdb.h
+++ b/fpga_interchange/chipdb.h
@@ -34,7 +34,7 @@ NEXTPNR_NAMESPACE_BEGIN
  * kExpectedChipInfoVersion
  */
 
-static constexpr int32_t kExpectedChipInfoVersion = 11;
+static constexpr int32_t kExpectedChipInfoVersion = 12;
 
 // Flattened site indexing.
 //


### PR DESCRIPTION
This adds the possibility to cluster cells belonging to different sites (e.g. IDELAY -> IDELAYCTRL). To avoid spending useless time discovering valid BELs for only in-site clusters, I have added an additional piece of data to the [clustersPOD](https://github.com/SymbiFlow/python-fpga-interchange/pull/107).

The PR is marked as WIP as I have removed a detailed check for the dedicated interconnects which I think should be done, but might require a restructuring due to being quite expensive. Upon building the context, all the dedicated interconnects are pre-calculated. We can potentially enhance the pre-computed structures with additional data, avoiding us to perform a detailed check once again. I'll need to investigate a bit more what can be a better way of performing this check.