### PR TITLE
generic: Add missing Pip vector binding

### DIFF
--- a/generic/arch_pybindings.cc
+++ b/generic/arch_pybindings.cc
@@ -266,6 +266,7 @@ void arch_wrap_python(py::module &m)
     WRAP_MAP_UPTR(m, NetMap, "IdNetMap");
     WRAP_MAP(m, HierarchyMap, wrap_context<HierarchicalCell &>, "HierarchyMap");
     WRAP_VECTOR(m, const std::vector<IdString>, conv_to_str<IdString>);
+    WRAP_VECTOR(m, const std::vector<PipId>, conv_to_str<PipId>);
 }
 
 NEXTPNR_NAMESPACE_END

--- a/generic/arch_pybindings.h
+++ b/generic/arch_pybindings.h
@@ -76,6 +76,18 @@ template <> struct string_converter<PipId>
     }
 };
 
+template <> struct string_converter<const PipId &>
+{
+    PipId from_str(Context *ctx, std::string name) { return ctx->getPipByNameStr(name); }
+
+    std::string to_str(Context *ctx, const PipId &id)
+    {
+        if (id == PipId())
+            throw bad_wrap();
+        return ctx->getPipName(id).str(ctx);
+    }
+};
+
 template <> struct string_converter<BelPin>
 {
     BelPin from_str(Context *ctx, std::string name)


### PR DESCRIPTION
This fixes `getPipsDownhill` and `getPipsUphill` in the generic python API.