### PR TITLE
Better hashing function for integer pairs

### DIFF
--- a/common/hashlib.h
+++ b/common/hashlib.h
@@ -26,8 +26,11 @@ NEXTPNR_NAMESPACE_BEGIN
 const int hashtable_size_trigger = 2;
 const int hashtable_size_factor = 3;
 
-// The XOR version of DJB2
-inline unsigned int mkhash(unsigned int a, unsigned int b) { return ((a << 5) + a) ^ b; }
+// Cantor pairing function for two non-negative integers
+// https://en.wikipedia.org/wiki/Pairing_function
+inline unsigned int mkhash(unsigned int a, unsigned int b) {
+    return (a*a + 3*a + 2*a*b + b + b*b) / 2;
+}
 
 // traditionally 5381 is used as starting value for the djb2 hash
 const unsigned int mkhash_init = 5381;


### PR DESCRIPTION
This PR changes the hashing function used for two integers from DJB2 to Cantor. The DJB2 one is meant for string characters and yields in quite high number of collisions for integers of values outside ASCII range. Cantor guarantees hash uniqueness.

Despite being more computationally complex the Cantor function boosts the performance which can be seen especially in router2 runtime on the nexus architecture. For the `hps_accel` design in `slim+cfu` configuration from the CFU Playground (https://github.com/google/CFU-Playground) its runtime dropped from `50s` to about `33.5s` (this may vary on different machines):

Routing times from 3 runs for DBJ2 and Cantor hashing:

router2:
| DJB2  | Cantor |
| ------------- | ------------- |
| 49.86s | 33.63s |
| 49.99s | 33.54s |
| 49.91s | 33.71s |

router1:
| DJB2  | Cantor |
| ------------- | ------------- |
| 1118.48s | 970.56 |
| 1112.91s | 914.58 |
| 1101.93s | 921.72 |