### PR TITLE
interchange: Don't attempt to import instances as modules

### DIFF
--- a/fpga_interchange/fpga_interchange.cpp
+++ b/fpga_interchange/fpga_interchange.cpp
@@ -808,11 +808,6 @@ struct LogicalNetlistImpl
 
     template <typename TFunc> void foreach_module(TFunc Func) const
     {
-        for (const auto &cell_inst : root.getInstList()) {
-            ModuleReader module(this, cell_inst, /*is_top=*/false);
-            Func(strings.at(cell_inst.getName()), module);
-        }
-
         auto top = root.getTopInst();
         ModuleReader top_module(this, top, /*is_top=*/true);
         Func(strings.at(top.getName()), top_module);


### PR DESCRIPTION
This was a harmless bug when cell names and types are always different, until you end up with an instance named after its type as LiteX tends to generate. This then means the cell name has been accidentally imported as an empty module, and then any instances of that type are replaced by nothing instead of becoming a leaf cell instance.