### PR TITLE
MachXO2 Checkpoint 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Currently nextpnr supports:
  * Lattice Nexus devices supported by [Project Oxide](https://github.com/gatecat/prjoxide)
  * Gowin LittleBee devices supported by [Project Apicula](https://github.com/YosysHQ/apicula)
  * *(experimental)* Cyclone V devices supported by [Mistral](https://github.com/Ravenslofty/mistral)
+ * *(experimental)* Lattice MachXO2 devices supported by [Project Trellis](https://github.com/YosysHQ/prjtrellis)
  * *(experimental)* a "generic" back-end for user-defined architectures
 
 There is some work in progress towards [support for Xilinx devices](https://github.com/gatecat/nextpnr-xilinx/) but it is not upstream and not intended for end users at the present time. We hope to see more FPGA families supported in the future. We would love your help in developing this awesome new project!

--- a/machxo2/bitstream.cc
+++ b/machxo2/bitstream.cc
@@ -62,6 +62,7 @@ static std::string get_trellis_wirename(Context *ctx, Location loc, WireId wire)
     // relative coords push them outside the bounds of the chip.
     // Indents are based on wires proximity/purpose.
     auto is_pio_wire = [](std::string name) {
+        // clang-format off
         return (name.find("DI") != std::string::npos || name.find("JDI") != std::string::npos ||
                     name.find("PADD") != std::string::npos || name.find("INDD") != std::string::npos ||
                     name.find("IOLDO") != std::string::npos || name.find("IOLTO") != std::string::npos ||
@@ -77,6 +78,7 @@ static std::string get_trellis_wirename(Context *ctx, Location loc, WireId wire)
                 name.find("JIN") != std::string::npos || name.find("JIP") != std::string::npos ||
                 // Connections to global mux
                 name.find("JINCK") != std::string::npos);
+        // clang-format on
     };
 
     if (prefix2 == "G_" || prefix2 == "L_" || prefix2 == "R_" || prefix7 == "BRANCH_")
@@ -103,14 +105,14 @@ static std::string get_trellis_wirename(Context *ctx, Location loc, WireId wire)
             if (wire.location.x == 0) {
                 std::string pio_name = "W1_" + basename;
                 if (ctx->verbose)
-                    log_info("PIO wire %s was adjusted by W1 to form Trellis name %s.\n", \
-                        ctx->nameOfWire(wire), pio_name.c_str());
+                    log_info("PIO wire %s was adjusted by W1 to form Trellis name %s.\n", ctx->nameOfWire(wire),
+                             pio_name.c_str());
                 return pio_name;
             } else if (wire.location.x == max_col) {
                 std::string pio_name = "E1_" + basename;
                 if (ctx->verbose)
-                    log_info("PIO wire %s was adjusted by E1 to form Trellis name %s.\n", \
-                        ctx->nameOfWire(wire), pio_name.c_str());
+                    log_info("PIO wire %s was adjusted by E1 to form Trellis name %s.\n", ctx->nameOfWire(wire),
+                             pio_name.c_str());
                 return pio_name;
             }
         }

--- a/machxo2/bitstream.cc
+++ b/machxo2/bitstream.cc
@@ -19,6 +19,7 @@
  */
 
 #include <fstream>
+#include <iostream>
 
 #include "bitstream.h"
 #include "config.h"
@@ -59,13 +60,20 @@ static std::string get_trellis_wirename(Context *ctx, Location loc, WireId wire)
 
     // Handle MachXO2's wonderful naming quirks for wires in left/right tiles, whose
     // relative coords push them outside the bounds of the chip.
+    // Indents are based on wires proximity/purpose.
     auto is_pio_wire = [](std::string name) {
         return (name.find("DI") != std::string::npos || name.find("JDI") != std::string::npos ||
-                name.find("PADD") != std::string::npos || name.find("INDD") != std::string::npos ||
-                name.find("IOLDO") != std::string::npos || name.find("IOLTO") != std::string::npos ||
-                name.find("JCE") != std::string::npos || name.find("JCLK") != std::string::npos ||
-                name.find("JLSR") != std::string::npos || name.find("JONEG") != std::string::npos ||
-                name.find("JOPOS") != std::string::npos || name.find("JTS") != std::string::npos ||
+                    name.find("PADD") != std::string::npos || name.find("INDD") != std::string::npos ||
+                    name.find("IOLDO") != std::string::npos || name.find("IOLTO") != std::string::npos ||
+                // JCE0-3, JCLK0-3, JLSR0-3 connect to PIO wires named JCEA-D, JCLKA-D, JLSRA-D.
+                name.find("JCEA") != std::string::npos || name.find("JCEB") != std::string::npos ||
+                    name.find("JCEC") != std::string::npos || name.find("JCED") != std::string::npos ||
+                    name.find("JCLKA") != std::string::npos || name.find("JCLKB") != std::string::npos ||
+                    name.find("JCLKC") != std::string::npos || name.find("JCLKD") != std::string::npos ||
+                    name.find("JLSRA") != std::string::npos || name.find("JLSRB") != std::string::npos ||
+                    name.find("JLSRC") != std::string::npos || name.find("JLSRD") != std::string::npos ||
+                name.find("JONEG") != std::string::npos || name.find("JOPOS") != std::string::npos ||
+                    name.find("JTS") != std::string::npos ||
                 name.find("JIN") != std::string::npos || name.find("JIP") != std::string::npos ||
                 // Connections to global mux
                 name.find("JINCK") != std::string::npos);
@@ -92,10 +100,19 @@ static std::string get_trellis_wirename(Context *ctx, Location loc, WireId wire)
     if (loc == wire.location) {
         // TODO: JINCK is not currently handled by this.
         if (is_pio_wire(basename)) {
-            if (wire.location.x == 0)
-                return "W1_" + basename;
-            else if (wire.location.x == max_col)
-                return "E1_" + basename;
+            if (wire.location.x == 0) {
+                std::string pio_name = "W1_" + basename;
+                if (ctx->verbose)
+                    log_info("PIO wire %s was adjusted by W1 to form Trellis name %s.\n", \
+                        ctx->nameOfWire(wire), pio_name.c_str());
+                return pio_name;
+            } else if (wire.location.x == max_col) {
+                std::string pio_name = "E1_" + basename;
+                if (ctx->verbose)
+                    log_info("PIO wire %s was adjusted by E1 to form Trellis name %s.\n", \
+                        ctx->nameOfWire(wire), pio_name.c_str());
+                return pio_name;
+            }
         }
         return basename;
     }

--- a/machxo2/examples/demo-vhdl.sh
+++ b/machxo2/examples/demo-vhdl.sh
@@ -19,6 +19,6 @@ set -ex
 ${YOSYS:-yosys} -p "ghdl --std=08 prims.vhd ${1}.vhd -e;
                     attrmap -tocase LOC
                     synth_machxo2 -json ${1}-vhdl.json"
-${NEXTPNR:-../../nextpnr-machxo2} --1200 --package QFN32 --no-iobs --json $1-vhdl.json --textcfg $1-vhdl.txt
+${NEXTPNR:-../../nextpnr-machxo2} --1200 --package QFN32 --json $1-vhdl.json --textcfg $1-vhdl.txt
 ecppack --compress $DB_ARG $1-vhdl.txt $1-vhdl.bit
 tinyproga -b $1-vhdl.bit

--- a/machxo2/examples/demo.sh
+++ b/machxo2/examples/demo.sh
@@ -17,6 +17,6 @@ fi
 set -ex
 
 ${YOSYS:-yosys} -p "synth_machxo2 -json $1.json" $1.v
-${NEXTPNR:-../../nextpnr-machxo2} --1200 --package QFN32 --no-iobs --json $1.json --textcfg $1.txt
+${NEXTPNR:-../../nextpnr-machxo2} --1200 --package QFN32 --json $1.json --textcfg $1.txt
 ecppack --compress $DB_ARG $1.txt $1.bit
 tinyproga -b $1.bit

--- a/machxo2/examples/mitertest.sh
+++ b/machxo2/examples/mitertest.sh
@@ -61,6 +61,7 @@ do_smt() {
                         miter -equiv -make_assert gold gate ${2}${1}_miter
                         hierarchy -top ${2}${1}_miter; proc;
                         opt_clean
+                        flatten t:*FACADE_IO*
                         write_verilog ${2}${1}_miter.v
                         write_smt2 ${2}${1}_miter.smt2"
 
@@ -71,7 +72,7 @@ do_smt() {
 set -ex
 
 ${YOSYS:-yosys} -p "read_verilog ${1}.v
-                    synth_machxo2 -noiopad -json ${1}.json"
+                    synth_machxo2 -json ${1}.json"
 ${NEXTPNR:-../../nextpnr-machxo2} $NEXTPNR_MODE --1200 --package QFN32 --no-iobs --json ${1}.json --write ${2}${1}.json
 ${YOSYS:-yosys} -p "read_verilog -lib +/machxo2/cells_sim.v
                     read_json ${2}${1}.json

--- a/machxo2/examples/mitertest.sh
+++ b/machxo2/examples/mitertest.sh
@@ -73,7 +73,7 @@ set -ex
 
 ${YOSYS:-yosys} -p "read_verilog ${1}.v
                     synth_machxo2 -json ${1}.json"
-${NEXTPNR:-../../nextpnr-machxo2} $NEXTPNR_MODE --1200 --package QFN32 --no-iobs --json ${1}.json --write ${2}${1}.json
+${NEXTPNR:-../../nextpnr-machxo2} $NEXTPNR_MODE --1200 --package QFN32 --json ${1}.json --write ${2}${1}.json
 ${YOSYS:-yosys} -p "read_verilog -lib +/machxo2/cells_sim.v
                     read_json ${2}${1}.json
                     clean -purge

--- a/machxo2/examples/simple.sh
+++ b/machxo2/examples/simple.sh
@@ -26,7 +26,7 @@ set -ex
 ${YOSYS:-yosys} -p "read_verilog ${1}.v
                     synth_machxo2 -json ${1}.json
                     show -format png -prefix ${1}"
-${NEXTPNR:-../../nextpnr-machxo2} $NEXTPNR_MODE --1200 --package QFN32 --no-iobs --json ${1}.json --write ${2}${1}.json
+${NEXTPNR:-../../nextpnr-machxo2} $NEXTPNR_MODE --1200 --package QFN32 --json ${1}.json --write ${2}${1}.json
 ${YOSYS:-yosys} -p "read_verilog -lib +/machxo2/cells_sim.v
                     read_json ${2}${1}.json
                     clean -purge

--- a/machxo2/examples/simtest.sh
+++ b/machxo2/examples/simtest.sh
@@ -30,7 +30,7 @@ set -ex
 
 ${YOSYS:-yosys} -p "read_verilog ${1}.v
                     synth_machxo2 -json ${1}.json"
-${NEXTPNR:-../../nextpnr-machxo2} $NEXTPNR_MODE --1200 --package QFN32 --no-iobs --json ${1}.json --write ${2}${1}.json
+${NEXTPNR:-../../nextpnr-machxo2} $NEXTPNR_MODE --1200 --package QFN32 --json ${1}.json --write ${2}${1}.json
 ${YOSYS:-yosys} -p "read_verilog -lib +/machxo2/cells_sim.v
                     read_json ${2}${1}.json
                     clean -purge

--- a/machxo2/main.cc
+++ b/machxo2/main.cc
@@ -69,7 +69,6 @@ po::options_description MachXO2CommandHandler::getArchOptions()
 
     // specific.add_options()("lpf", po::value<std::vector<std::string>>(), "LPF pin constraint file(s)");
 
-    specific.add_options()("no-iobs", "disable automatic IO buffer insertion (unimplemented- always enabled)");
     return specific;
 }
 
@@ -108,8 +107,6 @@ std::unique_ptr<Context> MachXO2CommandHandler::createContext(dict<std::string, 
     }
 
     auto ctx = std::unique_ptr<Context>(new Context(chipArgs));
-    if (vm.count("no-iobs"))
-        ctx->settings[ctx->id("disable_iobs")] = Property::State::S1;
     return ctx;
 }
 

--- a/machxo2/pack.cc
+++ b/machxo2/pack.cc
@@ -229,16 +229,17 @@ static bool is_nextpnr_iob(Context *ctx, CellInfo *cell)
 
 static bool is_facade_iob(const Context *ctx, const CellInfo *cell) { return cell->type == id_FACADE_IO; }
 
-static bool nextpnr_iob_connects_only_facade_iob(Context *ctx, CellInfo *iob, NetInfo *&top) {
+static bool nextpnr_iob_connects_only_facade_iob(Context *ctx, CellInfo *iob, NetInfo *&top)
+{
     NPNR_ASSERT(is_nextpnr_iob(ctx, iob));
 
-    if(iob->type == ctx->id("$nextpnr_ibuf")) {
+    if (iob->type == ctx->id("$nextpnr_ibuf")) {
         NetInfo *o = iob->ports.at(id_O).net;
         top = o;
 
         CellInfo *fio = net_only_drives(ctx, o, is_facade_iob, id_PAD, true);
         return fio != nullptr;
-    } else if(iob->type == ctx->id("$nextpnr_obuf")) {
+    } else if (iob->type == ctx->id("$nextpnr_obuf")) {
         NetInfo *i = iob->ports.at(id_I).net;
         top = i;
 
@@ -249,7 +250,7 @@ static bool nextpnr_iob_connects_only_facade_iob(Context *ctx, CellInfo *iob, Ne
         // we already know that the net drives the $nextpnr_obuf.
         CellInfo *fio = net_only_drives(ctx, i, is_facade_iob, id_PAD, true, iob);
         return fio != nullptr;
-    } else if(iob->type == ctx->id("$nextpnr_iobuf")) {
+    } else if (iob->type == ctx->id("$nextpnr_iobuf")) {
         NetInfo *o = iob->ports.at(id_O).net;
         top = o;
 
@@ -281,7 +282,7 @@ static void pack_io(Context *ctx)
         if (is_nextpnr_iob(ctx, ci)) {
             NetInfo *top;
 
-            if(!nextpnr_iob_connects_only_facade_iob(ctx, ci, top))
+            if (!nextpnr_iob_connects_only_facade_iob(ctx, ci, top))
                 log_error("Top level net '%s' is not connected to a FACADE_IO PAD port.\n", top->name.c_str(ctx));
 
             if (ctx->verbose)


### PR DESCRIPTION
This PR corrects the following bugs I found in the MachXO2 backend:

* Bitstream gen has more accurate logic to work around MachXO2's "wonderful" net naming scheme.
* `nextpnr-machxo2` will now error if the detected top-level I/O ports are not attached to a `FACADE_IO` `PAD` port.
* `--no-iobs` option was removed. It was always enabled, and it was a mistake to expose it in the first place.
* `mitertest.sh` can now handle JSON containing `FACADE_IO`. The script uses a flatten pass to instantiate tristate buffer modules and remove their `inout`s, which `write_smt2` doesn't support. 
  * `uart.v` example now passes BMC w/ an SMT solver. I'm holding off on making it pass k-induction for now because I ran into a [snag](https://github.com/cr1901/yosys-experiments/tree/master/sat/dffhold) I'm not sure how to handle rn. Additionally, `uart.v` still doesn't pass w/ `yosys's` built-in SAT solver, but this is more than likely because I don't understand how the built-in SAT solver works :).
* Add MachXO2 to the list of supported archs :).