### PR TITLE
[WIP] interchange: add routing delay model

### DIFF
--- a/.github/workflows/interchange_ci.yml
+++ b/.github/workflows/interchange_ci.yml
@@ -115,7 +115,7 @@ jobs:
         RAPIDWRIGHT_PATH: ${{ github.workspace }}/RapidWright
         PYTHON_INTERCHANGE_PATH: ${{ github.workspace }}/python-fpga-interchange
         PYTHON_INTERCHANGE_TAG: v0.0.17
-        PRJOXIDE_REVISION: 1bf30dee9c023c4c66cfc44fd0bc28addd229c89
+        PRJOXIDE_REVISION: 9b35cdb7640dd9916f39268a548fb0c15e9355d1
         DEVICE: ${{ matrix.device }}
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"

--- a/fpga_interchange/arch.cc
+++ b/fpga_interchange/arch.cc
@@ -2046,9 +2046,12 @@ void Arch::explain_bel_status(BelId bel) const
 
 static const NodeTimingPOD *get_node_timing(const Arch *arch, WireId wire)
 {
-    if (wire.tile != -1)
-        return nullptr;
-    int tmg_index = arch->chip_info->nodes[wire.index].timing_idx;
+    int tmg_index;
+    if (wire.tile != -1) {
+        tmg_index = loc_info(arch->chip_info, wire).wire_data[wire.index].timing_idx;
+    } else {
+        tmg_index = arch->chip_info->nodes[wire.index].timing_idx;
+    }
     if (tmg_index >= 0 && tmg_index < arch->chip_info->node_timings.ssize())
         return &(arch->chip_info->node_timings[tmg_index]);
     else

--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -1159,6 +1159,10 @@ struct Arch : ArchAPI<ArchRanges>
 
     dict<IdString, std::vector<CellInfo *>> macro_to_cells;
     void expand_macros();
+
+    // Load capacitance and drive resistance for nodes
+    dict<WireId, uint64_t> drive_res;
+    dict<WireId, uint64_t> load_cap;
 };
 
 NEXTPNR_NAMESPACE_END

--- a/fpga_interchange/chipdb.h
+++ b/fpga_interchange/chipdb.h
@@ -111,6 +111,8 @@ NPNR_PACKED_STRUCT(struct TileWireInfoPOD {
 
     int16_t site;         // site index in tile
     int16_t site_variant; // site variant index in tile
+
+    int32_t timing_idx;
 });
 
 NPNR_PACKED_STRUCT(struct PipInfoPOD {


### PR DESCRIPTION
This adds a simplified RC model for routing delays in the interchange arch, with no cell or site pip delays currently. See https://github.com/SymbiFlow/python-fpga-interchange/pull/111