### PR TITLE
generic: Refactor for faster performance

### DIFF
--- a/common/pywrappers.h
+++ b/common/pywrappers.h
@@ -257,7 +257,7 @@ template <typename Class, typename FuncT, FuncT fn, typename arg1_conv> struct f
     {
         Context *ctx = get_ctx<Class>(cls);
         Class &base = get_base<Class>(cls);
-        return (base.*fn)(arg1_conv()(ctx, arg1));
+        (base.*fn)(arg1_conv()(ctx, arg1));
     }
 
     template <typename WrapCls> static void def_wrap(WrapCls cls_, const char *name) { cls_.def(name, wrapped_fn); }
@@ -280,7 +280,7 @@ template <typename Class, typename FuncT, FuncT fn, typename arg1_conv, typename
     {
         Context *ctx = get_ctx<Class>(cls);
         Class &base = get_base<Class>(cls);
-        return (base.*fn)(arg1_conv()(ctx, arg1), arg2_conv()(ctx, arg2));
+        (base.*fn)(arg1_conv()(ctx, arg1), arg2_conv()(ctx, arg2));
     }
 
     template <typename WrapCls> static void def_wrap(WrapCls cls_, const char *name) { cls_.def(name, wrapped_fn); }
@@ -304,7 +304,7 @@ struct fn_wrapper_3a_v
     {
         Context *ctx = get_ctx<Class>(cls);
         Class &base = get_base<Class>(cls);
-        return (base.*fn)(arg1_conv()(ctx, arg1), arg2_conv()(ctx, arg2), arg3_conv()(ctx, arg3));
+        (base.*fn)(arg1_conv()(ctx, arg1), arg2_conv()(ctx, arg2), arg3_conv()(ctx, arg3));
     }
 
     template <typename WrapCls> static void def_wrap(WrapCls cls_, const char *name) { cls_.def(name, wrapped_fn); }
@@ -331,8 +331,7 @@ struct fn_wrapper_4a_v
     {
         Context *ctx = get_ctx<Class>(cls);
         Class &base = get_base<Class>(cls);
-        return (base.*fn)(arg1_conv()(ctx, arg1), arg2_conv()(ctx, arg2), arg3_conv()(ctx, arg3),
-                          arg4_conv()(ctx, arg4));
+        (base.*fn)(arg1_conv()(ctx, arg1), arg2_conv()(ctx, arg2), arg3_conv()(ctx, arg3), arg4_conv()(ctx, arg4));
     }
 
     template <typename WrapCls> static void def_wrap(WrapCls cls_, const char *name) { cls_.def(name, wrapped_fn); }
@@ -360,8 +359,8 @@ struct fn_wrapper_5a_v
     {
         Context *ctx = get_ctx<Class>(cls);
         Class &base = get_base<Class>(cls);
-        return (base.*fn)(arg1_conv()(ctx, arg1), arg2_conv()(ctx, arg2), arg3_conv()(ctx, arg3),
-                          arg4_conv()(ctx, arg4), arg5_conv()(ctx, arg5));
+        (base.*fn)(arg1_conv()(ctx, arg1), arg2_conv()(ctx, arg2), arg3_conv()(ctx, arg3), arg4_conv()(ctx, arg4),
+                   arg5_conv()(ctx, arg5));
     }
 
     template <typename WrapCls> static void def_wrap(WrapCls cls_, const char *name) { cls_.def(name, wrapped_fn); }
@@ -390,8 +389,8 @@ struct fn_wrapper_6a_v
     {
         Context *ctx = get_ctx<Class>(cls);
         Class &base = get_base<Class>(cls);
-        return (base.*fn)(arg1_conv()(ctx, arg1), arg2_conv()(ctx, arg2), arg3_conv()(ctx, arg3),
-                          arg4_conv()(ctx, arg4), arg5_conv()(ctx, arg5), arg6_conv()(ctx, arg6));
+        (base.*fn)(arg1_conv()(ctx, arg1), arg2_conv()(ctx, arg2), arg3_conv()(ctx, arg3), arg4_conv()(ctx, arg4),
+                   arg5_conv()(ctx, arg5), arg6_conv()(ctx, arg6));
     }
 
     template <typename WrapCls> static void def_wrap(WrapCls cls_, const char *name) { cls_.def(name, wrapped_fn); }

