### PR TITLE
gowin: add support for wide LUTs.

### DIFF
--- a/gowin/arch.h
+++ b/gowin/arch.h
@@ -330,6 +330,7 @@ struct Arch : BaseArch<ArchRanges>
     IdString wireToGlobal(int &row, int &col, const DatabasePOD *db, IdString &wire);
     DelayQuad getWireTypeDelay(IdString wire);
     void read_cst(std::istream &in);
+    void addMuxBels(const DatabasePOD *db, int row, int col);
 
     // ---------------------------------------------------------------
     // Common Arch API. Every arch must provide the following methods.
@@ -444,6 +445,8 @@ struct Arch : BaseArch<ArchRanges>
     // Internal usage
     void assignArchInfo() override;
     bool cellsCompatible(const CellInfo **cells, int count) const;
+    // start Z for the MUX2LUT5 bels
+    int const mux_0_z = 10;
 
     std::vector<IdString> cell_types;
 

--- a/gowin/archdefs.h
+++ b/gowin/archdefs.h
@@ -65,6 +65,7 @@ struct ArchCellInfo : BaseClusterInfo
     IdString ff_type;
     // Is a slice type primitive
     bool is_slice;
+
     // Only packing rule for slice type primitives is a single clock per tile
     const NetInfo *slice_clk;
     const NetInfo *slice_ce;

--- a/gowin/cells.h
+++ b/gowin/cells.h
@@ -43,6 +43,40 @@ inline bool is_lut(const BaseCtx *ctx, const CellInfo *cell)
     }
 }
 
+// Return true if a cell is a wide LUT mux
+inline bool is_widelut(const BaseCtx *ctx, const CellInfo *cell)
+{
+    switch (cell->type.index) {
+    case ID_MUX2_LUT5:
+    case ID_MUX2_LUT6:
+    case ID_MUX2_LUT7:
+    case ID_MUX2_LUT8:
+        return true;
+    default:
+        return false;
+    }
+}
+
+// is MUX2_LUT5
+inline bool is_mux2_lut5(const BaseCtx *ctx, const CellInfo *cell) { return (cell->type.index == ID_MUX2_LUT5); }
+
+inline bool is_gw_mux2_lut5(const BaseCtx *ctx, const CellInfo *cell) { return (cell->type.index == ID_GW_MUX2_LUT5); }
+
+// is MUX2_LUT6
+inline bool is_mux2_lut6(const BaseCtx *ctx, const CellInfo *cell) { return (cell->type.index == ID_MUX2_LUT6); }
+
+inline bool is_gw_mux2_lut6(const BaseCtx *ctx, const CellInfo *cell) { return (cell->type.index == ID_GW_MUX2_LUT6); }
+
+// is MUX2_LUT7
+inline bool is_mux2_lut7(const BaseCtx *ctx, const CellInfo *cell) { return (cell->type.index == ID_MUX2_LUT7); }
+
+inline bool is_gw_mux2_lut7(const BaseCtx *ctx, const CellInfo *cell) { return (cell->type.index == ID_GW_MUX2_LUT7); }
+
+// is MUX2_LUT8
+inline bool is_mux2_lut8(const BaseCtx *ctx, const CellInfo *cell) { return (cell->type.index == ID_MUX2_LUT8); }
+
+inline bool is_gw_mux2_lut8(const BaseCtx *ctx, const CellInfo *cell) { return (cell->type.index == ID_GW_MUX2_LUT8); }
+
 // Return true if a cell is a flipflop
 inline bool is_ff(const BaseCtx *ctx, const CellInfo *cell)
 {

--- a/gowin/constids.inc
+++ b/gowin/constids.inc
@@ -358,6 +358,16 @@ X(IOBH)
 X(IOBI)
 X(IOBJ)
 
+// Wide LUTs
+X(MUX2_LUT5)
+X(MUX2_LUT6)
+X(MUX2_LUT7)
+X(MUX2_LUT8)
+X(GW_MUX2_LUT5)
+X(GW_MUX2_LUT6)
+X(GW_MUX2_LUT7)
+X(GW_MUX2_LUT8)
+
 // DFF types
 X(DFF)
 X(DFFE)
@@ -409,6 +419,9 @@ X(I1)
 X(I2)
 X(I3)
 X(OEN)
+X(S0)
+X(SEL)
+X(OF)
 
 // timing
 X(X0)


### PR DESCRIPTION
  * A hardwired MUX within each logical cell is used.
  * The delay is equal 0.
  * No user placement constraints.
  * The output route contains dummy PIPs. They are ignored by gowin_pack, but it may be worth removing them.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>