### PR TITLE
gowin: add an option to manually specify family

### DIFF
--- a/gowin/main.cc
+++ b/gowin/main.cc
@@ -48,6 +48,7 @@ po::options_description GowinCommandHandler::getArchOptions()
 {
     po::options_description specific("Architecture specific options");
     specific.add_options()("device", po::value<std::string>(), "device name");
+    specific.add_options()("family", po::value<std::string>(), "family name");
     specific.add_options()("cst", po::value<std::string>(), "physical constraints file");
     return specific;
 }
@@ -61,12 +62,16 @@ std::unique_ptr<Context> GowinCommandHandler::createContext(dict<std::string, Pr
         log_error("Invalid device %s\n", device.c_str());
     }
     ArchArgs chipArgs;
-    char buf[36];
-    // GW1N and GW1NR variants share the same database.
-    // Most Gowin devices are a System in Package with some SDRAM wirebonded to a GPIO bank.
-    // However, it appears that the S series with embedded ARM core are unique silicon.
-    snprintf(buf, 36, "GW1N%s-%s", match[1].str().c_str(), match[3].str().c_str());
-    chipArgs.family = buf;
+    if (vm.count("family")) {
+	    chipArgs.family = vm["family"].as<std::string>();
+    } else {
+	    char buf[36];
+	    // GW1N and GW1NR variants share the same database.
+	    // Most Gowin devices are a System in Package with some SDRAM wirebonded to a GPIO bank.
+	    // However, it appears that the S series with embedded ARM core are unique silicon.
+	    snprintf(buf, 36, "GW1N%s-%s", match[1].str().c_str(), match[3].str().c_str());
+	    chipArgs.family = buf;
+    }
     chipArgs.partnumber = match[0];
     return std::unique_ptr<Context>(new Context(chipArgs));
 }


### PR DESCRIPTION
In the vendor IDE, there's a device family named GW1N-9C (which seems to
mean C revision of GW1N-9), in which the model numbers are all the same
with GW1N-9.

Add an option to nextpnr-gowin to allow manually specified family for
this situation.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>