--- a/docs/generic.md
+++ b/docs/generic.md
@@ -12,35 +12,42 @@ will be worked on in the future.
 
 ## Python API
 
-All identifiers (`IdString`) are automatically converted to
-and from a Python string, so no manual conversion is required.
+All identifiers (`IdString`, `IdStringList`, `WireId`, `PipId`, and `BelId`) are
+automatically converted to and from a Python string, so no manual conversion is
+required.
+
+`IdStringList`s will be most efficient if strings can be split according to a
+separator (currently fixed to `/`), as only the components need be stored 
+in-memory. For example; instead of needing to store an entire pip name
+`X33/Y45/V4A_TO_A6` which scales badly for large numbers of pips; the strings
+`X33`, `Y45` and `V4A_TO_A6` are stored.
 
 Argument names are included in the Python bindings,
 so named arguments may be used.
 
-### void addWire(IdString name, IdString type, int x, int y);
+### void addWire(IdStringList name, IdString type, int x, int y);
 
 Adds a wire with a name, type (for user purposes only, ignored by all nextpnr code other than the UI) to the FPGA description. x and y give a nominal location of the wire for delay estimation purposes. Delay estimates are important for router performance (as the router uses an A* type algorithm), even if timing is not of importance.
 
-### addPip(IdString name, IdString type, IdString srcWire, IdString dstWire, float delay, Loc loc);
+### addPip(IdStringList name, IdString type, WireId srcWire, WireId dstWire, float delay, Loc loc);
 
 Adds a pip (programmable connection between two named wires). Pip delays that correspond to delay estimates are important for router performance (as the router uses an A* type algorithm), even if timing is otherwise not of importance.
 
 Loc is constructed using `Loc(x, y, z)`. 'z' for pips is only important if region constraints (e.g. for partial reconfiguration regions) are used.
 
-### void addBel(IdString name, IdString type, Loc loc, bool gb, bool hidden);
+### void addBel(IdStringList name, IdString type, Loc loc, bool gb, bool hidden);
 
 Adds a bel to the FPGA description. Bel type should match the type of cells in the netlist that are placed at this bel (see below for information on special bel types supported by the packer). Loc is constructed using `Loc(x, y, z)` and must be unique. If `hidden` is true, then the bel will not be included in utilisation reports (e.g. for routing/internal use bels).
 
-### void addBelInput(IdString bel, IdString name, IdString wire);
-### void addBelOutput(IdString bel, IdString name, IdString wire);
-### void addBelInout(IdString bel, IdString name, IdString wire);
+### void addBelInput(BelId bel, IdString name, WireId wire);
+### void addBelOutput(BelId bel, IdString name, WireId wire);
+### void addBelInout(BelId bel, IdString name, WireId wire);
 
 Adds an input, output or inout pin to a bel, with an associated wire. Note that both `bel` and `wire` must have been created before calling this function.
 
-### void addGroupBel(IdString group, IdString bel);
-### void addGroupWire(IdString group, IdString wire);
-### void addGroupPip(IdString group, IdString pip);
+### void addGroupBel(IdString group, BelId bel);
+### void addGroupWire(IdString group, WireId wire);
+### void addGroupPip(IdString group, PipId pip);
 ### void addGroupGroup(IdString group, IdString grp);
 
 Add a bel, wire, pip or subgroup to a group, which will be created if it doesn't already exist. Groups are purely for visual presentation purposes in the user interface and are not used by any place-and-route algorithms.
@@ -56,9 +63,9 @@ Add a graphic element to a _decal_, a reusable drawing that may be used to repre
 
 Sets the decal ID and offset for a wire, bel, pip or group in the UI.
 
-### void setWireAttr(IdString wire, IdString key, const std::string &value);
-### void setPipAttr(IdString pip, IdString key, const std::string &value);
-### void setBelAttr(IdString bel, IdString key, const std::string &value);
+### void setWireAttr(WireId wire, IdString key, const std::string &value);
+### void setPipAttr(PipId pip, IdString key, const std::string &value);
+### void setBelAttr(BelId bel, IdString key, const std::string &value);
 
 Sets an attribute on a wire, pip or bel. Attributes are displayed in the tree view in the UI, but have no bearing on place-and-route itself.
 

