### PR TITLE
mistral: DATAIN and DATAOUT of GPIO have swapped

### DIFF
--- a/.github/workflows/mistral_ci.yml
+++ b/.github/workflows/mistral_ci.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Execute build nextpnr
       env:
         MISTRAL_PATH: ${{ github.workspace }}/deps/mistral
-        MISTRAL_REVISION: ecd413421b3b559fc63db13da30275fcd5cd3881
+        MISTRAL_REVISION: 0edeca112dda9bd463125feb869ddb7511d1acd9
       run: |
         source ./.github/ci/build_mistral.sh
         get_dependencies

--- a/mistral/io.cc
+++ b/mistral/io.cc
@@ -31,9 +31,9 @@ void Arch::create_gpio(int x, int y)
         BelId bel = add_bel(x, y, id(stringf("IO[%d]", z)), id_MISTRAL_IO);
         add_bel_pin(bel, id_PAD, PORT_INOUT, pad);
         // FIXME: is the port index of zero always correct?
-        add_bel_pin(bel, id_I, PORT_IN, get_port(CycloneV::GPIO, x, y, z, CycloneV::DATAIN, 0));
+        add_bel_pin(bel, id_I, PORT_IN, get_port(CycloneV::GPIO, x, y, z, CycloneV::DATAOUT, 0));
         add_bel_pin(bel, id_OE, PORT_IN, get_port(CycloneV::GPIO, x, y, z, CycloneV::OEIN, 0));
-        add_bel_pin(bel, id_O, PORT_OUT, get_port(CycloneV::GPIO, x, y, z, CycloneV::DATAOUT, 0));
+        add_bel_pin(bel, id_O, PORT_OUT, get_port(CycloneV::GPIO, x, y, z, CycloneV::DATAIN, 0));
         bel_data(bel).block_index = z;
     }
 }


### PR DESCRIPTION
Signed-off-by: gatecat <gatecat@ds0.me>