### PR TITLE
interchange: add user placement constraints handling

### DIFF
--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -402,13 +402,6 @@ class HeAPPlacer
         for (auto &cell_entry : ctx->cells) {
             CellInfo *cell = cell_entry.second.get();
 
-            if (cell->bel != BelId()) {
-                if (ctx->verbose)
-                    log_error("Cell \'%s\' (%s) has already been constrianed by arch implementation",
-                              cell->name.c_str(ctx), cell->type.c_str(ctx));
-                continue;
-            }
-
             auto loc = cell->attrs.find(ctx->id("BEL"));
             if (loc != cell->attrs.end()) {
                 std::string loc_name = loc->second.as_string();

--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -401,6 +401,14 @@ class HeAPPlacer
         // Initial constraints placer
         for (auto &cell_entry : ctx->cells) {
             CellInfo *cell = cell_entry.second.get();
+
+            if (cell->bel != BelId()) {
+                if (ctx->verbose)
+                    log_error("Cell \'%s\' (%s) has already been constrianed by arch implementation",
+                              cell->name.c_str(ctx), cell->type.c_str(ctx));
+                continue;
+            }
+
             auto loc = cell->attrs.find(ctx->id("BEL"));
             if (loc != cell->attrs.end()) {
                 std::string loc_name = loc->second.as_string();

--- a/fpga_interchange/arch.cc
+++ b/fpga_interchange/arch.cc
@@ -787,6 +787,7 @@ bool Arch::place()
     getCtx()->check();
 #endif
 
+    place_constraints();
     place_globals();
 
     std::string placer = str_or_default(settings, id("placer"), defaultPlacer);

--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -720,6 +720,9 @@ struct Arch : ArchAPI<ArchRanges>
     void prepare_cluster(const ClusterPOD *cluster, uint32_t index);
     dict<ClusterId, Cluster> clusters;
 
+    // User constraints
+    void place_constraints();
+
     void decode_lut_cells();
 
     const GlobalCellPOD *global_cell_info(IdString cell_type) const;

--- a/fpga_interchange/arch_place_constr.cc
+++ b/fpga_interchange/arch_place_constr.cc
@@ -1,0 +1,102 @@
+/*
+ *  nextpnr -- Next Generation Place and Route
+ *
+ *  Copyright (C) 2021  Symbiflow Authors
+ *
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "log.h"
+#include "nextpnr.h"
+#include "util.h"
+
+NEXTPNR_NAMESPACE_BEGIN
+
+void Arch::place_constraints()
+{
+    std::vector<std::pair<IdString, BelId>> constrained_cells;
+    for (auto &cell_pair : cells) {
+        CellInfo *cell = cell_pair.second.get();
+        auto loc_constr = cell->attrs.find(id("LOC"));
+        auto bel_constr = cell->attrs.find(id("BEL"));
+
+        if (loc_constr == cell->attrs.end() || bel_constr == cell->attrs.end())
+            continue;
+
+        IdString loc_name = id(loc_constr->second.as_string());
+        IdString bel_name = id(bel_constr->second.as_string());
+
+        BelId bel;
+        for (size_t i = 0; i < chip_info->tiles.size(); ++i) {
+            const auto &tile = chip_info->tiles[i];
+            bool site_found = false;
+            for (size_t j = 0; j < tile.sites.size(); ++j) {
+                auto &site_data = chip_info->sites[tile.sites[j]];
+                if (loc_name == id(site_data.site_name.get())) {
+                    site_found = true;
+                    break;
+                }
+            }
+
+            if (!site_found)
+                continue;
+
+            const auto &tile_type = chip_info->tile_types[tile.type];
+            bool bel_found = false;
+            for (size_t j = 0; j < tile_type.bel_data.size(); ++j) {
+                const BelInfoPOD &bel_data = tile_type.bel_data[j];
+                if (bel_name == IdString(bel_data.name)) {
+                    bel.tile = i;
+                    bel.index = j;
+                    bel_found = true;
+                    break;
+                }
+            }
+
+            if (bel_found)
+                break;
+            else
+                log_error("No bel found for user constraint \'%s/%s\' for cell \'%s\'\n", loc_name.c_str(getCtx()),
+                          bel_name.c_str(getCtx()), cell->name.c_str(getCtx()));
+        }
+
+        if (!isValidBelForCellType(cell->type, bel))
+            log_error("Bel \'%s\' is invalid for cell \'%s\' (%s)\n", nameOfBel(bel), cell->name.c_str(getCtx()),
+                      cell->type.c_str(getCtx()));
+
+        auto bound_cell = getBoundBelCell(bel);
+        if (bound_cell)
+            log_error("Cell \'%s\' cannot be bound to bel \'%s\' "
+                      "since it is already bound to cell \'%s\'\n",
+                      cell->name.c_str(getCtx()), nameOfBel(bel), bound_cell->name.c_str(getCtx()));
+
+        bindBel(bel, cell, STRENGTH_USER);
+        if (!isBelLocationValid(bel))
+            log_error("Bel \'%s\' is not valid for cell "
+                      "\'%s\' of type \'%s\'\n",
+                      nameOfBel(bel), cell->name.c_str(getCtx()), cell->type.c_str(getCtx()));
+
+        constrained_cells.emplace_back(cell->name, bel);
+    }
+
+    if (constrained_cells.empty())
+        return;
+
+    log_info("Cell placed via user constraints:\n");
+    for (auto cell_bel : constrained_cells)
+        log_info("  - %s placed at %s\n", cell_bel.first.c_str(getCtx()), nameOfBel(cell_bel.second));
+}
+
+NEXTPNR_NAMESPACE_END

--- a/fpga_interchange/arch_place_constr.cc
+++ b/fpga_interchange/arch_place_constr.cc
@@ -83,11 +83,8 @@ void Arch::place_constraints()
                       cell->name.c_str(getCtx()), nameOfBel(bel), bound_cell->name.c_str(getCtx()));
 
         bindBel(bel, cell, STRENGTH_USER);
-        if (!isBelLocationValid(bel))
-            log_error("Bel \'%s\' is not valid for cell "
-                      "\'%s\' of type \'%s\'\n",
-                      nameOfBel(bel), cell->name.c_str(getCtx()), cell->type.c_str(getCtx()));
 
+        cell->attrs.erase(id("BEL"));
         constrained_cells.emplace_back(cell->name, bel);
     }
 
@@ -95,8 +92,15 @@ void Arch::place_constraints()
         return;
 
     log_info("Cell placed via user constraints:\n");
-    for (auto cell_bel : constrained_cells)
-        log_info("  - %s placed at %s\n", cell_bel.first.c_str(getCtx()), nameOfBel(cell_bel.second));
+    for (auto cell_bel : constrained_cells) {
+        IdString cell_name = cell_bel.first;
+        BelId bel = cell_bel.second;
+
+        if (!isBelLocationValid(bel))
+            log_error("  - Bel \'%s\' is not valid for cell \'%s\'\n", nameOfBel(bel), cell_name.c_str(getCtx()));
+
+        log_info("  - %s placed at %s\n", cell_name.c_str(getCtx()), nameOfBel(cell_bel.second));
+    }
 }
 
 NEXTPNR_NAMESPACE_END

--- a/fpga_interchange/xdc.cc
+++ b/fpga_interchange/xdc.cc
@@ -130,15 +130,8 @@ static int get_cells(ClientData data, Tcl_Interp *interp, int objc, Tcl_Obj *CON
         const char *arg0 = Tcl_GetString(objv[1]);
         IdString cell_name = ctx->id(arg0);
 
-        CellInfo *cell = nullptr;
-        for (auto &cell_pair : ctx->cells) {
-            if (cell_pair.second.get()->name == cell_name) {
-                cell = cell_pair.second.get();
-                break;
-            }
-        }
-
-        if (cell == nullptr) {
+        auto iter = ctx->cells.find(cell_name);
+        if (iter == ctx->cells.end()) {
             Tcl_SetStringResult(interp, "Could not find cell " + cell_name.str(ctx));
             return TCL_ERROR;
         }
@@ -146,7 +139,7 @@ static int get_cells(ClientData data, Tcl_Interp *interp, int objc, Tcl_Obj *CON
         Tcl_Obj *result = Tcl_NewObj();
         result->typePtr = &cell_object;
         result->internalRep.twoPtrValue.ptr1 = (void *)(ctx);
-        result->internalRep.twoPtrValue.ptr2 = (void *)(cell);
+        result->internalRep.twoPtrValue.ptr2 = (void *)(iter->second.get());
 
         result->bytes = nullptr;
         cell_update_string(result);


### PR DESCRIPTION
This PR enables to LOC cells on BELs both from:
- attributes: `(* LOC="<site>", BEL="<bel>" *)`
- xdc: 
  - `set_property LOC <site> [get_cells <cell>]`
  - `set_property BEL <bel> [get_cells <cell>]`

Constraining a cell works only if both the LOC and BEL attributes are provided.