### PR TITLE
Improvements to ecp5 router speed

### DIFF
--- a/common/router1.cc
+++ b/common/router1.cc
@@ -108,7 +108,6 @@ struct Router1
     dict<arc_key, pool<WireId>> arc_to_wires;
     pool<arc_key> queued_arcs;
 
-    dict<WireId, QueuedWire> visited;
     std::priority_queue<QueuedWire, std::vector<QueuedWire>, QueuedWire::Greater> queue;
 
     dict<WireId, int> wireScores;
@@ -503,7 +502,7 @@ struct Router1
             std::priority_queue<QueuedWire, std::vector<QueuedWire>, QueuedWire::Greater> new_queue;
             queue.swap(new_queue);
         }
-        visited.clear();
+        dict<WireId, QueuedWire> visited;
 
         // A* main loop
 

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -123,6 +123,27 @@ Arch::Arch(ArchArgs args) : args(args)
         y_ids.push_back(y_id);
         id_to_y[y_id] = i;
     }
+
+    wire_tile_vecidx.resize(chip_info->num_tiles, -1);
+    int n_wires = 0;
+    for (auto e : getWires()) {
+        if (e.index == 0) {
+            wire_tile_vecidx.at(e.location.y * chip_info->width + e.location.x) = n_wires;
+        }
+        n_wires++;
+    }
+    wire2net.resize(n_wires, nullptr);
+    wire_fanout.resize(n_wires, 0);
+
+    pip_tile_vecidx.resize(chip_info->num_tiles, -1);
+    int n_pips = 0;
+    for (auto e : getPips()) {
+        if (e.index == 0) {
+            pip_tile_vecidx.at(e.location.y * chip_info->width + e.location.x) = n_pips;
+        }
+        n_pips++;
+    }
+    pip2net.resize(n_pips, nullptr);
 }
 
 // -----------------------------------------------------------------------

--- a/ecp5/archdefs.h
+++ b/ecp5/archdefs.h
@@ -156,6 +156,8 @@ struct ArchNetInfo
 
 typedef IdString ClusterId;
 
+struct NetInfo;
+
 struct ArchCellInfo : BaseClusterInfo
 {
     struct


### PR DESCRIPTION
With these two changes I see a roughly 3x speedup in router1 time, ~550 seconds to 180 secs (on a i5-1145G7 laptop). The vector change is the main improvement.

I've been testing with a build of [microwatt for orangecrab](https://github.com/mkj/microwatt).
`nextpnr-ecp5 --json microwatt-placed.json --no-pack --no-place --lpf constraints/orange-crab-0.2.lpf --textcfg microwatt_out.config.tmp --85k --freq 48 --speed 8 --write microwatt-routed.json --timing-allow-fail --ignore-loops --package CSFBGA285 `
Input files
 [microwatt-placed-bench.json](https://matt.ucc.asn.au/p/microwatt-placed-bench.json) 
[orange-crab-0.2.lpf](https://matt.ucc.asn.au/p/orange-crab-0.2.lpf)
([microwatt-bench.json](https://matt.ucc.asn.au/p/microwatt-bench.json) as input for pack and place)