### PR TITLE
gowin: Add GW1NZ-1 support

### DIFF
--- a/.cirrus/Dockerfile.ubuntu20.04
+++ b/.cirrus/Dockerfile.ubuntu20.04
@@ -65,4 +65,4 @@ RUN set -e -x ;\
     PATH=$PATH:$HOME/.cargo/bin cargo install --path prjoxide
 
 RUN set -e -x ;\
-    pip3 install apycula==0.2a3
+    pip3 install apycula==0.2a4

--- a/gowin/CMakeLists.txt
+++ b/gowin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(chipdb-gowin NONE)
 
-set(ALL_GOWIN_DEVICES GW1N-1 GW1N-4 GW1N-9 GW1N-9C GW1NS-2 GW1NS-4)
+set(ALL_GOWIN_DEVICES GW1N-1 GW1NZ-1 GW1N-4 GW1N-9 GW1N-9C GW1NS-2 GW1NS-4)
 set(GOWIN_DEVICES ${ALL_GOWIN_DEVICES} CACHE STRING
     "Include support for these Gowin devices (available: ${ALL_GOWIN_DEVICES})")
 message(STATUS "Enabled Gowin devices: ${GOWIN_DEVICES}")


### PR DESCRIPTION
Adds support for GW1NZ-1 chip that's found in the Tang Nano 1K development board.

~~Depends on https://github.com/YosysHQ/apicula/pull/81~~ (merged)