### PR TITLE
interchange: place only cells belonging to the same clusters in the same site

### DIFF
--- a/.github/workflows/interchange_ci.yml
+++ b/.github/workflows/interchange_ci.yml
@@ -114,7 +114,7 @@ jobs:
       env:
         RAPIDWRIGHT_PATH: ${{ github.workspace }}/RapidWright
         PYTHON_INTERCHANGE_PATH: ${{ github.workspace }}/python-fpga-interchange
-        PYTHON_INTERCHANGE_TAG: v0.0.17
+        PYTHON_INTERCHANGE_TAG: v0.0.18
         PRJOXIDE_REVISION: 1bf30dee9c023c4c66cfc44fd0bc28addd229c89
         DEVICE: ${{ matrix.device }}
       run: |

--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -878,16 +878,11 @@ struct Arch : ArchAPI<ArchRanges>
             }
 
             for (auto ci : site_status.cells_in_site) {
-                if (ci->cluster != ClusterId() && cell->cluster != ClusterId())
-                    continue;
-                else if (ci->cluster == cell->cluster)
-                    continue;
-
-                if (ci->cluster != ClusterId() &&
+                if (ci->cluster != ClusterId() && ci->cluster != cell->cluster &&
                     cluster_info(chip_info, clusters.at(ci->cluster).index).disallow_other_cells)
                     return false;
 
-                if (cell->cluster != ClusterId() &&
+                if (cell->cluster != ClusterId() && ci->cluster != cell->cluster &&
                     cluster_info(chip_info, clusters.at(cell->cluster).index).disallow_other_cells)
                     return false;
             }

--- a/fpga_interchange/chipdb.h
+++ b/fpga_interchange/chipdb.h
@@ -34,7 +34,7 @@ NEXTPNR_NAMESPACE_BEGIN
  * kExpectedChipInfoVersion
  */
 
-static constexpr int32_t kExpectedChipInfoVersion = 13;
+static constexpr int32_t kExpectedChipInfoVersion = 14;
 
 // Flattened site indexing.
 //
@@ -422,6 +422,7 @@ NPNR_PACKED_STRUCT(struct ClusterPOD {
     RelSlice<ChainablePortPOD> chainable_ports;
     RelSlice<ClusterCellPortPOD> cluster_cells_map;
     uint32_t out_of_site_clusters;
+    uint32_t disallow_other_cells;
 });
 
 NPNR_PACKED_STRUCT(struct ChipInfoPOD {


### PR DESCRIPTION
This PR is to improve placement run-time, sacrificing placement density.

It appears in fact that quite some time is still spent when finding routing solutions within a site, and, with the presence of clusters (and specifically carry-chains), congestion within the sites has increased.

Clusters have a flag to indicate whether they are to be the only ones occupying a site.

Note: the site routing cache clear step is not required for this patch to work, but the problem I saw was that, in some runs when trying to place and route a LiteX design, the site router is not able to find a solution after clearing the cache. This seems quite odd, but I still need to investigate why the failure is happening.