--- a/generic/arch_pybindings.cc
+++ b/generic/arch_pybindings.cc
@@ -42,6 +42,10 @@ void arch_wrap_python(py::module &m)
 {
     using namespace PythonConversion;
 
+    typedef linear_range<BelId> BelRange;
+    typedef linear_range<WireId> WireRange;
+    typedef linear_range<PipId> AllPipRange;
+
     auto arch_cls = py::class_<Arch, BaseCtx>(m, "Arch").def(py::init<ArchArgs>());
 
     auto dxy_cls = py::class_<ContextualWrapper<DecalXY>>(m, "DecalXY_");
@@ -74,8 +78,8 @@ void arch_wrap_python(py::module &m)
                   conv_from_str<BelId>>::def_wrap(ctx_cls, "getBoundBelCell");
     fn_wrapper_1a<Context, decltype(&Context::getConflictingBelCell), &Context::getConflictingBelCell,
                   deref_and_wrap<CellInfo>, conv_from_str<BelId>>::def_wrap(ctx_cls, "getConflictingBelCell");
-    fn_wrapper_0a<Context, decltype(&Context::getBels), &Context::getBels,
-                  wrap_context<const std::vector<BelId> &>>::def_wrap(ctx_cls, "getBels");
+    fn_wrapper_0a<Context, decltype(&Context::getBels), &Context::getBels, wrap_context<BelRange>>::def_wrap(ctx_cls,
+                                                                                                             "getBels");
 
     fn_wrapper_2a<Context, decltype(&Context::getBelPinWire), &Context::getBelPinWire, conv_to_str<WireId>,
                   conv_from_str<BelId>, conv_from_str<IdString>>::def_wrap(ctx_cls, "getBelPinWire");
@@ -96,11 +100,11 @@ void arch_wrap_python(py::module &m)
     fn_wrapper_1a<Context, decltype(&Context::getConflictingWireNet), &Context::getConflictingWireNet,
                   deref_and_wrap<NetInfo>, conv_from_str<WireId>>::def_wrap(ctx_cls, "getConflictingWireNet");
 
-    fn_wrapper_0a<Context, decltype(&Context::getWires), &Context::getWires,
-                  wrap_context<const std::vector<WireId> &>>::def_wrap(ctx_cls, "getWires");
+    fn_wrapper_0a<Context, decltype(&Context::getWires), &Context::getWires, wrap_context<WireRange>>::def_wrap(
+            ctx_cls, "getWires");
 
-    fn_wrapper_0a<Context, decltype(&Context::getPips), &Context::getPips,
-                  wrap_context<const std::vector<PipId> &>>::def_wrap(ctx_cls, "getPips");
+    fn_wrapper_0a<Context, decltype(&Context::getPips), &Context::getPips, wrap_context<AllPipRange>>::def_wrap(
+            ctx_cls, "getPips");
     fn_wrapper_1a<Context, decltype(&Context::getPipChecksum), &Context::getPipChecksum, pass_through<uint32_t>,
                   conv_from_str<PipId>>::def_wrap(ctx_cls, "getPipChecksum");
     fn_wrapper_3a_v<Context, decltype(&Context::bindPip), &Context::bindPip, conv_from_str<PipId>,
@@ -156,50 +160,50 @@ void arch_wrap_python(py::module &m)
                                                                                              "name"_a, "type"_a, "x"_a,
                                                                                              "y"_a);
     fn_wrapper_6a_v<Context, decltype(&Context::addPip), &Context::addPip, conv_from_str<IdStringList>,
-                    conv_from_str<IdString>, conv_from_str<IdStringList>, conv_from_str<IdStringList>,
-                    pass_through<delay_t>, pass_through<Loc>>::def_wrap(ctx_cls, "addPip", "name"_a, "type"_a,
-                                                                        "srcWire"_a, "dstWire"_a, "delay"_a, "loc"_a);
+                    conv_from_str<IdString>, conv_from_str<WireId>, conv_from_str<WireId>, pass_through<delay_t>,
+                    pass_through<Loc>>::def_wrap(ctx_cls, "addPip", "name"_a, "type"_a, "srcWire"_a, "dstWire"_a,
+                                                 "delay"_a, "loc"_a);
 
     fn_wrapper_5a_v<Context, decltype(&Context::addBel), &Context::addBel, conv_from_str<IdStringList>,
                     conv_from_str<IdString>, pass_through<Loc>, pass_through<bool>,
                     pass_through<bool>>::def_wrap(ctx_cls, "addBel", "name"_a, "type"_a, "loc"_a, "gb"_a, "hidden"_a);
