### PR TITLE
Fix definition of an empty IdStringList

### DIFF
--- a/common/idstringlist.h
+++ b/common/idstringlist.h
@@ -35,7 +35,7 @@ struct IdStringList
 {
     SSOArray<IdString, 4> ids;
 
-    IdStringList(){};
+    IdStringList() : ids(1, IdString()){};
     explicit IdStringList(size_t n) : ids(n, IdString()){};
     explicit IdStringList(IdString id) : ids(1, id){};
     template <typename Tlist> explicit IdStringList(const Tlist &list) : ids(list){};


### PR DESCRIPTION
This defines an empty `IdStringList` as being of size 1 containing an empty `IdString`, consistent with other uses of `IdStringList`. It should hopefully fix an occasional crash when clicking around in the GUI.