### PR TITLE
Fix for Nexus DSP packing

### DIFF
--- a/nexus/pack.cc
+++ b/nexus/pack.cc
@@ -1784,7 +1784,7 @@ struct NexusPacker
                     copy_port(ctx, ci, mt.has_addsub ? id_SIGNED : id_SIGNEDA, mult9[i], id_ASIGNED);
             }
 
-            bool mult36_used = (mt.a_width >= 36) && (mt.b_width >= 36);
+            bool mult36_used = (mt.a_width >= 36) && (mt.b_width >= 36) && !(mt.wide > 0);
             // Configure mult18x36s
             for (int i = 0; i < mt.N18x36; i++) {
                 mult18x36[i]->params[id_MULT36] = mult36_used ? std::string("ENABLED") : std::string("DISABLED");


### PR DESCRIPTION
This PR removes the `MULT36_CORE` bel from DSP clusters created to implement the `MULTADDSUB9X9WIDE` macro as apparently it is not needed.

I couldn't find anywhere in the vendor docs which parts of sysDSP are actually required to implement this macro but from its description it certainly shouldn't require the mult36x36 core.

The fix has been tested on the HPS design from CFU playground in which a total of 8 of `MULTADDSUB9X9WIDE` for `LIFCL-17` is instanced. The final bitstream worked correctly in hardware proving that this fix is sound.

Apart from that I have run the same design through Radiant. It did fail on "mapping" as it run out of other DSP components but it didn't report that there is a need for 8 mult36x36. Besides that, LIFCL-17 has only 6 of those.