### PR TITLE
gowin: Add support for IOBUF and TBUF I/O modes. Change the constraint parser.

### DIFF
--- a/gowin/pack.cc
+++ b/gowin/pack.cc
@@ -229,8 +229,10 @@ static void pack_io(Context *ctx)
                 iob = net_only_drives(ctx, ci->ports.at(id_O).net, is_nextpnr_iob, id_I);
                 break;
             case ID_IOBUF:
+                iob = net_driven_by(ctx, ci->ports.at(id_IO).net, is_nextpnr_iob, id_O);
+                break;
             case ID_TBUF:
-                log_error("untested tristate stuff");
+                iob = net_only_drives(ctx, ci->ports.at(id_O).net, is_nextpnr_iob, id_I);
                 break;
             default:
                 break;


### PR DESCRIPTION
Compatible with the current version of Apycula on constraints, of course the tri-state primitives will not be packed (yet), but in this case there is a message in gowin_pack about unsupported modes.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>