### PR TITLE
gowin: Add support for true differential output

### DIFF
--- a/gowin/constids.inc
+++ b/gowin/constids.inc
@@ -636,6 +636,8 @@ X(I)
 X(O)
 X(IO)
 X(OE)
+X(OB)
+
 // bels
 X(DFF0)
 X(DFF1)
@@ -735,6 +737,7 @@ X(IBUF)
 X(OBUF)
 X(IOBUF)
 X(TBUF)
+X(TLVDS_OBUF)
 
 // primitive attributes
 X(INIT)
@@ -744,6 +747,8 @@ X(INPUT_USED)
 X(OUTPUT_USED)
 X(ENABLE_USED)
 X(BEL)
+X(DIFF)
+X(DIFF_TYPE)
 
 // ports
 X(EN)


### PR DESCRIPTION
The new primitive appears as an amalgamation of two existing OBUF
primitives.  Compatible with older versions of apicula, although, of
course, using TLVDS_OBUF with old databases will not bring the desired
result, but no crash.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>