### PR TITLE
Timing report in JSON format

### DIFF
--- a/common/command.cc
+++ b/common/command.cc
@@ -183,6 +183,9 @@ po::options_description CommandHandler::getGeneralOptions()
     general.add_options()("placed-svg", po::value<std::string>(), "write render of placement to SVG file");
     general.add_options()("routed-svg", po::value<std::string>(), "write render of routing to SVG file");
 
+    general.add_options()("timing-report", po::value<std::string>(),
+                          "write timing analysis report in CSV format to file");
+
     return general;
 }
 
@@ -247,6 +250,11 @@ void CommandHandler::setupContext(Context *ctx)
 
     if (vm.count("timing-allow-fail")) {
         ctx->settings[ctx->id("timing/allowFail")] = true;
+    }
+
+    if (vm.count("timing-report")) {
+        std::string filename = vm["timing-report"].as<std::string>();
+        ctx->settings[ctx->id("timing/reportFile")] = filename;
     }
 
     if (vm.count("placer")) {

--- a/common/command.cc
+++ b/common/command.cc
@@ -183,9 +183,6 @@ po::options_description CommandHandler::getGeneralOptions()
     general.add_options()("placed-svg", po::value<std::string>(), "write render of placement to SVG file");
     general.add_options()("routed-svg", po::value<std::string>(), "write render of routing to SVG file");
 
-    general.add_options()("timing-report", po::value<std::string>(),
-                          "write timing analysis report in CSV format to file");
-
     return general;
 }
 
@@ -250,11 +247,6 @@ void CommandHandler::setupContext(Context *ctx)
 
     if (vm.count("timing-allow-fail")) {
         ctx->settings[ctx->id("timing/allowFail")] = true;
-    }
-
-    if (vm.count("timing-report")) {
-        std::string filename = vm["timing-report"].as<std::string>();
-        ctx->settings[ctx->id("timing/reportFile")] = filename;
     }
 
     if (vm.count("placer")) {

--- a/common/command.cc
+++ b/common/command.cc
@@ -179,6 +179,8 @@ po::options_description CommandHandler::getGeneralOptions()
 
     general.add_options()("report", po::value<std::string>(),
                           "write timing and utilization report in JSON format to file");
+    general.add_options()("detailed-timing-report",
+                          "Append detailed net timing data to the JSON report");
 
     general.add_options()("placed-svg", po::value<std::string>(), "write render of placement to SVG file");
     general.add_options()("routed-svg", po::value<std::string>(), "write render of routing to SVG file");
@@ -328,6 +330,10 @@ void CommandHandler::setupContext(Context *ctx)
         ctx->settings[ctx->id("placerHeap/criticalityExponent")] = std::to_string(2);
     if (ctx->settings.find(ctx->id("placerHeap/timingWeight")) == ctx->settings.end())
         ctx->settings[ctx->id("placerHeap/timingWeight")] = std::to_string(10);
+
+    if (vm.count("detailed-timing-report")) {
+        ctx->detailed_timing_report = true;
+    }
 }
 
 int CommandHandler::executeMain(std::unique_ptr<Context> ctx)

--- a/common/command.cc
+++ b/common/command.cc
@@ -179,8 +179,7 @@ po::options_description CommandHandler::getGeneralOptions()
 
     general.add_options()("report", po::value<std::string>(),
                           "write timing and utilization report in JSON format to file");
-    general.add_options()("detailed-timing-report",
-                          "Append detailed net timing data to the JSON report");
+    general.add_options()("detailed-timing-report", "Append detailed net timing data to the JSON report");
 
     general.add_options()("placed-svg", po::value<std::string>(), "write render of placement to SVG file");
     general.add_options()("routed-svg", po::value<std::string>(), "write render of routing to SVG file");

--- a/common/context.h
+++ b/common/context.h
@@ -36,6 +36,8 @@ struct Context : Arch, DeterministicRNG
 
     // Should we disable printing of the location of nets in the critical path?
     bool disable_critical_path_source_print = false;
+    // True when detailed per-net timing is to be stored / reported
+    bool detailed_timing_report = false;
 
     ArchArgs arch_args;
 

