### PR TITLE
ecp5: LUT permutation support

### DIFF
--- a/.cirrus/Dockerfile.ubuntu20.04
+++ b/.cirrus/Dockerfile.ubuntu20.04
@@ -48,7 +48,7 @@ RUN set -e -x ;\
     cd /usr/local/src ;\
     git clone --recursive https://github.com/YosysHQ/prjtrellis.git ;\
     cd prjtrellis ;\
-    git reset --hard 210a0a72757d57b278ac7397ae6b14729f149b10 ;\
+    git reset --hard 7239331d5463321d4864164f320beef67310f1e5 ;\
     cd libtrellis ;\
     cmake . ;\
     make -j $(nproc) ;\

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -144,6 +144,8 @@ Arch::Arch(ArchArgs args) : args(args)
         n_pips++;
     }
     pip2net.resize(n_pips, nullptr);
+
+    lutperm_allowed.resize(chip_info->width * chip_info->height * 4);
 }
 
 // -----------------------------------------------------------------------
@@ -624,6 +626,8 @@ bool Arch::place()
 bool Arch::route()
 {
     std::string router = str_or_default(settings, id("router"), defaultRouter);
+
+    disable_router_lutperm = getCtx()->setting<bool>("arch.disable_router_lutperm", false);
 
     setup_wire_locations();
     route_ecp5_globals(getCtx());

--- a/ecp5/archdefs.h
+++ b/ecp5/archdefs.h
@@ -165,6 +165,7 @@ struct ArchCellInfo : BaseClusterInfo
         bool using_dff;
         bool has_l6mux;
         bool is_carry;
+        bool is_memory;
         IdString clk_sig, lsr_sig, clkmux, lsrmux, srmode;
         int sd0, sd1;
     } sliceInfo;

--- a/ecp5/main.cc
+++ b/ecp5/main.cc
@@ -85,6 +85,7 @@ po::options_description ECP5CommandHandler::getArchOptions()
     specific.add_options()(
             "out-of-context",
             "disable IO buffer insertion and global promotion/routing, for building pre-routed blocks (experimental)");
+    specific.add_options()("disable-router-lutperm", "don't allow the router to permute LUT inputs");
 
     return specific;
 }
@@ -255,6 +256,8 @@ std::unique_ptr<Context> ECP5CommandHandler::createContext(dict<std::string, Pro
     ctx->settings[ctx->id("arch.speed")] = speedString(ctx->archArgs().speed);
     if (vm.count("out-of-context"))
         ctx->settings[ctx->id("arch.ooc")] = 1;
+    if (vm.count("disable-router-lutperm"))
+        ctx->settings[ctx->id("arch.disable_router_lutperm")] = 1;
     return ctx;
 }
 

--- a/ecp5/pack.cc
+++ b/ecp5/pack.cc
@@ -3253,7 +3253,9 @@ void Arch::assignArchInfo()
             ci->sliceInfo.clkmux = id(str_or_default(ci->params, id_CLKMUX, "CLK"));
             ci->sliceInfo.lsrmux = id(str_or_default(ci->params, id_LSRMUX, "LSR"));
             ci->sliceInfo.srmode = id(str_or_default(ci->params, id_SRMODE, "LSR_OVER_CE"));
-            ci->sliceInfo.is_carry = str_or_default(ci->params, id("MODE"), "LOGIC") == "CCU2";
+            std::string mode = str_or_default(ci->params, id("MODE"), "LOGIC");
+            ci->sliceInfo.is_carry = (mode == "CCU2");
+            ci->sliceInfo.is_memory = (mode == "DPRAM" || mode == "RAMW");
             ci->sliceInfo.sd0 = std::stoi(str_or_default(ci->params, id("REG0_SD"), "0"));
             ci->sliceInfo.sd1 = std::stoi(str_or_default(ci->params, id("REG1_SD"), "0"));
             ci->sliceInfo.has_l6mux = false;

--- a/ecp5/trellis_import.py
+++ b/ecp5/trellis_import.py
@@ -426,6 +426,8 @@ def write_database(dev_name, chip, ddrg, endianness):
                 if cls == 1 and "PCS" in snk_name or "DCU" in snk_name or "DCU" in src_name:
                    cls = 2
                 bba.u8(cls, "pip_type")
+                bba.u16(arc.lutperm_flags, "lutperm_flags")
+                bba.u16(0, "padding")
         if len(loctype.wires) > 0:
             for wire_idx in range(len(loctype.wires)):
                 wire = loctype.wires[wire_idx]
@@ -623,7 +625,7 @@ def main():
     # print("Initialising chip...")
     chip = pytrellis.Chip(dev_names[args.device])
     # print("Building routing graph...")
-    ddrg = pytrellis.make_dedup_chipdb(chip)
+    ddrg = pytrellis.make_dedup_chipdb(chip, include_lutperm_pips=True)
     max_row = chip.get_max_row()
     max_col = chip.get_max_col()
     process_timing_data()


### PR DESCRIPTION
This enables the router to permute LUT inputs to improve routeability. Although this gets a big route time speedup on congested designs; it does seem to come with possible small Fmax cost on some low-congestion designs as the previous criticality-driven permute no longer takes effect (this could probably be fixed by having a router that was better at taking timing into account...)

Requires https://github.com/YosysHQ/prjtrellis/pull/181