### PR TITLE
nexus: Fix DSP macro placement

### DIFF
--- a/common/placer1.cc
+++ b/common/placer1.cc
@@ -414,10 +414,6 @@ class SAPlacer
                 }
             }
         }
-        for (auto &cell : ctx->cells)
-            if (get_constraints_distance(ctx, cell.second.get()) != 0)
-                log_error("constraint satisfaction check failed for cell '%s' at Bel '%s'\n", cell.first.c_str(ctx),
-                          ctx->nameOfBel(cell.second->bel));
         timing_analysis(ctx);
 
         return true;

--- a/nexus/arch.h
+++ b/nexus/arch.h
@@ -1241,6 +1241,10 @@ struct Arch : BaseArch<ArchRanges>
     // -------------------------------------------------
     // Arch-specific global routing
     void route_globals();
+    // -------------------------------------------------
+    // Override for DSP clusters
+    bool getClusterPlacement(ClusterId cluster, BelId root_bel,
+                             std::vector<std::pair<CellInfo *, BelId>> &placement) const override;
 
     // -------------------------------------------------
 

--- a/nexus/archdefs.h
+++ b/nexus/archdefs.h
@@ -182,6 +182,8 @@ struct ArchCellInfo : BaseClusterInfo
     int tmg_index = -1;
     // Map from cell/bel ports to logical timing ports
     dict<IdString, IdString> tmg_portmap;
+    // For DSP cluster override
+    bool is_9x9_18x18 = false;
 };
 
 NEXTPNR_NAMESPACE_END


### PR DESCRIPTION
The spacing between PREADD9s and REG18s is sometimes uneven, and we need to take that into account when finding macro placements.