### PR TITLE
nexus: reduce OSCA worst case to 7%

### DIFF
--- a/nexus/pack.cc
+++ b/nexus/pack.cc
@@ -1987,7 +1987,7 @@ struct NexusPacker
                     copy_constraint(ci, id_CLKI, id_CLKO, 1);
                 } else if (ci->type == id_OSC_CORE) {
                     int div = int_or_default(ci->params, ctx->id("HF_CLK_DIV"), 128);
-                    const float tol = 1.15f; // OSCA has +/-15% frequency tolerance, assume the worst case.
+                    const float tol = 1.07f; // OSCA has +/-7% frequency tolerance, assume the worst case.
                     set_period(ci, id_HFCLKOUT, delay_t((1.0e6 / 450) * (div + 1) / tol));
                     set_period(ci, id_LFCLKOUT, delay_t((1.0e3 / 10) / tol));
                 } else if (ci->type == id_PLL_CORE) {


### PR DESCRIPTION
The current version of Crosslink-NX Family Data Sheet lists the high
frequency oscillator maximum frequency as 481.5MHz (that is, 7% higher
than its nominal 450MHz):

https://www.latticesemi.com/-/media/LatticeSemi/Documents/DataSheets/CrossLink/FPGA-DS-02049-1-2-1-CrossLink-NX-Family.ashx?document_id=52780

Older documents listed a wider frequency range but ±7% is the range for
production parts.

I confirmed with Lattice that ±7% is the correct number. In this PR I haven't tried to tackle the question of pre-production parts. Lattice doesn't disclose anything publicly that I can find about the existence or performance of pre-production parts (no surprise there). It might be okay to just assume that if someone has such a part, they know that the tolerance was previously documented as 10%, and they will override the timing constraint appropriately...

Btw I don't think there is any difference in idcode for LIFCL-17 over its lifetime so maybe there is no way to handle pre-production parts for that one anyway.