### PR TITLE
Remove python path from gowin target

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@ Nexus support is currently experimental, and has only been tested with engineeri
 
 ### nextpnr-gowin
 
-For Gowin support, install [Project Apicula](https://github.com/YosysHQ/apicula). If a virtualenv is used, the python paths need to be provided as follows:
+For Gowin support, install [Project Apicula](https://github.com/YosysHQ/apicula). If a virtualenv is used, the path to `gowin_bba` needs to be provided as follows:
 
 ```
-cmake . -DARCH=gowin -DPYTHON_EXECUTABLE=path -DGOWIN_BBA_EXECUTABLE=path
+cmake . -DARCH=gowin -DGOWIN_BBA_EXECUTABLE=path
 make -j$(nproc)
 sudo make install
 ```

--- a/gowin/CMakeLists.txt
+++ b/gowin/CMakeLists.txt
@@ -12,8 +12,6 @@ message(STATUS "gowin_bba executable: ${GOWIN_BBA_EXECUTABLE}")
 if(DEFINED GOWIN_CHIPDB)
     add_custom_target(chipdb-gowin-bbas ALL)
 else()
-    find_package(PythonInterp 3.6 REQUIRED)
-
     # shared among all families
     set(SERIALIZE_CHIPDBS TRUE CACHE BOOL
         "Serialize device data preprocessing to minimize memory use")


### PR DESCRIPTION
As far as I can tell this was only used while gradually porting from the generic target.