-    fn_wrapper_3a_v<Context, decltype(&Context::addBelInput), &Context::addBelInput, conv_from_str<IdStringList>,
-                    conv_from_str<IdString>, conv_from_str<IdStringList>>::def_wrap(ctx_cls, "addBelInput", "bel"_a,
-                                                                                    "name"_a, "wire"_a);
-    fn_wrapper_3a_v<Context, decltype(&Context::addBelOutput), &Context::addBelOutput, conv_from_str<IdStringList>,
-                    conv_from_str<IdString>, conv_from_str<IdStringList>>::def_wrap(ctx_cls, "addBelOutput", "bel"_a,
-                                                                                    "name"_a, "wire"_a);
-    fn_wrapper_3a_v<Context, decltype(&Context::addBelInout), &Context::addBelInout, conv_from_str<IdStringList>,
-                    conv_from_str<IdString>, conv_from_str<IdStringList>>::def_wrap(ctx_cls, "addBelInout", "bel"_a,
-                                                                                    "name"_a, "wire"_a);
+    fn_wrapper_3a_v<Context, decltype(&Context::addBelInput), &Context::addBelInput, conv_from_str<BelId>,
+                    conv_from_str<IdString>, conv_from_str<WireId>>::def_wrap(ctx_cls, "addBelInput", "bel"_a, "name"_a,
+                                                                              "wire"_a);
+    fn_wrapper_3a_v<Context, decltype(&Context::addBelOutput), &Context::addBelOutput, conv_from_str<BelId>,
+                    conv_from_str<IdString>, conv_from_str<WireId>>::def_wrap(ctx_cls, "addBelOutput", "bel"_a,
+                                                                              "name"_a, "wire"_a);
+    fn_wrapper_3a_v<Context, decltype(&Context::addBelInout), &Context::addBelInout, conv_from_str<BelId>,
+                    conv_from_str<IdString>, conv_from_str<WireId>>::def_wrap(ctx_cls, "addBelInout", "bel"_a, "name"_a,
+                                                                              "wire"_a);
 
     fn_wrapper_2a_v<Context, decltype(&Context::addGroupBel), &Context::addGroupBel, conv_from_str<IdStringList>,
-                    conv_from_str<IdStringList>>::def_wrap(ctx_cls, "addGroupBel", "group"_a, "bel"_a);
+                    conv_from_str<BelId>>::def_wrap(ctx_cls, "addGroupBel", "group"_a, "bel"_a);
     fn_wrapper_2a_v<Context, decltype(&Context::addGroupWire), &Context::addGroupWire, conv_from_str<IdStringList>,
-                    conv_from_str<IdStringList>>::def_wrap(ctx_cls, "addGroupWire", "group"_a, "wire"_a);
+                    conv_from_str<WireId>>::def_wrap(ctx_cls, "addGroupWire", "group"_a, "wire"_a);
     fn_wrapper_2a_v<Context, decltype(&Context::addGroupPip), &Context::addGroupPip, conv_from_str<IdStringList>,
-                    conv_from_str<IdStringList>>::def_wrap(ctx_cls, "addGroupPip", "group"_a, "pip"_a);
-    fn_wrapper_2a_v<Context, decltype(&Context::addGroupGroup), &Context::addGroupPip, conv_from_str<IdStringList>,
+                    conv_from_str<PipId>>::def_wrap(ctx_cls, "addGroupPip", "group"_a, "pip"_a);
+    fn_wrapper_2a_v<Context, decltype(&Context::addGroupGroup), &Context::addGroupGroup, conv_from_str<IdStringList>,
                     conv_from_str<IdStringList>>::def_wrap(ctx_cls, "addGroupGroup", "group"_a, "grp"_a);
 
     fn_wrapper_2a_v<Context, decltype(&Context::addDecalGraphic), &Context::addDecalGraphic, conv_from_str<DecalId>,
                     pass_through<GraphicElement>>::def_wrap(ctx_cls, "addDecalGraphic", (py::arg("decal"), "graphic"));