--- a/common/nextpnr_types.h
+++ b/common/nextpnr_types.h
@@ -242,15 +242,17 @@ struct ClockPair
 
 struct CriticalPath
 {
-    struct Segment {
+    struct Segment
+    {
 
         // Segment type
-        enum class Type {
-            CLK_TO_Q,   // Clock-to-Q delay
-            SOURCE,     // Delayless source
-            LOGIC,      // Combinational logic delay
-            ROUTING,    // Routing delay
-            SETUP       // Setup time in sink
+        enum class Type
+        {
+            CLK_TO_Q, // Clock-to-Q delay
+            SOURCE,   // Delayless source
+            LOGIC,    // Combinational logic delay
+            ROUTING,  // Routing delay
+            SETUP     // Setup time in sink
         };
 
         // Type

--- a/common/nextpnr_types.h
+++ b/common/nextpnr_types.h
@@ -246,8 +246,11 @@ struct CriticalPath
 
         // Segment type
         enum class Type {
-            LOGIC,
-            ROUTING
+            CLK_TO_Q,   // Clock-to-Q delay
+            SOURCE,     // Delayless source
+            LOGIC,      // Combinational logic delay
+            ROUTING,    // Routing delay
+            SETUP       // Setup time in sink
         };
 
         // Type

--- a/common/report.cc
+++ b/common/report.cc
@@ -41,60 +41,53 @@ dict<IdString, std::pair<int, int>> get_utilization(const Context *ctx)
 }
 } // namespace
 
-static std::string clock_event_name (const Context* ctx, const ClockEvent& e) {
+static std::string clock_event_name(const Context *ctx, const ClockEvent &e)
+{
     std::string value;
     if (e.clock == ctx->id("$async$"))
         value = std::string("<async>");
     else
-        value = (e.edge == FALLING_EDGE ? std::string("negedge ") :
-                                          std::string("posedge ")) + e.clock.str(ctx);
+        value = (e.edge == FALLING_EDGE ? std::string("negedge ") : std::string("posedge ")) + e.clock.str(ctx);
     return value;
 };
 
-static Json::array report_critical_paths (const Context* ctx) {
+static Json::array report_critical_paths(const Context *ctx)
+{
 
-    auto report_critical_path = [ctx](const CriticalPath& report) {
+    auto report_critical_path = [ctx](const CriticalPath &report) {
         Json::array pathJson;
 
-        for (const auto& segment : report.segments) {
+        for (const auto &segment : report.segments) {
 
-            const auto& driver = ctx->cells.at(segment.from.first);
-            const auto& sink = ctx->cells.at(segment.to.first);
+            const auto &driver = ctx->cells.at(segment.from.first);
+            const auto &sink = ctx->cells.at(segment.to.first);
 
             auto fromLoc = ctx->getBelLocation(driver->bel);
             auto toLoc = ctx->getBelLocation(sink->bel);
 
-            auto fromJson = Json::object({
-                {"cell", segment.from.first.c_str(ctx)},
-                {"port", segment.from.second.c_str(ctx)},
-                {"loc", Json::array({fromLoc.x, fromLoc.y})}
-            });
+            auto fromJson = Json::object({{"cell", segment.from.first.c_str(ctx)},
+                                          {"port", segment.from.second.c_str(ctx)},
+                                          {"loc", Json::array({fromLoc.x, fromLoc.y})}});
 
-            auto toJson = Json::object({
-                {"cell", segment.to.first.c_str(ctx)},
-                {"port", segment.to.second.c_str(ctx)},
-                {"loc", Json::array({toLoc.x, toLoc.y})}
-            });
+            auto toJson = Json::object({{"cell", segment.to.first.c_str(ctx)},
+                                        {"port", segment.to.second.c_str(ctx)},
+                                        {"loc", Json::array({toLoc.x, toLoc.y})}});
 
             auto segmentJson = Json::object({
-                {"delay", ctx->getDelayNS(segment.delay)},
-                {"from", fromJson},
-                {"to", toJson},
+                    {"delay", ctx->getDelayNS(segment.delay)},
+                    {"from", fromJson},
+                    {"to", toJson},
             });
 
             if (segment.type == CriticalPath::Segment::Type::CLK_TO_Q) {
                 segmentJson["type"] = "clk-to-q";
-            }
-            else if (segment.type == CriticalPath::Segment::Type::SOURCE) {
+            } else if (segment.type == CriticalPath::Segment::Type::SOURCE) {
                 segmentJson["type"] = "source";
-            }
-            else if (segment.type == CriticalPath::Segment::Type::LOGIC) {
+            } else if (segment.type == CriticalPath::Segment::Type::LOGIC) {
                 segmentJson["type"] = "logic";
-            }
-            else if (segment.type == CriticalPath::Segment::Type::SETUP) {
+            } else if (segment.type == CriticalPath::Segment::Type::SETUP) {
                 segmentJson["type"] = "setup";
-            }
-            else if (segment.type == CriticalPath::Segment::Type::ROUTING) {
+            } else if (segment.type == CriticalPath::Segment::Type::ROUTING) {
                 segmentJson["type"] = "routing";
                 segmentJson["net"] = segment.net.c_str(ctx);
                 segmentJson["budget"] = ctx->getDelayNS(segment.budget);
@@ -111,58 +104,51 @@ static Json::array report_critical_paths (const Context* ctx) {
     // Critical paths
     for (auto &report : ctx->timing_result.clock_paths) {
 
-        critPathsJson.push_back(Json::object({
-            {"from", clock_event_name(ctx, report.second.clock_pair.start)},
-            {"to", clock_event_name(ctx, report.second.clock_pair.end)},
-            {"path", report_critical_path(report.second)}
-        }));
+        critPathsJson.push_back(Json::object({{"from", clock_event_name(ctx, report.second.clock_pair.start)},
+                                              {"to", clock_event_name(ctx, report.second.clock_pair.end)},
+                                              {"path", report_critical_path(report.second)}}));
     }
 
     // Cross-domain paths
     for (auto &report : ctx->timing_result.xclock_paths) {
-        critPathsJson.push_back(Json::object({
-            {"from", clock_event_name(ctx, report.clock_pair.start)},
-            {"to", clock_event_name(ctx, report.clock_pair.end)},
-            {"path", report_critical_path(report)}
-        }));
+        critPathsJson.push_back(Json::object({{"from", clock_event_name(ctx, report.clock_pair.start)},
+                                              {"to", clock_event_name(ctx, report.clock_pair.end)},
+                                              {"path", report_critical_path(report)}}));
     }
 
     return critPathsJson;
 }
 
-static Json::array report_detailed_net_timings (const Context* ctx) {
+static Json::array report_detailed_net_timings(const Context *ctx)
+{
     auto detailedNetTimingsJson = Json::array();
 
     // Detailed per-net timing analysis
-    for (const auto& it : ctx->timing_result.detailed_net_timings) {
+    for (const auto &it : ctx->timing_result.detailed_net_timings) {
 
-        const NetInfo* net = ctx->nets.at(it.first).get();
+        const NetInfo *net = ctx->nets.at(it.first).get();
         ClockEvent start = it.second[0].clock_pair.start;
 
         Json::array endpointsJson;
-        for (const auto& sink_timing : it.second) {
+        for (const auto &sink_timing : it.second) {
 
             // FIXME: Is it possible that there are multiple different start
             // events for a single net? It has a single driver
             NPNR_ASSERT(sink_timing.clock_pair.start == start);
 
-            auto endpointJson = Json::object({
-                {"cell", sink_timing.cell_port.first.c_str(ctx)},
-                {"port", sink_timing.cell_port.second.c_str(ctx)},
-                {"event", clock_event_name(ctx, sink_timing.clock_pair.end)},
-                {"delay", ctx->getDelayNS(sink_timing.delay)},
-                {"budget", ctx->getDelayNS(sink_timing.budget)}
-            });
+            auto endpointJson = Json::object({{"cell", sink_timing.cell_port.first.c_str(ctx)},
+                                              {"port", sink_timing.cell_port.second.c_str(ctx)},
+                                              {"event", clock_event_name(ctx, sink_timing.clock_pair.end)},
+                                              {"delay", ctx->getDelayNS(sink_timing.delay)},
+                                              {"budget", ctx->getDelayNS(sink_timing.budget)}});
             endpointsJson.push_back(endpointJson);
         }
 
-        auto netTimingJson = Json::object({
-            {"net", net->name.c_str(ctx)},
-            {"driver", net->driver.cell->name.c_str(ctx)},
-            {"port", net->driver.port.c_str(ctx)},
-            {"event", clock_event_name(ctx, start)},
-            {"endpoints", endpointsJson}
-        });
+        auto netTimingJson = Json::object({{"net", net->name.c_str(ctx)},
+                                           {"driver", net->driver.cell->name.c_str(ctx)},
+                                           {"port", net->driver.port.c_str(ctx)},
+                                           {"event", clock_event_name(ctx, start)},
+                                           {"endpoints", endpointsJson}});
 
         detailedNetTimingsJson.push_back(netTimingJson);
     }
@@ -261,10 +247,7 @@ void Context::writeReport(std::ostream &out) const
     }
 
     Json::object jsonRoot{
-        {"utilization", util_json},
-        {"fmax", fmax_json},
-        {"critical_paths", report_critical_paths(this)}
-    };
+            {"utilization", util_json}, {"fmax", fmax_json}, {"critical_paths", report_critical_paths(this)}};
 
     if (detailed_timing_report) {
         jsonRoot["detailed_net_timings"] = report_detailed_net_timings(this);

--- a/common/report.cc
+++ b/common/report.cc
@@ -250,14 +250,18 @@ void Context::writeReport(std::ostream &out) const
                 {"constraint", kv.second.constraint},
         };
     }
-    out << Json(Json::object{
-                        {"utilization", util_json},
-                        {"fmax", fmax_json},
-                        {"critical_paths", report_critical_paths(this)},
-                        {"detailed_net_timings", report_detailed_net_timings(this)}
-                })
-                    .dump()
-        << std::endl;
+
+    Json::object jsonRoot{
+        {"utilization", util_json},
+        {"fmax", fmax_json},
+        {"critical_paths", report_critical_paths(this)}
+    };
+
+    if (detailed_timing_report) {
+        jsonRoot["detailed_net_timings"] = report_detailed_net_timings(this);
+    }
+
+    out << Json(jsonRoot).dump() << std::endl;
 }
 
 NEXTPNR_NAMESPACE_END

--- a/common/report.cc
+++ b/common/report.cc
@@ -101,7 +101,7 @@ static Json::array report_critical_paths (const Context* ctx) {
 
     // Critical paths
     for (auto &report : ctx->timing_result.clock_paths) {
-        
+
         critPathsJson.push_back(Json::object({
             {"from", clock_event_name(ctx, report.second.clock_pair.start)},
             {"to", clock_event_name(ctx, report.second.clock_pair.end)},
@@ -160,6 +160,78 @@ static Json::array report_detailed_net_timings (const Context* ctx) {
 
     return detailedNetTimingsJson;
 }
+
+/*
+Report JSON structure:
+
+{
+  "utilization": {
+    <BEL name>: {
+      "available": <available count>,
+      "used": <used count>
+    },
+    ...
+  },
+  "fmax" {
+    <clock name>: {
+      "achieved": <achieved fmax [MHz]>,
+      "constraint": <target fmax [MHz]>
+    },
+    ...
+  },
+  "critical_paths": [
+    {
+      "from": <clock event edge and name>,
+      "to": <clock event edge and name>,
+      "path": [
+        {
+          "from": {
+            "cell": <driver cell name>
+            "port": <driver port name>
+            "loc": [
+              <grid x>,
+              <grid y>
+            ]
+          },
+          "to": {
+            "cell": <sink cell name>
+            "port": <sink port name>
+            "loc": [
+              <grid x>,
+              <grid y>
+            ]
+          },
+          "type": <path segment type "logic" or "routing">,
+          "net": <net name (for routing only!)>,
+          "delay": <segment delay [ns]>,
+          "budget": <segment delay budget [ns] (for routing only!)>,
+        }
+        ...
+      ]
+    },
+    ...
+  ],
+  "detailed_net_timings": [
+    {
+      "driver": <driving cell name>,
+      "port": <driving cell port name>,
+      "event": <driver clock event name>,
+      "net": <net name>,
+      "endpoints": [
+        {
+          "cell": <sink cell name>,
+          "port": <sink cell port name>,
+          "event": <destination clock event name>,
+          "delay": <delay [ns]>,
+          "budget": <delay budget [ns]>,
+        }
+        ...
+      ]
+    }
+    ...
+  ]
+}
+*/
 
 void Context::writeReport(std::ostream &out) const
 {

--- a/common/report.cc
+++ b/common/report.cc
@@ -82,8 +82,17 @@ static Json::array report_critical_paths (const Context* ctx) {
                 {"to", toJson},
             });
 
-            if (segment.type == CriticalPath::Segment::Type::LOGIC) {
+            if (segment.type == CriticalPath::Segment::Type::CLK_TO_Q) {
+                segmentJson["type"] = "clk-to-q";
+            }
+            else if (segment.type == CriticalPath::Segment::Type::SOURCE) {
+                segmentJson["type"] = "source";
+            }
+            else if (segment.type == CriticalPath::Segment::Type::LOGIC) {
                 segmentJson["type"] = "logic";
+            }
+            else if (segment.type == CriticalPath::Segment::Type::SETUP) {
+                segmentJson["type"] = "setup";
             }
             else if (segment.type == CriticalPath::Segment::Type::ROUTING) {
                 segmentJson["type"] = "routing";
@@ -201,7 +210,7 @@ Report JSON structure:
               <grid y>
             ]
           },
-          "type": <path segment type "logic" or "routing">,
+          "type": <path segment type "clk-to-q", "source", "logic", "routing" or "setup">,
           "net": <net name (for routing only!)>,
           "delay": <segment delay [ns]>,
           "budget": <segment delay budget [ns] (for routing only!)>,

--- a/common/router1.cc
+++ b/common/router1.cc
@@ -874,7 +874,7 @@ bool router1(Context *ctx, const Router1Cfg &cfg)
 
         log_info("Checksum: 0x%08x\n", ctx->checksum());
         timing_analysis(ctx, true /* slack_histogram */, true /* print_fmax */, true /* print_path */,
-                        true /* warn_on_failure */);
+                        true /* warn_on_failure */, true /* write_report */);
 
         return true;
     } catch (log_execution_error_exception) {

--- a/common/router1.cc
+++ b/common/router1.cc
@@ -874,7 +874,7 @@ bool router1(Context *ctx, const Router1Cfg &cfg)
 
         log_info("Checksum: 0x%08x\n", ctx->checksum());
         timing_analysis(ctx, true /* slack_histogram */, true /* print_fmax */, true /* print_path */,
-                        true /* warn_on_failure */, true /* write_report */);
+                        true /* warn_on_failure */, true /* update_results */);
 
         return true;
     } catch (log_execution_error_exception) {

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -1299,17 +1299,6 @@ void timing_analysis(Context *ctx, bool print_histogram, bool print_fmax, bool p
         }
     }
 
-    // Update timing results in the context
-    if (update_results) {
-        auto& results = ctx->timing_result;
-
-        results.clock_fmax   = std::move(clock_fmax);
-        results.clock_paths  = std::move(clock_reports);
-        results.xclock_paths = std::move(xclock_reports);
-
-        results.detailed_net_timings = std::move(detailed_net_timings);
-    }
-
     // Print critical paths
     if (print_path) {
 
@@ -1499,6 +1488,17 @@ void timing_analysis(Context *ctx, bool print_histogram, bool print_fmax, bool p
             log_info("[%6d, %6d) |%s%c\n", min_slack + bin_size * i, min_slack + bin_size * (i + 1),
                      std::string(bins[i] * bar_width / max_freq, '*').c_str(),
                      (bins[i] * bar_width) % max_freq > 0 ? '+' : ' ');
+    }
+
+    // Update timing results in the context
+    if (update_results) {
+        auto& results = ctx->timing_result;
+
+        results.clock_fmax   = std::move(clock_fmax);
+        results.clock_paths  = std::move(clock_reports);
+        results.xclock_paths = std::move(xclock_reports);
+
+        results.detailed_net_timings = std::move(detailed_net_timings);
     }
 }
 

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -1216,7 +1216,8 @@ void timing_analysis(Context *ctx, bool print_histogram, bool print_fmax, bool p
     DetailedNetTimings detailed_net_timings;
 
     Timing timing(ctx, true /* net_delays */, false /* update */, (print_path || print_fmax) ? &crit_paths : nullptr,
-                  print_histogram ? &slack_histogram : nullptr, update_results ? &detailed_net_timings : nullptr);
+                  print_histogram ? &slack_histogram : nullptr,
+                  (update_results && ctx->detailed_timing_report) ? &detailed_net_timings : nullptr);
     timing.walk_paths();
 
     bool report_critical_paths = print_path || print_fmax || update_results;

--- a/common/timing.h
+++ b/common/timing.h
@@ -252,7 +252,7 @@ void assign_budget(Context *ctx, bool quiet = false);
 // Perform timing analysis and print out the fmax, and optionally the
 //    critical path
 void timing_analysis(Context *ctx, bool slack_histogram = true, bool print_fmax = true, bool print_path = false,
-                     bool warn_on_failure = false, bool write_report = false);
+                     bool warn_on_failure = false, bool update_results = false);
 
 NEXTPNR_NAMESPACE_END
 

--- a/common/timing.h
+++ b/common/timing.h
@@ -252,7 +252,7 @@ void assign_budget(Context *ctx, bool quiet = false);
 // Perform timing analysis and print out the fmax, and optionally the
 //    critical path
 void timing_analysis(Context *ctx, bool slack_histogram = true, bool print_fmax = true, bool print_path = false,
-                     bool warn_on_failure = false);
+                     bool warn_on_failure = false, bool write_report = false);
 
 NEXTPNR_NAMESPACE_END
 


### PR DESCRIPTION
In this PR I'm adding writing the final timing analysis report in the machine-readable JSON format. The report is attached to the current report JSON.

The included changes are:

- [x] decouple critical path report generation from its printout
- [ ] ~add an commandline option to specify report file name~
- [x] write critical paths to the JSON report
- [x] write all sequential net delays to the JSON report
- [x] commandline option to control detailed per-net timing writeout
- [x] decouple fmax met/not met calculation from its printout
- [ ] ~write fmax and met/not met information to the JSON report~ Already there
- [x] add some documentation for the JSON structure