### PR TITLE
gowin: Initializing the grid dimensions

### DIFF
--- a/gowin/arch.h
+++ b/gowin/arch.h
@@ -298,7 +298,7 @@ struct Arch : BaseArch<ArchRanges>
 
     dict<DecalId, std::vector<GraphicElement>> decal_graphics;
 
-    int gridDimX, gridDimY;
+    int gridDimX = 0, gridDimY = 0;
     std::vector<std::vector<int>> tileBelDimZ;
     std::vector<std::vector<int>> tilePipDimZ;
 


### PR DESCRIPTION
gridDimX and gridDimY are not initialized explicitly, which leads to
effects when the design is reloaded, say, from the GUI.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>