### PR TITLE
gowin: Add simplified IO cells processing

### DIFF
--- a/gowin/arch.cc
+++ b/gowin/arch.cc
@@ -870,6 +870,39 @@ Arch::Arch(ArchArgs args) : args(args)
                 snprintf(buf, 32, "R%dC%d_%s", row + 1, col + 1, portname.c_str(this));
                 addBelInput(belname, id_OEN, id(buf));
                 break;
+                // Simplified IO
+            case ID_IOBJS:
+                z++; /* fall-through*/
+            case ID_IOBIS:
+                z++; /* fall-through*/
+            case ID_IOBHS:
+                z++; /* fall-through*/
+            case ID_IOBGS:
+                z++; /* fall-through*/
+            case ID_IOBFS:
+                z++; /* fall-through*/
+            case ID_IOBES:
+                z++; /* fall-through*/
+            case ID_IOBDS:
+                z++; /* fall-through*/
+            case ID_IOBCS:
+                z++; /* fall-through*/
+            case ID_IOBBS:
+                z++; /* fall-through*/
+            case ID_IOBAS:
+                snprintf(buf, 32, "R%dC%d_IOB%c", row + 1, col + 1, 'A' + z);
+                belname = id(buf);
+                addBel(belname, id_IOBS, Loc(col, row, z), false);
+                portname = IdString(pairLookup(bel->ports.get(), bel->num_ports, ID_O)->src_id);
+                snprintf(buf, 32, "R%dC%d_%s", row + 1, col + 1, portname.c_str(this));
+                addBelOutput(belname, id_O, id(buf));
+                portname = IdString(pairLookup(bel->ports.get(), bel->num_ports, ID_I)->src_id);
+                snprintf(buf, 32, "R%dC%d_%s", row + 1, col + 1, portname.c_str(this));
+                addBelInput(belname, id_I, id(buf));
+                portname = IdString(pairLookup(bel->ports.get(), bel->num_ports, ID_OE)->src_id);
+                snprintf(buf, 32, "R%dC%d_%s", row + 1, col + 1, portname.c_str(this));
+                addBelInput(belname, id_OEN, id(buf));
+                break;
 
             default:
                 break;

--- a/gowin/constids.inc
+++ b/gowin/constids.inc
@@ -358,6 +358,19 @@ X(IOBH)
 X(IOBI)
 X(IOBJ)
 
+// simplified iobs
+X(IOBS)
+X(IOBAS)
+X(IOBBS)
+X(IOBCS)
+X(IOBDS)
+X(IOBES)
+X(IOBFS)
+X(IOBGS)
+X(IOBHS)
+X(IOBIS)
+X(IOBJS)
+
 // Wide LUTs
 X(MUX2_LUT5)
 X(MUX2_LUT6)


### PR DESCRIPTION
Some models have I/O cells that are IOBUFs, and other types (IBUFs and
OBUFs) are obtained by feeding 1 or 0 to the OEN input.  This is done
with general-purpose routing so it's best to do it here to avoid
conflicts.

For this purpose, in the new bases, these special cells are of type IOBS
(IOB Simplified).

The proposed changes are compatible with bases of previous versions of
Apycula and do not require changing .CST constraint files.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>