### PR TITLE
nexus: handle SLEWRATE in pdc

### DIFF
--- a/nexus/constids.inc
+++ b/nexus/constids.inc
@@ -109,6 +109,7 @@ X(CIB_T)
 X(CIB_LR)
 
 X(IO_TYPE)
+X(SLEWRATE)
 
 
 X(OSCA)

--- a/nexus/fasm.cc
+++ b/nexus/fasm.cc
@@ -433,7 +433,7 @@ struct NexusFasmWriter
         write_bit(stringf("BASE_TYPE.%s_%s", iodir, str_or_default(cell->attrs, id_IO_TYPE, "LVCMOS33").c_str()));
         write_ioattr(cell, "PULLMODE", "NONE");
         write_ioattr(cell, "GLITCHFILTER", "OFF");
-        write_ioattr(cell, "SLEWRATE", "MED");
+        write_ioattr(cell, "SLEWRATE", str_or_default(cell->attrs, id_SLEWRATE, "MED").c_str());
         write_cell_muxes(cell);
         pop();
     }
@@ -458,7 +458,7 @@ struct NexusFasmWriter
         const char *iodir = is_input ? "INPUT" : (is_output ? "OUTPUT" : "BIDIR");
         write_bit(stringf("BASE_TYPE.%s_%s", iodir, str_or_default(cell->attrs, id_IO_TYPE, "LVCMOS18H").c_str()));
         write_ioattr(cell, "PULLMODE", "NONE");
-        write_ioattr(cell, "SLEWRATE", "MED");
+        write_ioattr(cell, "SLEWRATE", str_or_default(cell->attrs, id_SLEWRATE, "MED").c_str());
         pop();
         write_cell_muxes(cell);
         pop();

--- a/nexus/pdc.cc
+++ b/nexus/pdc.cc
@@ -21,6 +21,7 @@
 #include "log.h"
 #include "nextpnr.h"
 
+#include <algorithm>
 #include <iterator>
 
 NEXTPNR_NAMESPACE_BEGIN
@@ -423,6 +424,12 @@ struct PDCParser
                         if (eqp == std::string::npos)
                             log_error("expected key-value pair separated by '=' (line %d)", lineno);
                         std::string k = kv.substr(0, eqp), v = kv.substr(eqp + 1);
+                        if (k == "SLEWRATE") {
+                            std::vector<std::string> slewrate_allowed = {"SLOW", "MED", "FAST", "NA"};
+                            if (std::find(std::begin(slewrate_allowed), std::end(slewrate_allowed), v) ==
+                                std::end(slewrate_allowed))
+                                log_error("unexpected SLEWRATE configuration %s (line %d)\n", v.c_str(), lineno);
+                        }
                         args[ctx->id(k)] = v;
                     }
                 } else {


### PR DESCRIPTION
This PR adds possibility to provide `SLEWRATE` for nexus in PDC. This can be done with e.g:

```
ldc_set_port -iobuf {SLEWRATE=FAST} [get_ports my_awesome_port]
```
If not provided, the value is set to `MED` 