### PR TITLE
gowin: Add constraints on primitive placement.

### DIFF
--- a/gowin/arch.h
+++ b/gowin/arch.h
@@ -446,6 +446,9 @@ struct Arch : BaseArch<ArchRanges>
     bool cellsCompatible(const CellInfo **cells, int count) const;
 
     std::vector<IdString> cell_types;
+
+    // Permissible combinations of modes in a single slice
+    std::map<const IdString, IdString> dff_comp_mode;
 };
 
 NEXTPNR_NAMESPACE_END

--- a/gowin/pack.cc
+++ b/gowin/pack.cc
@@ -253,9 +253,19 @@ static void pack_io(Context *ctx)
             auto gwiob = new_cells.back().get();
 
             packed_cells.insert(ci->name);
-            if (iob != nullptr)
-                for (auto &attr : iob->attrs)
-                    gwiob->attrs[attr.first] = attr.second;
+            if (iob != nullptr) {
+                // in Gowin .CST port attributes take precedence over cell attributes.
+                // first copy cell attrs related to IO
+                for (auto &attr : ci->attrs) {
+                    if (attr.first == IdString(ID_BEL) || attr.first.str(ctx)[0] == '&') {
+                        gwiob->setAttr(attr.first, attr.second);
+                    }
+                }
+                // rewrite attributes from the port
+                for (auto &attr : iob->attrs) {
+                    gwiob->setAttr(attr.first, attr.second);
+                }
+            }
         }
     }
     for (auto pcell : packed_cells) {

--- a/mistral/bitstream.cc
+++ b/mistral/bitstream.cc
@@ -329,9 +329,9 @@ struct MistralBitgen
         }
         for (int i = 0; i < 3; i++) {
             // Check for fabric->clock routing
-            if (ctx->wires_connected(ctx->get_port(block_type, CycloneV::pos2x(pos), CycloneV::pos2y(pos), -1,
-                                                   CycloneV::DATAIN, 0),
-                                     lab_data.clk_wires[i]))
+            if (ctx->wires_connected(
+                        ctx->get_port(block_type, CycloneV::pos2x(pos), CycloneV::pos2y(pos), -1, CycloneV::DATAIN, 0),
+                        lab_data.clk_wires[i]))
                 cv->bmux_m_set(block_type, pos, CycloneV::CLKA_SEL, 0, CycloneV::GIN2);
         }
     }


### PR DESCRIPTION
Added support for the INS_LOC instruction in the constraints file
(.CST), which is used to specify object placement.
Expanded treatment of IO_LOC/IO_PORT constraints, which now can
be applied to both ports and IO buffers.
Port constraints have priority.

Also allow the registers of the same type or pairs shown below to be
placed in the same slide:

```
    |--------|--------|
    | DFFS   | DFFR   |
    | DFFSE  | DFFRE  |
    | DFFP   | DFFC   |
    | DFFPE  | DFFCE  |
    | DFFNS  | DFFNR  |
    | DFFNSE | DFFNRE |
    | DFFNP  | DFFNC  |
    | DFFNPE | DFFNCE |
```
Signed-off-by: YRabbit <rabbit@yrabbit.cyou>