### PR TITLE
refactor: New NetInfo and CellInfo constructors

### DIFF
--- a/common/basectx.cc
+++ b/common/basectx.cc
@@ -211,8 +211,7 @@ NetInfo *BaseCtx::createNet(IdString name)
 {
     NPNR_ASSERT(!nets.count(name));
     NPNR_ASSERT(!net_aliases.count(name));
-    std::unique_ptr<NetInfo> net{new NetInfo};
-    net->name = name;
+    auto net = std::make_unique<NetInfo>(name);
     net_aliases[name] = name;
     NetInfo *ptr = net.get();
     nets[name] = std::move(net);
@@ -252,9 +251,7 @@ void BaseCtx::lockNetRouting(IdString name)
 CellInfo *BaseCtx::createCell(IdString name, IdString type)
 {
     NPNR_ASSERT(!cells.count(name));
-    std::unique_ptr<CellInfo> cell{new CellInfo};
-    cell->name = name;
-    cell->type = type;
+    auto cell = std::make_unique<CellInfo>(getCtx(), name, type);
     CellInfo *ptr = cell.get();
     cells[name] = std::move(cell);
     refreshUi();

--- a/common/design_utils.cc
+++ b/common/design_utils.cc
@@ -129,12 +129,8 @@ void connect_ports(Context *ctx, CellInfo *cell1, IdString port1_name, CellInfo 
     PortInfo &port1 = cell1->ports.at(port1_name);
     if (port1.net == nullptr) {
         // No net on port1; need to create one
-        std::unique_ptr<NetInfo> p1net(new NetInfo());
-        p1net->name = ctx->id(cell1->name.str(ctx) + "$conn$" + port1_name.str(ctx));
-        connect_port(ctx, p1net.get(), cell1, port1_name);
-        IdString p1name = p1net->name;
-        NPNR_ASSERT(!ctx->cells.count(p1name));
-        ctx->nets[p1name] = std::move(p1net);
+        NetInfo *p1net = ctx->createNet(ctx->id(cell1->name.str(ctx) + "$conn$" + port1_name.str(ctx)));
+        connect_port(ctx, p1net, cell1, port1_name);
     }
     connect_port(ctx, port1.net, cell2, port2_name);
 }

--- a/common/nextpnr_types.h
+++ b/common/nextpnr_types.h
@@ -124,6 +124,7 @@ struct ClockConstraint;
 
 struct NetInfo : ArchNetInfo
 {
+    explicit NetInfo(IdString name) : name(name){};
     IdString name, hierpath;
     int32_t udata = 0;
 
@@ -155,8 +156,13 @@ struct PortInfo
     PortType type;
 };
 
+struct Context;
+
 struct CellInfo : ArchCellInfo
 {
+    CellInfo(Context *ctx, IdString name, IdString type) : ctx(ctx), name(name), type(type){};
+    Context *ctx = nullptr;
+
     IdString name, type, hierpath;
     int32_t udata;
 

--- a/fpga_interchange/pseudo_pip_model.cc
+++ b/fpga_interchange/pseudo_pip_model.cc
@@ -355,12 +355,11 @@ void PseudoPipModel::update_site(const Context *ctx, size_t site)
 
         NPNR_ASSERT(bel_data.lut_element != -1);
 
-        lut_thru_cells.emplace_back();
+        lut_thru_cells.emplace_back(nullptr, IdString(), IdString(ctx->wire_lut->cell));
         CellInfo &cell = lut_thru_cells.back();
 
         cell.bel = bel;
 
-        cell.type = IdString(ctx->wire_lut->cell);
         NPNR_ASSERT(ctx->wire_lut->input_pins.size() == 1);
         cell.lut_cell.pins.push_back(IdString(ctx->wire_lut->input_pins[0]));
 
@@ -384,7 +383,7 @@ void PseudoPipModel::update_site(const Context *ctx, size_t site)
             continue;
         }
 
-        lut_cells.emplace_back();
+        lut_cells.emplace_back(nullptr, IdString(), ctx->wire_lut ? IdString(ctx->wire_lut->cell) : IdString());
         CellInfo &cell = lut_cells.back();
 
         cell.bel.tile = tile;
@@ -393,7 +392,6 @@ void PseudoPipModel::update_site(const Context *ctx, size_t site)
         if (ctx->wire_lut == nullptr)
             continue;
 
-        cell.type = IdString(ctx->wire_lut->cell);
         NPNR_ASSERT(ctx->wire_lut->input_pins.size() == 1);
         cell.lut_cell.pins.push_back(IdString(ctx->wire_lut->input_pins[0]));
 

--- a/fpga_interchange/site_arch.cc
+++ b/fpga_interchange/site_arch.cc
@@ -103,7 +103,8 @@ void SiteArch::archcheck()
     }
 }
 