-    fn_wrapper_2a_v<Context, decltype(&Context::setWireDecal), &Context::setWireDecal, conv_from_str<DecalId>,
+    fn_wrapper_2a_v<Context, decltype(&Context::setWireDecal), &Context::setWireDecal, conv_from_str<WireId>,
                     unwrap_context<DecalXY>>::def_wrap(ctx_cls, "setWireDecal", "wire"_a, "decalxy"_a);
-    fn_wrapper_2a_v<Context, decltype(&Context::setPipDecal), &Context::setPipDecal, conv_from_str<DecalId>,
+    fn_wrapper_2a_v<Context, decltype(&Context::setPipDecal), &Context::setPipDecal, conv_from_str<PipId>,
                     unwrap_context<DecalXY>>::def_wrap(ctx_cls, "setPipDecal", "pip"_a, "decalxy"_a);
-    fn_wrapper_2a_v<Context, decltype(&Context::setBelDecal), &Context::setBelDecal, conv_from_str<DecalId>,
+    fn_wrapper_2a_v<Context, decltype(&Context::setBelDecal), &Context::setBelDecal, conv_from_str<BelId>,
                     unwrap_context<DecalXY>>::def_wrap(ctx_cls, "setBelDecal", "bel"_a, "decalxy"_a);
     fn_wrapper_2a_v<Context, decltype(&Context::setGroupDecal), &Context::setGroupDecal, conv_from_str<DecalId>,
                     unwrap_context<DecalXY>>::def_wrap(ctx_cls, "setGroupDecal", "group"_a, "decalxy"_a);
 
-    fn_wrapper_3a_v<Context, decltype(&Context::setWireAttr), &Context::setWireAttr, conv_from_str<DecalId>,
+    fn_wrapper_3a_v<Context, decltype(&Context::setWireAttr), &Context::setWireAttr, conv_from_str<WireId>,
                     conv_from_str<IdString>, pass_through<std::string>>::def_wrap(ctx_cls, "setWireAttr", "wire"_a,
                                                                                   "key"_a, "value"_a);
-    fn_wrapper_3a_v<Context, decltype(&Context::setBelAttr), &Context::setBelAttr, conv_from_str<DecalId>,
+    fn_wrapper_3a_v<Context, decltype(&Context::setBelAttr), &Context::setBelAttr, conv_from_str<BelId>,
                     conv_from_str<IdString>, pass_through<std::string>>::def_wrap(ctx_cls, "setBelAttr", "bel"_a,
                                                                                   "key"_a, "value"_a);
-    fn_wrapper_3a_v<Context, decltype(&Context::setPipAttr), &Context::setPipAttr, conv_from_str<DecalId>,
+    fn_wrapper_3a_v<Context, decltype(&Context::setPipAttr), &Context::setPipAttr, conv_from_str<PipId>,
                     conv_from_str<IdString>, pass_through<std::string>>::def_wrap(ctx_cls, "setPipAttr", "pip"_a,
                                                                                   "key"_a, "value"_a);
 
@@ -253,6 +257,10 @@ void arch_wrap_python(py::module &m)
     fn_wrapper_2a<Context, decltype(&Context::isValidBelForCellType), &Context::isValidBelForCellType,
                   pass_through<bool>, conv_from_str<IdString>, conv_from_str<BelId>>::def_wrap(ctx_cls,
                                                                                                "isValidBelForCellType");
+
+    WRAP_RANGE(m, Bel, conv_to_str<BelId>);
+    WRAP_RANGE(m, Wire, conv_to_str<WireId>);
+    WRAP_RANGE(m, AllPip, conv_to_str<PipId>);
 
     WRAP_MAP_UPTR(m, CellMap, "IdCellMap");
     WRAP_MAP_UPTR(m, NetMap, "IdNetMap");

--- a/generic/arch_pybindings.h
+++ b/generic/arch_pybindings.h
@@ -26,6 +26,73 @@
 
 NEXTPNR_NAMESPACE_BEGIN
 
