### PR TITLE
gowin: Add partnumbers and packages to the chipdb

### DIFF
--- a/.cirrus/Dockerfile.ubuntu20.04
+++ b/.cirrus/Dockerfile.ubuntu20.04
@@ -65,4 +65,4 @@ RUN set -e -x ;\
     PATH=$PATH:$HOME/.cargo/bin cargo install --path prjoxide
 
 RUN set -e -x ;\
-    pip3 install apycula==0.0.1a9
+    pip3 install apycula==0.0.1a12

--- a/gowin/arch.cc
+++ b/gowin/arch.cc
@@ -698,24 +698,38 @@ Arch::Arch(ArchArgs args) : args(args)
     if (speed == nullptr) {
         log_error("Unsuported speed grade '%s'.\n", args.speed.c_str());
     }
+
+    IdString package_name;
+    IdString device_id;
+    for (unsigned int i = 0; i < db->num_partnumbers; i++) {
+        auto partnumber = &db->partnumber_packages[i];
+        // std::cout << IdString(partnumber->name_id).str(this) << IdString(partnumber->package_id).str(this) <<
+        // std::endl;
+        if (IdString(partnumber->name_id) == id(args.partnumber)) {
+            package_name = IdString(partnumber->package_id);
+            device_id = IdString(partnumber->device_id);
+            break;
+        }
+    }
+
     const VariantPOD *variant = nullptr;
     for (unsigned int i = 0; i < db->num_variants; i++) {
         auto var = &db->variants[i];
         // std::cout << IdString(var->name_id).str(this) << std::endl;
-        if (IdString(var->name_id) == id(args.device)) {
+        if (IdString(var->name_id) == device_id) {
             variant = var;
             break;
         }
     }
     if (variant == nullptr) {
-        log_error("Unsuported device grade '%s'.\n", args.device.c_str());
+        log_error("Unsuported device grade '%s'.\n", device_id.c_str(this));
     }
 
     package = nullptr;
     for (unsigned int i = 0; i < variant->num_packages; i++) {
         auto pkg = &variant->packages[i];
         // std::cout << IdString(pkg->name_id).str(this) << std::endl;
-        if (IdString(pkg->name_id) == id(args.package)) {
+        if (IdString(pkg->name_id) == package_name) {
             package = pkg;
             break;
         }
@@ -724,8 +738,9 @@ Arch::Arch(ArchArgs args) : args(args)
         //     std::cout << IdString(pin.src_id).str(this) << " " << IdString(pin.dest_id).str(this) << std::endl;
         // }
     }
+
     if (package == nullptr) {
-        log_error("Unsuported package '%s'.\n", args.package.c_str());
+        log_error("Unsuported package '%s'.\n", package_name.c_str(this));
     }
     // setup db
     char buf[32];

--- a/gowin/arch.cc
+++ b/gowin/arch.cc
@@ -674,8 +674,12 @@ Arch::Arch(ArchArgs args) : args(args)
     // Load database
     std::string chipdb = stringf("gowin/chipdb-%s.bin", family.c_str());
     auto db = reinterpret_cast<const DatabasePOD *>(get_chipdb(chipdb));
-    if (db == nullptr)
+    if (db == nullptr) {
         log_error("Failed to load chipdb '%s'\n", chipdb.c_str());
+    }
+    if (db->version != chipdb_version) {
+        log_error("Incorrect chipdb version %u is used. Version %u is required\n", db->version, chipdb_version);
+    }
     if (db->family.get() != family) {
         log_error("Database is for family '%s' but provided device is family '%s'.\n", db->family.get(),
                   family.c_str());

--- a/gowin/arch.h
+++ b/gowin/arch.h
@@ -454,6 +454,8 @@ struct Arch : BaseArch<ArchRanges>
     bool cellsCompatible(const CellInfo **cells, int count) const;
     // start Z for the MUX2LUT5 bels
     int const mux_0_z = 10;
+    // chip db version
+    unsigned int const chipdb_version = 1;
 
     std::vector<IdString> cell_types;
 

--- a/gowin/arch.h
+++ b/gowin/arch.h
@@ -135,6 +135,7 @@ NPNR_PACKED_STRUCT(struct PartnumberPOD {
     uint32_t name_id;
     uint32_t package_id;
     uint32_t device_id;
+    uint32_t speed_id;
 });
 
 NPNR_PACKED_STRUCT(struct PackagePOD {
@@ -170,9 +171,7 @@ NPNR_PACKED_STRUCT(struct DatabasePOD {
 
 struct ArchArgs
 {
-    std::string device;
     std::string family;
-    std::string speed;
     std::string partnumber;
     // y = mx + c relationship between distance and delay for interconnect
     // delay estimates

--- a/gowin/arch.h
+++ b/gowin/arch.h
@@ -131,6 +131,12 @@ NPNR_PACKED_STRUCT(struct TimingClassPOD {
     RelPtr<TimingGroupsPOD> groups;
 });
 
+NPNR_PACKED_STRUCT(struct PartnumberPOD {
+    uint32_t name_id;
+    uint32_t package_id;
+    uint32_t device_id;
+});
+
 NPNR_PACKED_STRUCT(struct PackagePOD {
     uint32_t name_id;
     uint32_t num_pins;
@@ -153,6 +159,8 @@ NPNR_PACKED_STRUCT(struct DatabasePOD {
     RelPtr<GlobalAliasPOD> aliases;
     uint32_t num_speeds;
     RelPtr<TimingClassPOD> speeds;
+    uint32_t num_partnumbers;
+    RelPtr<PartnumberPOD> partnumber_packages;
     uint32_t num_variants;
     RelPtr<VariantPOD> variants;
     uint16_t num_constids;
@@ -165,7 +173,7 @@ struct ArchArgs
     std::string device;
     std::string family;
     std::string speed;
-    std::string package;
+    std::string partnumber;
     // y = mx + c relationship between distance and delay for interconnect
     // delay estimates
     double delayScale = 0.4, delayOffset = 0.4;

--- a/gowin/main.cc
+++ b/gowin/main.cc
@@ -73,7 +73,7 @@ std::unique_ptr<Context> GowinCommandHandler::createContext(dict<std::string, Pr
         snprintf(buf, 36, "GW1N-%s", match[3].str().c_str());
     }
     chipArgs.family = buf;
-    chipArgs.package = match[5];
+    chipArgs.partnumber = match[0];
     chipArgs.speed = match[6];
     return std::unique_ptr<Context>(new Context(chipArgs));
 }

--- a/gowin/main.cc
+++ b/gowin/main.cc
@@ -54,7 +54,7 @@ po::options_description GowinCommandHandler::getArchOptions()
 
 std::unique_ptr<Context> GowinCommandHandler::createContext(dict<std::string, Property> &values)
 {
-    std::regex devicere = std::regex("GW1N([A-Z]*)-(LV|UV|UX)([0-9])(C?)([A-Z]{2}[0-9]+)(C[0-9]/I[0-9])");
+    std::regex devicere = std::regex("GW1N([A-Z]*)-(LV|UV|UX)([0-9])(C?).*");
     std::smatch match;
     std::string device = vm["device"].as<std::string>();
     if (!std::regex_match(device, match, devicere)) {
@@ -62,8 +62,6 @@ std::unique_ptr<Context> GowinCommandHandler::createContext(dict<std::string, Pr
     }
     ArchArgs chipArgs;
     char buf[36];
-    snprintf(buf, 36, "GW1N%s-%s%s", match[1].str().c_str(), match[3].str().c_str(), match[4].str().c_str());
-    chipArgs.device = buf;
     // GW1N and GW1NR variants share the same database.
     // Most Gowin devices are a System in Package with some SDRAM wirebonded to a GPIO bank.
     // However, it appears that the S series with embedded ARM core are unique silicon.
@@ -74,7 +72,6 @@ std::unique_ptr<Context> GowinCommandHandler::createContext(dict<std::string, Pr
     }
     chipArgs.family = buf;
     chipArgs.partnumber = match[0];
-    chipArgs.speed = match[6];
     return std::unique_ptr<Context>(new Context(chipArgs));
 }
 


### PR DESCRIPTION
Instead of parsing the partnumber with a regular expression, a simple table is used. This is done because the structure of the partnumber changes as new features appear (e.g., ES instead of C6/I5)