### PR TITLE
nexus: Fixed an improved SIOLOGIC handling

### DIFF
--- a/nexus/fasm.cc
+++ b/nexus/fasm.cc
@@ -567,14 +567,10 @@ struct NexusFasmWriter
         push_bel(bel);
         write_enum(cell, "MODE");
         write_enum(cell, "IDDRX1_ODDRX1.OUTPUT");
+        write_enum(cell, "IDDRX1_ODDRX1.TRISTATE");
         write_enum(cell, "GSR", "DISABLED");
         write_enum(cell, "TSREG.REGSET", "RESET");
         write_cell_muxes(cell);
-        pop();
-
-        // FIXME: Workaround for unknown bits
-        push_tile(bel.tile);
-        write_enum(cell, "UNKNOWN");
         pop();
     }
 

--- a/nexus/fasm.cc
+++ b/nexus/fasm.cc
@@ -568,7 +568,13 @@ struct NexusFasmWriter
         write_enum(cell, "MODE");
         write_enum(cell, "IDDRX1_ODDRX1.OUTPUT");
         write_enum(cell, "GSR", "DISABLED");
+        write_enum(cell, "TSREG.REGSET", "RESET");
         write_cell_muxes(cell);
+        pop();
+
+        // FIXME: Workaround for unknown bits
+        push_tile(bel.tile);
+        write_enum(cell, "UNKNOWN");
         pop();
     }
 

--- a/nexus/pack.cc
+++ b/nexus/pack.cc
@@ -2276,24 +2276,10 @@ struct NexusPacker
                 iol->params[id_SRMODE] = ff->params.at(id_SRMODE);
                 iol->params[id_REGSET] = ff->params.at(id_REGSET);
 
-                iol->params[ctx->id("TSREG.REGSET")] = std::string("SET");
-
-                // CEOUTMUX.1
+                // Enable the TSREG
                 iol->params[ctx->id("CEOUTMUX")] = std::string("1");
-
-                // FIXME: Workaround for an unknown bit
-                IdStringList belName = IdStringList::parse(ctx, iob->attrs[id_BEL].as_string());
-                if (belName[2] == ctx->id("PIOA")) {
-                    // UNKNOWN.22.1 for A
-                    iol->params[ctx->id("UNKNOWN")] = std::string("22.1");
-                }
-                else if (belName[2] == ctx->id("PIOB")) {
-                    // UNKNOWN.77.1 for B
-                    iol->params[ctx->id("UNKNOWN")] = std::string("77.1");
-                }
-                else {
-                    log_error("Unknown IO BEL type '%s'\n", belName[2].c_str(ctx));
-                }
+                iol->params[ctx->id("TSREG.REGSET")] = std::string("SET");
+                iol->params[ctx->id("IDDRX1_ODDRX1.TRISTATE")] = std::string("ENABLED");
             }
 
             // Disconnect the flip-flop


### PR DESCRIPTION
This PR includes two major changes required for `IDDRX1` and `ODDRX1` plus tri-state control to work together on `LIFCL-17`:
 - Fixed the case when `SIOLOGIC` is used ant `SEIOxx_CORE.T` connection is bypassing it
 - Added inference and integration of flip-flops which drive `SEIOxx_CORE.T` into `SIOLOGIC` whenever possible

The first issue was causing a routing conflict as there are no separate routes for `SEIOxx_CORE.T` and `SIOLOGIC.TSDATA0` outside the tile. This is solved by detecting that `SEIOxx_CORE.T` bypasses `SIOLOGIC` and connecting `SIOLOGIC.TSDATA0`  to the same net. This does not affect the design operation as the mux on `SEIOxx_CORE.T` still choses the correct input making `SIOLOGIC.TOUT` ignored.

The second thing is an improvement which allows nextpnr to take advantage of "TREG" located aside the ODDR part of `SIOLOGIC`. Whenever it is detected that a flip-flop drives `SEIOxx_CORE.T` bypassing `SIOLOGIC` appropriate transformation is applied which removes the filp-flop and enables the one in `SIOLOGIC`.

There is currently a workaround in place for unknown bits emission which seem to control the `SEIOxx_CORE.T` input mux.