+namespace PythonConversion {
+
+template <> struct string_converter<BelId>
+{
+    BelId from_str(Context *ctx, std::string name) { return ctx->getBelByNameStr(name); }
+
+    std::string to_str(Context *ctx, BelId id)
+    {
+        if (id == BelId())
+            throw bad_wrap();
+        return ctx->getBelName(id).str(ctx);
+    }
+};
+
+template <> struct string_converter<WireId>
+{
+    WireId from_str(Context *ctx, std::string name) { return ctx->getWireByNameStr(name); }
+
+    std::string to_str(Context *ctx, WireId id)
+    {
+        if (id == WireId())
+            throw bad_wrap();
+        return ctx->getWireName(id).str(ctx);
+    }
+};
+
+template <> struct string_converter<const WireId>
+{
+    WireId from_str(Context *ctx, std::string name) { return ctx->getWireByNameStr(name); }
+
+    std::string to_str(Context *ctx, WireId id)
+    {
+        if (id == WireId())
+            throw bad_wrap();
+        return ctx->getWireName(id).str(ctx);
+    }
+};
+
+template <> struct string_converter<PipId>
+{
+    PipId from_str(Context *ctx, std::string name) { return ctx->getPipByNameStr(name); }
+
+    std::string to_str(Context *ctx, PipId id)
+    {
+        if (id == PipId())
+            throw bad_wrap();
+        return ctx->getPipName(id).str(ctx);
+    }
+};
+
+template <> struct string_converter<BelPin>
+{
+    BelPin from_str(Context *ctx, std::string name)
+    {
+        NPNR_ASSERT_FALSE("string_converter<BelPin>::from_str not implemented");
+    }
+
+    std::string to_str(Context *ctx, BelPin pin)
+    {
+        if (pin.bel == BelId())
+            throw bad_wrap();
+        return ctx->getBelName(pin.bel).str(ctx) + "/" + pin.pin.str(ctx);
+    }
+};
+
+} // namespace PythonConversion
+
 NEXTPNR_NAMESPACE_END
 #endif
 #endif

--- a/generic/archdefs.h
+++ b/generic/archdefs.h
@@ -27,9 +27,42 @@ NEXTPNR_NAMESPACE_BEGIN
 
 typedef float delay_t;
 
-typedef IdStringList BelId;
-typedef IdStringList WireId;
-typedef IdStringList PipId;
+struct BelId
+{
+    BelId() : index(-1){};
+    explicit BelId(int32_t index) : index(index){};
+    int32_t index = -1;
+
+    bool operator==(const BelId &other) const { return index == other.index; }
+    bool operator!=(const BelId &other) const { return index != other.index; }
+    bool operator<(const BelId &other) const { return index < other.index; }
+    unsigned int hash() const { return index; }
+};
+
+struct WireId
+{
+    WireId() : index(-1){};
+    explicit WireId(int32_t index) : index(index){};
+    int32_t index = -1;
+
+    bool operator==(const WireId &other) const { return index == other.index; }
+    bool operator!=(const WireId &other) const { return index != other.index; }
+    bool operator<(const WireId &other) const { return index < other.index; }
+    unsigned int hash() const { return index; }
+};
+
+struct PipId
+{
+    PipId() : index(-1){};
+    explicit PipId(int32_t index) : index(index){};
+    int32_t index = -1;
+
+    bool operator==(const PipId &other) const { return index == other.index; }
+    bool operator!=(const PipId &other) const { return index != other.index; }
+    bool operator<(const PipId &other) const { return index < other.index; }
+    unsigned int hash() const { return index; }
+};
+
 typedef IdStringList GroupId;
 typedef IdStringList DecalId;
 typedef IdString BelBucketId;

--- a/generic/examples/write_fasm.py
+++ b/generic/examples/write_fasm.py
@@ -29,7 +29,7 @@ def write_fasm(ctx, paramCfg, f):
 	for nname, net in sorted(ctx.nets, key=lambda x: str(x[1].name)):
 		print("# Net %s" % nname, file=f)
 		for wire, pip in sorted(net.wires, key=lambda x: str(x[1])):
-			if pip.pip != "":
+			if pip.pip is not None:
 				print("%s" % pip.pip, file=f)
 		print("", file=f)
 	for cname, cell in sorted(ctx.cells, key=lambda x: str(x[1].name)):


### PR DESCRIPTION
This won't affect Python-built arches significantly; but will be useful for the future 'viaduct' functionality where generic routing graphs can be built on the C++ side; too.

In particular; the number of hash table lookups during PnR are vastly reduced by using linear indices into `vector`s instead of `IdStringList`s looked up in `dict`s.