### PR TITLE
nexus: router1 speedup based on #867

### DIFF
--- a/nexus/arch.cc
+++ b/nexus/arch.cc
@@ -119,6 +119,9 @@ Arch::Arch(ArchArgs args) : args(args)
             ts.bels_by_z[bel.z].tile = i;
             ts.bels_by_z[bel.z].index = j;
         }
+        auto &ts = tileStatus.at(i);
+        ts.boundwires.resize(loc.wires.size());
+        ts.boundpips.resize(loc.pips.size());
     }
 
     for (int i = 0; i < chip_info->width; i++) {


### PR DESCRIPTION
This uses a set of data structures based on #867 to speed up the nexus router1 runtime

cc @tcal-x; as you are using router1 for congested designs the runtime speedup from this might be of interest to you