### PR TITLE
mistral: Fix MLAB clustering

### DIFF
--- a/mistral/lab.cc
+++ b/mistral/lab.cc
@@ -492,6 +492,12 @@ void Arch::update_alm_input_count(uint32_t lab, uint8_t alm)
     for (int i = 0; i < 2; i++) {
         if (!luts[i])
             continue;
+        // MLAB that has been clustered with other MLABs (due to shared read port) costs no extra inputs
+        if (luts[i]->combInfo.mlab_group != -1 && luts[i]->constr_z > 2) {
+            alm_data.unique_input_count = 0;
+            return;
+        }
+
         total_lut_inputs += luts[i]->combInfo.used_lut_input_count - luts[i]->combInfo.chain_shared_input_count;
     }
     int shared_lut_inputs = 0;

--- a/mistral/pack.cc
+++ b/mistral/pack.cc
@@ -367,8 +367,9 @@ struct MistralPacker
                 CellInfo *ci = group.at(i);
                 CellInfo *base = group.at((i / cluster_size) * cluster_size);
                 int cell_index = int(i) % cluster_size;
-                int alm = i / 2;
-                int alm_cell = i % 2;
+                int alm = cell_index / 2;
+                int alm_cell = cell_index % 2;
+                ci->cluster = base->name;
                 ci->constr_abs_z = true;
                 ci->constr_z = alm * 6 + alm_cell;
                 if (cell_index != 0) {


### PR DESCRIPTION
We weren't actually clustering MLABs correctly, and also need to fix a bug in the validity checking this shows up.