### PR TITLE
gui: Improve Fatal Error message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,11 @@ if (BUILD_GUI AND NOT BUILD_PYTHON)
     message(FATAL_ERROR "GUI requires Python to build")
 endif()
 
+if (BUILD_GUI)
+    # For higher quality backtraces
+    set(CMAKE_ENABLE_EXPORTS ON)
+endif()
+
 find_package(PythonInterp 3.5 REQUIRED)
 if (BUILD_PYTHON)
     # TODO: sensible minimum Python version


### PR DESCRIPTION
Due to issues around static symbols, this is quite likely to produce a backtrace that only contains addresses. But at least this can be manually run through `addr2line` to get a more useful backtrace, it's better than nothing.

Backtraces are also currently implemented only on Linux only, because I don't have a Windows setup readily available.

cc @lethalbit 