### PR TITLE
pybindings: Fix mapping for PortRefVector

### DIFF
--- a/common/pybindings.cc
+++ b/common/pybindings.cc
@@ -285,6 +285,8 @@ PYBIND11_EMBEDDED_MODULE(MODULE_NAME, m)
     WRAP_MAP(m, WireMap, wrap_context<PipMap &>, "WireMap");
     WRAP_MAP_UPTR(m, RegionMap, "RegionMap");
 
+    WRAP_VECTOR(m, PortRefVector, wrap_context<PortRef &>);
+
     typedef dict<IdString, ClockFmax> ClockFmaxMap;
     WRAP_MAP(m, ClockFmaxMap, pass_through<ClockFmax>, "ClockFmaxMap");
 


### PR DESCRIPTION
This is used by net.users for instance.

Removed by mistake in 4ac00af6fadc0405867fdac84229d2cda390c108

Fixes #799

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>