### PR TITLE
nexus: LUT and FF clustering

### DIFF
--- a/nexus/main.cc
+++ b/nexus/main.cc
@@ -52,6 +52,7 @@ po::options_description NexusCommandHandler::getArchOptions()
     specific.add_options()("pdc", po::value<std::string>(), "physical constraints file");
     specific.add_options()("no-post-place-opt", "disable post-place repacking (debugging use only)");
     specific.add_options()("no-pack-lutff", "disable packing (clustering) LUTs and FFs together");
+    specific.add_options()("carry-lutff-ratio", po::value<float>(), "ratio of FFs to be added to carry-chain LUT clusters");
 
     return specific;
 }
@@ -79,6 +80,13 @@ std::unique_ptr<Context> NexusCommandHandler::createContext(dict<std::string, Pr
         ctx->settings[ctx->id("no_post_place_opt")] = Property::State::S1;
     if (vm.count("no-pack-lutff"))
         ctx->settings[ctx->id("no_pack_lutff")] = Property::State::S1;
+    if (vm.count("carry-lutff-ratio")) {
+        float ratio = vm["carry-lutff-ratio"].as<float>();
+        if (ratio < 0.0f || ratio > 1.0f) {
+            log_error("Carry LUT+FF packing ration must be between 0.0 and 1.0");
+        }
+        ctx->settings[ctx->id("carry_lutff_ratio")] = ratio;
+    }
     return ctx;
 }
 

--- a/nexus/main.cc
+++ b/nexus/main.cc
@@ -51,6 +51,7 @@ po::options_description NexusCommandHandler::getArchOptions()
     specific.add_options()("fasm", po::value<std::string>(), "fasm file to write");
     specific.add_options()("pdc", po::value<std::string>(), "physical constraints file");
     specific.add_options()("no-post-place-opt", "disable post-place repacking (debugging use only)");
+    specific.add_options()("no-pack-lutff", "disable packing (clustering) LUTs and FFs together");
 
     return specific;
 }
@@ -76,6 +77,8 @@ std::unique_ptr<Context> NexusCommandHandler::createContext(dict<std::string, Pr
     auto ctx = std::unique_ptr<Context>(new Context(chipArgs));
     if (vm.count("no-post-place-opt"))
         ctx->settings[ctx->id("no_post_place_opt")] = Property::State::S1;
+    if (vm.count("no-pack-lutff"))
+        ctx->settings[ctx->id("no_pack_lutff")] = Property::State::S1;
     return ctx;
 }
 

--- a/nexus/pack.cc
+++ b/nexus/pack.cc
@@ -2395,7 +2395,11 @@ struct NexusPacker
         pack_luts();
         pack_ip();
         handle_iologic();
-        pack_lutffs();
+
+        if (!bool_or_default(ctx->settings, ctx->id("no_pack_lutff"))) {
+            pack_lutffs();
+        }
+
         promote_globals();
         place_globals();
         generate_constraints();


### PR DESCRIPTION
This PR adds to the nexus architecture inference of directly connected LUT+FF pairs followed by clustering them together.

For each directly connected LUT and FF nextpnr now creates a new cluster. Moreover it glues FFs to existing clusters comprised of LUTs like wide LUTs and carry-chains.

The new behavior is enabled by default but can be disabled by the `--no-pack-lutff` option. Another option `--carry-lutff-ratio` allows to specify a ratio of clustering together FFs and LUTs which are part of carry-chains.

The added clustering approach has been analyzed on a single design (the SoC from https://chromium.googlesource.com/chromiumos/platform/hps-firmware) targeting LIFCL-17 FPGA using 500 chosen seeds. A timeout of 5min was set for each run so that when it expired a run was considered a failure. The conclusions are the following:

- median runtime was reduced to ~78% of the original,
- 99% of the runs succeeded instead of 88.2% for without clustering,
- 16.0% runs met timing instead of 0.6% for without clustering,
- median router iteration count dropped to 67 from 103.

The following two charts show router2 progression in terms of overused wire count vs. iteration count. Each trace is terminated either with a green circle (indicating a success) or a red "x" (indicating a failure). Plots are clipped to 200 iterations for better clarity.

No clustering:
![no-clustering](https://user-images.githubusercontent.com/47315577/142894384-9dcebc97-872b-40ac-b0d0-0d391be4c1d3.png)

With clustering:
![with-clustering](https://user-images.githubusercontent.com/47315577/142894408-5b5ab4aa-7c47-4322-afb5-68b38578dbb6.png)

I'm also attaching CSV files with the gathered statistical results:
[no-clustering.csv](https://github.com/YosysHQ/nextpnr/files/7582536/no-clustering.csv)
[with-clustering.csv](https://github.com/YosysHQ/nextpnr/files/7582537/with-clustering.csv)

As it can be seen in the pictures with the LUT and FF clustering enabled the router is able to converge much quicker and gets stuck more rarely.

The option to specify clustering ratio for FFs and existing carry-chain clusters is meant to mitigate situations when placement of such large clusters of fully populated slices cannot be legalized.