### PR TITLE
Add support for GW1N-9C and --family argument

### DIFF
--- a/.cirrus/Dockerfile.ubuntu20.04
+++ b/.cirrus/Dockerfile.ubuntu20.04
@@ -65,4 +65,4 @@ RUN set -e -x ;\
     PATH=$PATH:$HOME/.cargo/bin cargo install --path prjoxide
 
 RUN set -e -x ;\
-    pip3 install apycula==0.2a2
+    pip3 install apycula==0.2a3

--- a/gowin/CMakeLists.txt
+++ b/gowin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(chipdb-gowin NONE)
 
-set(ALL_GOWIN_DEVICES GW1N-1 GW1N-4 GW1N-9 GW1NS-2 GW1NS-4)
+set(ALL_GOWIN_DEVICES GW1N-1 GW1N-4 GW1N-9 GW1N-9C GW1NS-2 GW1NS-4)
 set(GOWIN_DEVICES ${ALL_GOWIN_DEVICES} CACHE STRING
     "Include support for these Gowin devices (available: ${ALL_GOWIN_DEVICES})")
 message(STATUS "Enabled Gowin devices: ${GOWIN_DEVICES}")

--- a/gowin/main.cc
+++ b/gowin/main.cc
@@ -48,6 +48,7 @@ po::options_description GowinCommandHandler::getArchOptions()
 {
     po::options_description specific("Architecture specific options");
     specific.add_options()("device", po::value<std::string>(), "device name");
+    specific.add_options()("family", po::value<std::string>(), "family name");
     specific.add_options()("cst", po::value<std::string>(), "physical constraints file");
     return specific;
 }
@@ -62,12 +63,16 @@ std::unique_ptr<Context> GowinCommandHandler::createContext(dict<std::string, Pr
     }
     ArchArgs chipArgs;
     chipArgs.gui = vm.count("gui") != 0;
-    char buf[36];
-    // GW1N and GW1NR variants share the same database.
-    // Most Gowin devices are a System in Package with some SDRAM wirebonded to a GPIO bank.
-    // However, it appears that the S series with embedded ARM core are unique silicon.
-    snprintf(buf, 36, "GW1N%s-%s", match[1].str().c_str(), match[3].str().c_str());
-    chipArgs.family = buf;
+    if (vm.count("family")) {
+	    chipArgs.family = vm["family"].as<std::string>();
+    } else {
+	    char buf[36];
+	    // GW1N and GW1NR variants share the same database.
+	    // Most Gowin devices are a System in Package with some SDRAM wirebonded to a GPIO bank.
+	    // However, it appears that the S series with embedded ARM core are unique silicon.
+	    snprintf(buf, 36, "GW1N%s-%s", match[1].str().c_str(), match[3].str().c_str());
+	    chipArgs.family = buf;
+    }
     chipArgs.partnumber = match[0];
     return std::unique_ptr<Context>(new Context(chipArgs));
 }


### PR DESCRIPTION
This supersedes and includes #898 rebased on top of master