### PR TITLE
common: Improved the random seed initialisation for the context

### DIFF
--- a/common/command.cc
+++ b/common/command.cc
@@ -33,6 +33,7 @@
 #include <boost/program_options.hpp>
 #include <fstream>
 #include <iostream>
+#include <random>
 #include "command.h"
 #include "design_utils.h"
 #include "json_frontend.h"
@@ -223,12 +224,9 @@ void CommandHandler::setupContext(Context *ctx)
     }
 
     if (vm.count("randomize-seed")) {
-        srand(time(NULL));
-        int r;
-        do {
-            r = rand();
-        } while (r == 0);
-        ctx->rngseed(r);
+        std::random_device randDev{};
+        std::uniform_int_distribution<int> distrib{1};
+        ctx->rngseed(distrib(randDev));
     }
 
     if (vm.count("slack_redist_iter")) {


### PR DESCRIPTION
The method for randomisation initialisation used in nextpnr at present has been deprecated because of several extreme issues with it for some time now (for example, some implementations of rand() have near unchanging low bits, resulting in very predicable values).

This patch replaces that bad C code with modern C++11 `<random>` header based code.