### PR TITLE
nexus: arch: add option to adjust the estimation delay multiplication factor

### DIFF
--- a/nexus/arch.cc
+++ b/nexus/arch.cc
@@ -601,7 +601,8 @@ delay_t Arch::estimateDelay(WireId src, WireId dst) const
     int dst_x = dst.tile % chip_info->width, dst_y = dst.tile / chip_info->width;
     int dist_x = std::abs(src_x - dst_x);
     int dist_y = std::abs(src_y - dst_y);
-    return 75 * dist_x + 75 * dist_y + 250;
+
+    return estimate_delay_mult * (dist_x + dist_y) + 250;
 }
 delay_t Arch::predictDelay(BelId src_bel, IdString src_pin, BelId dst_bel, IdString dst_pin) const
 {
@@ -655,6 +656,10 @@ ArcBounds Arch::getRouteBoundingBox(WireId src, WireId dst) const
 
 bool Arch::place()
 {
+    estimate_delay_mult = 75;
+    if (getCtx()->settings.count(getCtx()->id("estimate-delay-mult")))
+        estimate_delay_mult = getCtx()->setting<int>("estimate-delay-mult");
+
     std::string placer = str_or_default(settings, id("placer"), defaultPlacer);
 
     if (placer == "heap") {

--- a/nexus/arch.h
+++ b/nexus/arch.h
@@ -1290,6 +1290,7 @@ struct Arch : BaseArch<ArchRanges>
 
     // -------------------------------------------------
 
+    int32_t estimate_delay_mult;
     delay_t estimateDelay(WireId src, WireId dst) const override;
     delay_t predictDelay(BelId src_bel, IdString src_pin, BelId dst_bel, IdString dst_pin) const override;
     delay_t getDelayEpsilon() const override { return 20; }

--- a/nexus/main.cc
+++ b/nexus/main.cc
@@ -54,6 +54,8 @@ po::options_description NexusCommandHandler::getArchOptions()
     specific.add_options()("no-pack-lutff", "disable packing (clustering) LUTs and FFs together");
     specific.add_options()("carry-lutff-ratio", po::value<float>(),
                            "ratio of FFs to be added to carry-chain LUT clusters");
+    specific.add_options()("estimate-delay-mult", po::value<int>(),
+                           "multiplier for the estimate delay");
 
     return specific;
 }
@@ -88,6 +90,8 @@ std::unique_ptr<Context> NexusCommandHandler::createContext(dict<std::string, Pr
         }
         ctx->settings[ctx->id("carry_lutff_ratio")] = ratio;
     }
+    if (vm.count("estimate-delay-mult"))
+        ctx->settings[ctx->id("estimate-delay-mult")] = vm["estimate-delay-mult"].as<int>();
     return ctx;
 }
 


### PR DESCRIPTION
(edited)

This PR adds the a runtime parameter to control the multiplication factor of the estimate delay for nexus devices, without changing the default behaviour.

@gatecat cc