### PR TITLE
Convert macros to clusters for better placement 

### DIFF
--- a/.github/workflows/interchange_ci.yml
+++ b/.github/workflows/interchange_ci.yml
@@ -114,7 +114,7 @@ jobs:
       env:
         RAPIDWRIGHT_PATH: ${{ github.workspace }}/RapidWright
         PYTHON_INTERCHANGE_PATH: ${{ github.workspace }}/python-fpga-interchange
-        PYTHON_INTERCHANGE_TAG: v0.0.18
+        PYTHON_INTERCHANGE_TAG: v0.0.20
         PRJOXIDE_REVISION: 1bf30dee9c023c4c66cfc44fd0bc28addd229c89
         DEVICE: ${{ matrix.device }}
       run: |

--- a/common/exclusive_state_groups.impl.h
+++ b/common/exclusive_state_groups.impl.h
@@ -74,10 +74,11 @@ void ExclusiveStateGroup<StateCount, StateType, CountType>::explain_requires(con
         log_info("Placing cell %s at bel %s does not violate %s.%s\n", cell.c_str(ctx), ctx->nameOfBel(bel),
                  object.c_str(ctx), definition.prefix.c_str(ctx));
     } else {
+        log_info("%d\n", state);
         log_info("Placing cell %s at bel %s does violates %s.%s, because current state is %s, constraint requires one "
                  "of:\n",
-                 cell.c_str(ctx), ctx->nameOfBel(bel), object.c_str(ctx), definition.prefix.c_str(ctx),
-                 definition.states.at(state).c_str(ctx));
+                 cell.c_str(ctx), ctx->nameOfBel(bel), object.c_str(ctx), definition.prefix.c_str(ctx), "-1");
+//                 definition.states.at(state).c_str(ctx));
 
         for (const auto required_state : state_range) {
             log_info(" - %s\n", definition.states.at(required_state).c_str(ctx));

--- a/common/exclusive_state_groups.impl.h
+++ b/common/exclusive_state_groups.impl.h
@@ -74,11 +74,10 @@ void ExclusiveStateGroup<StateCount, StateType, CountType>::explain_requires(con
         log_info("Placing cell %s at bel %s does not violate %s.%s\n", cell.c_str(ctx), ctx->nameOfBel(bel),
                  object.c_str(ctx), definition.prefix.c_str(ctx));
     } else {
-        log_info("%d\n", state);
-        log_info("Placing cell %s at bel %s does violates %s.%s, because current state is %s, constraint requires one "
+        log_info("Placing cell %s at bel %s does violate %s.%s, because current state is %s, constraint requires one "
                  "of:\n",
-                 cell.c_str(ctx), ctx->nameOfBel(bel), object.c_str(ctx), definition.prefix.c_str(ctx), "-1");
-//                 definition.states.at(state).c_str(ctx));
+                 cell.c_str(ctx), ctx->nameOfBel(bel), object.c_str(ctx), definition.prefix.c_str(ctx),
+                 state != -1 ? definition.states.at(state).c_str(ctx) : "unset");
 
         for (const auto required_state : state_range) {
             log_info(" - %s\n", definition.states.at(required_state).c_str(ctx));

--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -731,11 +731,11 @@ class SAPlacer
         return true;
     swap_fail:
 #if CHAIN_DEBUG
-            log_info("Swap failed\n");
+        log_info("Swap failed\n");
 #endif
         for (auto cell_pair : moved_cells) {
             CellInfo *cell = ctx->cells.at(cell_pair.first).get();
-            if (cell->bel != BelId()){
+            if (cell->bel != BelId()) {
 #if CHAIN_DEBUG
                 log_info("%d unbind %s\n", __LINE__, ctx->nameOfBel(cell->bel));
 #endif

--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -720,6 +720,7 @@ struct Arch : ArchAPI<ArchRanges>
     // Clusters
     void pack_cluster();
     void prepare_cluster(const ClusterPOD *cluster, uint32_t index);
+    void prepare_macro_cluster(const ClusterPOD *cluster, uint32_t index);
     dict<ClusterId, Cluster> clusters;
 
     // User constraints

--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -860,8 +860,6 @@ struct Arch : ArchAPI<ArchRanges>
         const TileStatus &tile_status = iter->second;
         CellInfo *cell = tile_status.boundcells[bel.index];
         auto &bel_data = bel_info(chip_info, bel);
-
-        auto &bel_data = bel_info(chip_info, bel);
         auto &site_status = get_site_status(tile_status, bel_data);
 
         if (cell != nullptr) {

--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -858,7 +858,8 @@ struct Arch : ArchAPI<ArchRanges>
             return true;
         }
         const TileStatus &tile_status = iter->second;
-        const CellInfo *cell = tile_status.boundcells[bel.index];
+        CellInfo *cell = tile_status.boundcells[bel.index];
+        auto &bel_data = bel_info(chip_info, bel);
 
         auto &bel_data = bel_info(chip_info, bel);
         auto &site_status = get_site_status(tile_status, bel_data);
@@ -900,6 +901,10 @@ struct Arch : ArchAPI<ArchRanges>
     ArcBounds getClusterBounds(ClusterId cluster) const override;
     Loc getClusterOffset(const CellInfo *cell) const override;
     bool isClusterStrict(const CellInfo *cell) const override;
+    bool normal_cluster_placement(const Context *, const Cluster &, const ClusterPOD &,CellInfo*,
+                                  BelId, std::vector<std::pair<CellInfo *, BelId>> &) const;
+    bool macro_cluster_placement(const Context *, const Cluster &, const ClusterPOD &,CellInfo*,
+                                  BelId, std::vector<std::pair<CellInfo *, BelId>> &) const;
     bool getClusterPlacement(ClusterId cluster, BelId root_bel,
                              std::vector<std::pair<CellInfo *, BelId>> &placement) const override;
 

--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -899,10 +899,10 @@ struct Arch : ArchAPI<ArchRanges>
     ArcBounds getClusterBounds(ClusterId cluster) const override;
     Loc getClusterOffset(const CellInfo *cell) const override;
     bool isClusterStrict(const CellInfo *cell) const override;
-    bool normal_cluster_placement(const Context *, const Cluster &, const ClusterPOD &,CellInfo*,
-                                  BelId, std::vector<std::pair<CellInfo *, BelId>> &) const;
-    bool macro_cluster_placement(const Context *, const Cluster &, const ClusterPOD &,CellInfo*,
-                                  BelId, std::vector<std::pair<CellInfo *, BelId>> &) const;
+    bool normal_cluster_placement(const Context *, const Cluster &, const ClusterPOD &, CellInfo *, BelId,
+                                  std::vector<std::pair<CellInfo *, BelId>> &) const;
+    bool macro_cluster_placement(const Context *, const Cluster &, const ClusterPOD &, CellInfo *, BelId,
+                                 std::vector<std::pair<CellInfo *, BelId>> &) const;
     bool getClusterPlacement(ClusterId cluster, BelId root_bel,
                              std::vector<std::pair<CellInfo *, BelId>> &placement) const override;
 

--- a/fpga_interchange/chipdb.h
+++ b/fpga_interchange/chipdb.h
@@ -451,6 +451,14 @@ NPNR_PACKED_STRUCT(struct ClusterConnectionGraphPOD{
     RelSlice<ClusterUsedPortPOD> used_ports;
 });
 
+NPNR_PACKED_STRUCT(struct ClusterPhysicalPlacementEntryPOD{
+    RelSlice<uint32_t> bels;
+});
+
+NPNR_PACKED_STRUCT(struct ClusterPhysicalPlacementsPOD{
+    uint32_t site_type;
+    RelSlice<ClusterPhysicalPlacementEntryPOD> places;
+});
 
 NPNR_PACKED_STRUCT(struct ClusterPOD {
     uint32_t name;
@@ -459,6 +467,7 @@ NPNR_PACKED_STRUCT(struct ClusterPOD {
     RelSlice<ClusterCellPortPOD> cluster_cells_map;
     RelSlice<ClusterRequiredCellPOD> required_cells;
     RelSlice<ClusterConnectionGraphPOD> connection_graph;
+    RelSlice<ClusterPhysicalPlacementsPOD> physical_placements;
     uint32_t out_of_site_clusters;
     uint32_t disallow_other_cells;
     uint32_t from_macro;

--- a/fpga_interchange/chipdb.h
+++ b/fpga_interchange/chipdb.h
@@ -37,8 +37,8 @@ NEXTPNR_NAMESPACE_BEGIN
 static constexpr int32_t kExpectedChipInfoVersion = 15;
 
 NPNR_PACKED_STRUCT(struct BelConnectedPinsPOD {
-    uint32_t pin1;
-    uint32_t pin2;
+    int32_t pin1;
+    int32_t pin2;
 });
 
 // Flattened site indexing.

--- a/fpga_interchange/chipdb.h
+++ b/fpga_interchange/chipdb.h
@@ -34,7 +34,12 @@ NEXTPNR_NAMESPACE_BEGIN
  * kExpectedChipInfoVersion
  */
 
-static constexpr int32_t kExpectedChipInfoVersion = 14;
+static constexpr int32_t kExpectedChipInfoVersion = 15;
+
+NPNR_PACKED_STRUCT(struct BelConnectedPinsPOD {
+    uint32_t pin1;
+    uint32_t pin2;
+});
 
 // Flattened site indexing.
 //
@@ -80,6 +85,8 @@ NPNR_PACKED_STRUCT(struct BelInfoPOD {
     int8_t inverting_pin;
 
     int16_t padding;
+
+    RelSlice<BelConnectedPinsPOD> connected_pins;
 });
 
 enum BELCategory
@@ -416,13 +423,45 @@ NPNR_PACKED_STRUCT(struct ChainablePortPOD {
     int16_t avg_y_offset;
 });
 
+NPNR_PACKED_STRUCT(struct ClusterRequiredCellPOD{
+    uint32_t name;
+    uint32_t count;
+});
+
+NPNR_PACKED_STRUCT(struct ClusterUsedPortPOD{
+    uint32_t name;
+});
+
+NPNR_PACKED_STRUCT(struct ClusterEdgePOD{
+    uint32_t dir;
+    uint32_t cell_pin;
+    uint32_t other_cell_pin;
+    uint32_t other_cell_type;
+});
+
+NPNR_PACKED_STRUCT(struct ClusterConnectionsPOD{
+    uint32_t target_idx;
+    RelSlice<ClusterEdgePOD> edges;
+});
+
+NPNR_PACKED_STRUCT(struct ClusterConnectionGraphPOD{
+    uint32_t idx;
+    uint32_t cell_type;
+    RelSlice<ClusterConnectionsPOD> connections;
+    RelSlice<ClusterUsedPortPOD> used_ports;
+});
+
+
 NPNR_PACKED_STRUCT(struct ClusterPOD {
     uint32_t name;
     RelSlice<uint32_t> root_cell_types;
     RelSlice<ChainablePortPOD> chainable_ports;
     RelSlice<ClusterCellPortPOD> cluster_cells_map;
+    RelSlice<ClusterRequiredCellPOD> required_cells;
+    RelSlice<ClusterConnectionGraphPOD> connection_graph;
     uint32_t out_of_site_clusters;
     uint32_t disallow_other_cells;
+    uint32_t from_macro;
 });
 
 NPNR_PACKED_STRUCT(struct ChipInfoPOD {

--- a/fpga_interchange/chipdb.h
+++ b/fpga_interchange/chipdb.h
@@ -423,39 +423,35 @@ NPNR_PACKED_STRUCT(struct ChainablePortPOD {
     int16_t avg_y_offset;
 });
 
-NPNR_PACKED_STRUCT(struct ClusterRequiredCellPOD{
+NPNR_PACKED_STRUCT(struct ClusterRequiredCellPOD {
     uint32_t name;
     uint32_t count;
 });
 
-NPNR_PACKED_STRUCT(struct ClusterUsedPortPOD{
-    uint32_t name;
-});
+NPNR_PACKED_STRUCT(struct ClusterUsedPortPOD { uint32_t name; });
 
-NPNR_PACKED_STRUCT(struct ClusterEdgePOD{
+NPNR_PACKED_STRUCT(struct ClusterEdgePOD {
     uint32_t dir;
     uint32_t cell_pin;
     uint32_t other_cell_pin;
     uint32_t other_cell_type;
 });
 
-NPNR_PACKED_STRUCT(struct ClusterConnectionsPOD{
+NPNR_PACKED_STRUCT(struct ClusterConnectionsPOD {
     uint32_t target_idx;
     RelSlice<ClusterEdgePOD> edges;
 });
 
-NPNR_PACKED_STRUCT(struct ClusterConnectionGraphPOD{
+NPNR_PACKED_STRUCT(struct ClusterConnectionGraphPOD {
     uint32_t idx;
     uint32_t cell_type;
     RelSlice<ClusterConnectionsPOD> connections;
     RelSlice<ClusterUsedPortPOD> used_ports;
 });
 
-NPNR_PACKED_STRUCT(struct ClusterPhysicalPlacementEntryPOD{
-    RelSlice<uint32_t> bels;
-});
+NPNR_PACKED_STRUCT(struct ClusterPhysicalPlacementEntryPOD { RelSlice<uint32_t> bels; });
 
-NPNR_PACKED_STRUCT(struct ClusterPhysicalPlacementsPOD{
+NPNR_PACKED_STRUCT(struct ClusterPhysicalPlacementsPOD {
     uint32_t site_type;
     RelSlice<ClusterPhysicalPlacementEntryPOD> places;
 });

--- a/fpga_interchange/macros.cc
+++ b/fpga_interchange/macros.cc
@@ -50,6 +50,7 @@ static IdString derived_name(Context *ctx, IdString base_name, IdString suffix)
 
 void Arch::expand_macros()
 {
+    log_info("Expand macros\n");
     // Make up a list of cells, so we don't have modify-while-iterating issues
     Context *ctx = getCtx();
     std::vector<CellInfo *> cells;
@@ -78,6 +79,7 @@ void Arch::expand_macros()
 
             // Get the ultimate root of this macro expansion
             IdString parent = (cell->macro_parent == IdString()) ? cell->name : cell->macro_parent;
+            log_info("%s %s\n", cell->name.c_str(ctx), parent.c_str(ctx));
             // Create child instances
             for (const auto &inst : macro->cell_insts) {
                 CellInfo *inst_cell =
@@ -86,6 +88,7 @@ void Arch::expand_macros()
                     inst_cell->params[IdString(param.key)] = IdString(param.value).str(ctx);
                 }
                 inst_cell->macro_parent = parent;
+                log_info("  %s %s\n", inst_cell->name.c_str(ctx), inst_cell->type.c_str(ctx));
                 next_cells.push_back(inst_cell);
             }
             // Create and connect nets

--- a/fpga_interchange/macros.cc
+++ b/fpga_interchange/macros.cc
@@ -79,7 +79,6 @@ void Arch::expand_macros()
 
             // Get the ultimate root of this macro expansion
             IdString parent = (cell->macro_parent == IdString()) ? cell->name : cell->macro_parent;
-            log_info("%s %s\n", cell->name.c_str(ctx), parent.c_str(ctx));
             // Create child instances
             for (const auto &inst : macro->cell_insts) {
                 CellInfo *inst_cell =
@@ -88,7 +87,6 @@ void Arch::expand_macros()
                     inst_cell->params[IdString(param.key)] = IdString(param.value).str(ctx);
                 }
                 inst_cell->macro_parent = parent;
-                log_info("  %s %s\n", inst_cell->name.c_str(ctx), inst_cell->type.c_str(ctx));
                 next_cells.push_back(inst_cell);
             }
             // Create and connect nets


### PR DESCRIPTION
This code adds cluster detection and placement for clusters created from macros.
So far only in-site macros are being placed, as out-site macros may could use global routing resources leading to visiting whole FPGA fabric.
This issue can be rectified be checking routing outside site if it's dedicated routing, like in BRAM64, carry chains or DIFF IO.
and only using them, and fail on routing that uses global routing.

Done so far:
- [x] Cluster from macro detection
    - [x] Cluster cells to idx mapping
    - [x] Idx solver 
- [x]  Cluster placement 
    - [x] root_bel check
    - [x] compatible bell checker
    - [x] logical netlist checker
