### PR TITLE
interchange: Support for UltraScale+ differential input buffers

### DIFF
--- a/fpga_interchange/arch_pack_io.cc
+++ b/fpga_interchange/arch_pack_io.cc
@@ -246,7 +246,8 @@ void Arch::pack_ports()
 
         if (possible_site_types.empty()) {
             if (getCtx()->verbose)
-                log_info("Port '%s' has no possible site types, falling back to all types!\n", port_name.c_str(getCtx()));
+                log_info("Port '%s' has no possible site types, falling back to all types!\n",
+                         port_name.c_str(getCtx()));
             possible_site_types = package_pin_site_types;
         }
 
@@ -316,6 +317,7 @@ void Arch::pack_ports()
         for (CellInfo *cell : placed_cells) {
             NPNR_ASSERT(cell->bel != BelId());
             if (!isBelLocationValid(cell->bel)) {
+                explain_bel_status(cell->bel);
                 log_error("Tightly bound BEL %s was not valid!\n", nameOfBel(cell->bel));
             }
         }

--- a/fpga_interchange/dedicated_interconnect.cc
+++ b/fpga_interchange/dedicated_interconnect.cc
@@ -457,12 +457,12 @@ void DedicatedInterconnect::explain_bel_status(BelId bel, const CellInfo *cell) 
         // Only check sink BELs.
         if (net->driver.cell == cell && net->driver.port == port_name) {
             if (!is_driver_on_net_valid(bel, cell, port_name, net)) {
-                log_info("Driver %s/%s is not valid on net '%s'", cell->name.c_str(ctx), port_name.c_str(ctx),
+                log_info("Driver %s/%s is not valid on net '%s'\n", cell->name.c_str(ctx), port_name.c_str(ctx),
                          net->name.c_str(ctx));
             }
         } else {
             if (!is_sink_on_net_valid(bel, cell, port_name, net)) {
-                log_info("Sink %s/%s is not valid on net '%s'", cell->name.c_str(ctx), port_name.c_str(ctx),
+                log_info("Sink %s/%s is not valid on net '%s'\n", cell->name.c_str(ctx), port_name.c_str(ctx),
                          net->name.c_str(ctx));
             }
         }

--- a/fpga_interchange/dedicated_interconnect.cc
+++ b/fpga_interchange/dedicated_interconnect.cc
@@ -425,6 +425,10 @@ bool DedicatedInterconnect::isBelLocationValid(BelId bel, const CellInfo *cell) 
             continue;
         }
 
+        if (ctx->io_port_types.count(net->driver.cell->type)) {
+            continue;
+        }
+
         // Only check sink BELs.
         if (net->driver.cell == cell && net->driver.port == port_name) {
             if (!is_driver_on_net_valid(bel, cell, port_name, net)) {
@@ -453,6 +457,10 @@ void DedicatedInterconnect::explain_bel_status(BelId bel, const CellInfo *cell) 
 
         // This net doesn't have a driver, probably not valid?
         NPNR_ASSERT(net->driver.cell != nullptr);
+
+        if (ctx->io_port_types.count(net->driver.cell->type)) {
+            continue;
+        }
 
         // Only check sink BELs.
         if (net->driver.cell == cell && net->driver.port == port_name) {


### PR DESCRIPTION
This currently includes the following changes, enough to place the `DIFFINBUF` and `IBUFCTRL`

 - falling back to all site types (and later on the default site type) when none match, needed because the `DIFFINBUF` is in a different site to the pad
 - removing the search for 'special' intent wires only, as this doesn't apply to UltraScale+ and the iteration limit in the BFS search prevents a significant amount of general interconnect being searched in any case
 - fixing the update of placed cells.
 - skipping IO port pads in the dedicated interconnect check, as these are somewhat special with bidirectional wires and dealt with in `arch_pack_io`.