-SiteArch::SiteArch(const SiteInformation *site_info) : ctx(site_info->ctx), site_info(site_info)
+SiteArch::SiteArch(const SiteInformation *site_info)
+        : ctx(site_info->ctx), site_info(site_info), blocking_net(site_info->ctx->id("$nextpnr_blocked_net"))
 {
     // Build list of input and output site ports
     //
@@ -275,7 +276,6 @@ SiteArch::SiteArch(const SiteInformation *site_info) : ctx(site_info->ctx), site
         }
     }
 
-    blocking_net.name = ctx->id("$nextpnr_blocked_net");
     blocking_site_net.net = &blocking_net;
 }
 

--- a/generic/cells.cc
+++ b/generic/cells.cc
@@ -34,13 +34,9 @@ void add_port(const Context *ctx, CellInfo *cell, std::string name, PortType dir
 std::unique_ptr<CellInfo> create_generic_cell(Context *ctx, IdString type, std::string name)
 {
     static int auto_idx = 0;
-    std::unique_ptr<CellInfo> new_cell = std::unique_ptr<CellInfo>(new CellInfo());
-    if (name.empty()) {
-        new_cell->name = ctx->id("$nextpnr_" + type.str(ctx) + "_" + std::to_string(auto_idx++));
-    } else {
-        new_cell->name = ctx->id(name);
-    }
-    new_cell->type = type;
+    IdString name_id =
+            name.empty() ? ctx->id("$nextpnr_" + type.str(ctx) + "_" + std::to_string(auto_idx++)) : ctx->id(name);
+    auto new_cell = std::make_unique<CellInfo>(ctx, name_id, type);
     if (type == ctx->id("GENERIC_SLICE")) {
         new_cell->params[ctx->id("K")] = ctx->args.K;
         new_cell->params[ctx->id("INIT")] = 0;

--- a/generic/pack.cc
+++ b/generic/pack.cc
@@ -140,8 +140,7 @@ static void pack_constants(Context *ctx)
 
     std::unique_ptr<CellInfo> gnd_cell = create_generic_cell(ctx, ctx->id("GENERIC_SLICE"), "$PACKER_GND");
     gnd_cell->params[ctx->id("INIT")] = Property(0, 1 << ctx->args.K);
-    std::unique_ptr<NetInfo> gnd_net = std::unique_ptr<NetInfo>(new NetInfo);
-    gnd_net->name = ctx->id("$PACKER_GND_NET");
+    std::unique_ptr<NetInfo> gnd_net = std::make_unique<NetInfo>(ctx->id("$PACKER_GND_NET"));
     gnd_net->driver.cell = gnd_cell.get();
     gnd_net->driver.port = ctx->id("F");
     gnd_cell->ports.at(ctx->id("F")).net = gnd_net.get();
@@ -149,8 +148,7 @@ static void pack_constants(Context *ctx)
     std::unique_ptr<CellInfo> vcc_cell = create_generic_cell(ctx, ctx->id("GENERIC_SLICE"), "$PACKER_VCC");
     // Fill with 1s
     vcc_cell->params[ctx->id("INIT")] = Property(Property::S1).extract(0, (1 << ctx->args.K), Property::S1);
-    std::unique_ptr<NetInfo> vcc_net = std::unique_ptr<NetInfo>(new NetInfo);
-    vcc_net->name = ctx->id("$PACKER_VCC_NET");
+    std::unique_ptr<NetInfo> vcc_net = std::make_unique<NetInfo>(ctx->id("$PACKER_VCC_NET"));
     vcc_net->driver.cell = vcc_cell.get();
     vcc_net->driver.port = ctx->id("F");
     vcc_cell->ports.at(ctx->id("F")).net = vcc_net.get();

--- a/gowin/cells.cc
+++ b/gowin/cells.cc
@@ -35,13 +35,9 @@ void add_port(const Context *ctx, CellInfo *cell, IdString id, PortType dir)
 std::unique_ptr<CellInfo> create_generic_cell(Context *ctx, IdString type, std::string name)
 {
     static int auto_idx = 0;
-    std::unique_ptr<CellInfo> new_cell = std::unique_ptr<CellInfo>(new CellInfo());
-    if (name.empty()) {
-        new_cell->name = ctx->id("$nextpnr_" + type.str(ctx) + "_" + std::to_string(auto_idx++));
-    } else {
-        new_cell->name = ctx->id(name);
-    }
-    new_cell->type = type;
+    IdString name_id =
+            name.empty() ? ctx->id("$nextpnr_" + type.str(ctx) + "_" + std::to_string(auto_idx++)) : ctx->id(name);
+    auto new_cell = std::make_unique<CellInfo>(ctx, name_id, type);
     if (type == id_SLICE) {
         new_cell->params[id_INIT] = 0;
         new_cell->params[id_FF_USED] = 0;

--- a/gowin/pack.cc
+++ b/gowin/pack.cc
@@ -612,8 +612,7 @@ static void pack_constants(Context *ctx)
 
     std::unique_ptr<CellInfo> gnd_cell = create_generic_cell(ctx, ctx->id("SLICE"), "$PACKER_GND");
     gnd_cell->params[ctx->id("INIT")] = Property(0, 1 << 4);
-    std::unique_ptr<NetInfo> gnd_net = std::unique_ptr<NetInfo>(new NetInfo);
-    gnd_net->name = ctx->id("$PACKER_GND_NET");
+    auto gnd_net = std::make_unique<NetInfo>(ctx->id("$PACKER_GND_NET"));
     gnd_net->driver.cell = gnd_cell.get();
     gnd_net->driver.port = ctx->id("F");
     gnd_cell->ports.at(ctx->id("F")).net = gnd_net.get();
@@ -621,8 +620,7 @@ static void pack_constants(Context *ctx)
     std::unique_ptr<CellInfo> vcc_cell = create_generic_cell(ctx, ctx->id("SLICE"), "$PACKER_VCC");
     // Fill with 1s
     vcc_cell->params[ctx->id("INIT")] = Property(Property::S1).extract(0, (1 << 4), Property::S1);
-    std::unique_ptr<NetInfo> vcc_net = std::unique_ptr<NetInfo>(new NetInfo);
-    vcc_net->name = ctx->id("$PACKER_VCC_NET");
+    auto vcc_net = std::make_unique<NetInfo>(ctx->id("$PACKER_VCC_NET"));
     vcc_net->driver.cell = vcc_cell.get();
     vcc_net->driver.port = ctx->id("F");
     vcc_cell->ports.at(ctx->id("F")).net = vcc_net.get();

--- a/ice40/bitstream.cc
+++ b/ice40/bitstream.cc
@@ -979,9 +979,7 @@ void read_config(Context *ctx, std::istream &in, chipconfig_t &config)
                 IdString netName = ctx->id(name);
 
                 if (ctx->nets.find(netName) == ctx->nets.end()) {
-                    std::unique_ptr<NetInfo> created_net = std::unique_ptr<NetInfo>(new NetInfo);
-                    created_net->name = netName;
-                    ctx->nets[netName] = std::move(created_net);
+                    ctx->createNet(netName);
                 }
 
                 WireId wire;

--- a/machxo2/cells.cc
+++ b/machxo2/cells.cc
@@ -41,13 +41,9 @@ void add_port(const Context *ctx, CellInfo *cell, IdString id, PortType dir)
 std::unique_ptr<CellInfo> create_machxo2_cell(Context *ctx, IdString type, std::string name)
 {
     static int auto_idx = 0;
-    std::unique_ptr<CellInfo> new_cell = std::unique_ptr<CellInfo>(new CellInfo());
-    if (name.empty()) {
-        new_cell->name = ctx->id("$nextpnr_" + type.str(ctx) + "_" + std::to_string(auto_idx++));
-    } else {
-        new_cell->name = ctx->id(name);
-    }
-    new_cell->type = type;
+    IdString name_id =
+            name.empty() ? ctx->id("$nextpnr_" + type.str(ctx) + "_" + std::to_string(auto_idx++)) : ctx->id(name);
+    auto new_cell = std::make_unique<CellInfo>(ctx, name_id, type);
 
     if (type == id_FACADE_SLICE) {
         new_cell->params[id_MODE] = std::string("LOGIC");


### PR DESCRIPTION
This is part one of a potentially large and breaking netlist refactor.

It adds new, mandatory `NetInfo` and `CellInfo` constructors and starts to clean up older code constructing these objects in various ways to be more consistent.

It also adds a `Context` backreference to cells which will become of use in future steps when `design_util` functions are moved to being cell member functions.