### PR TITLE
interchange: Enable Werror on CI and fix some compile warnings

### DIFF
--- a/.github/ci/build_interchange.sh
+++ b/.github/ci/build_interchange.sh
@@ -57,7 +57,7 @@ function build_nextpnr {
     build_capnp
     mkdir build
     pushd build
-    cmake .. -DARCH=fpga_interchange -DRAPIDWRIGHT_PATH=${RAPIDWRIGHT_PATH} -DPYTHON_INTERCHANGE_PATH=${PYTHON_INTERCHANGE_PATH}
+    cmake .. -DARCH=fpga_interchange -DRAPIDWRIGHT_PATH=${RAPIDWRIGHT_PATH} -DPYTHON_INTERCHANGE_PATH=${PYTHON_INTERCHANGE_PATH} -DWERROR=on
     make nextpnr-fpga_interchange -j`nproc`
     popd
 }

--- a/fpga_interchange/arch_pack_clusters.cc
+++ b/fpga_interchange/arch_pack_clusters.cc
@@ -29,6 +29,7 @@
 
 NEXTPNR_NAMESPACE_BEGIN
 
+namespace {
 enum ClusterWireNodeState
 {
     IN_SINK_SITE = 0,
@@ -51,6 +52,7 @@ struct ClusterWireNode
     int depth;
     bool only_down;
 };
+} // namespace
 
 static void handle_expansion_node(const Context *ctx, WireId prev_wire, PipId pip, ClusterWireNode curr_node,
                                   std::vector<ClusterWireNode> &nodes_to_expand, pool<BelId> &bels,
@@ -678,7 +680,7 @@ void Arch::prepare_macro_cluster(const ClusterPOD *cluster, uint32_t index)
         for (auto &cell : macro_to_cells[ci->macro_parent])
             for (auto &node : cluster->connection_graph)
                 if (IdString(node.cell_type) == cell->type)
-                    if (node.idx != 0 && cell->name != ci->name || node.idx == 0 && cell->name == ci->name) {
+                    if ((node.idx != 0 && cell->name != ci->name) || (node.idx == 0 && cell->name == ci->name)) {
                         idx_to_cells[node.idx].insert(cell);
                     }
 
@@ -712,7 +714,7 @@ void Arch::prepare_macro_cluster(const ClusterPOD *cluster, uint32_t index)
                 for (const auto &cell : arc.second)
                     possible_idx[cell].insert(arc.first);
 
-            for (const auto arc : possible_idx) {
+            for (const auto &arc : possible_idx) {
                 log_info("Possible idx %s:\n", arc.first->name.c_str(ctx));
                 for (const auto idx : arc.second)
                     log_info("    - %d\n", idx);
@@ -743,7 +745,7 @@ void Arch::prepare_macro_cluster(const ClusterPOD *cluster, uint32_t index)
                 for (const auto &cell : arc.second)
                     possible_idx[cell].insert(arc.first);
 
-            for (const auto arc : possible_idx) {
+            for (const auto &arc : possible_idx) {
                 log_info("Possible idx %s:\n", arc.first->name.c_str(ctx));
                 for (const auto idx : arc.second)
                     log_info("    - %d\n", idx);
@@ -809,7 +811,7 @@ void Arch::prepare_macro_cluster(const ClusterPOD *cluster, uint32_t index)
                 for (const auto &cell : arc.second)
                     possible_idx[cell].insert(arc.first);
 
-            for (const auto arc : possible_idx) {
+            for (const auto &arc : possible_idx) {
                 log_info("Possible idx %s:\n", arc.first->name.c_str(ctx));
                 for (const auto idx : arc.second)
                     log_info("    - %d\n", idx);
@@ -831,7 +833,7 @@ void Arch::prepare_macro_cluster(const ClusterPOD *cluster, uint32_t index)
                 for (const auto &cell : arc.second)
                     possible_idx[cell].insert(arc.first);
 
-            for (const auto arc : possible_idx) {
+            for (const auto &arc : possible_idx) {
                 log_info("Possible idx %s:\n", arc.first->name.c_str(ctx));
                 for (const auto idx : arc.second)
                     log_info("    - %d\n", idx);

--- a/fpga_interchange/dedicated_interconnect.cc
+++ b/fpga_interchange/dedicated_interconnect.cc
@@ -23,7 +23,7 @@
 #include "util.h"
 
 NEXTPNR_NAMESPACE_BEGIN
-
+namespace {
 // All legal routes involved at most 2 sites, the source site and the sink
 // site.  The source site and sink sites may be the same, but that is not
 // dedicated routing, that is intra site routing.
@@ -51,6 +51,7 @@ struct WireNode
     WireNodeState state;
     int depth;
 };
+} // namespace
 
 // Maximum depth that a dedicate interconnect is considered.
 //


### PR DESCRIPTION
cc @mtdudek 

```
/home/gatecat/nextpnr/fpga_interchange/arch_pack_clusters.cc: In member function ‘void nextpnr_fpga_interchange::Arch::prepare_macro_cluster(const nextpnr_fpga_interchange::ClusterPOD*, uint32_t)’:
/home/gatecat/nextpnr/fpga_interchange/arch_pack_clusters.cc:681:39: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
  681 |                     if (node.idx != 0 && cell->name != ci->name || node.idx == 0 && cell->name == ci->name) {
      |                         ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/home/gatecat/nextpnr/fpga_interchange/arch_pack_clusters.cc:715:29: warning: loop variable ‘arc’ creates a copy from type ‘const std::pair<nextpnr_fpga_interchange::CellInfo*, nextpnr_fpga_interchange::pool<unsigned int> >’ [-Wrange-loop-construct]
  715 |             for (const auto arc : possible_idx) {
      |                             ^~~
/home/gatecat/nextpnr/fpga_interchange/arch_pack_clusters.cc:715:29: note: use reference type to prevent copying
  715 |             for (const auto arc : possible_idx) {
```
