### PR TITLE
gowin: recognize partnumbers of GW1NZ-1

### DIFF
--- a/gowin/main.cc
+++ b/gowin/main.cc
@@ -55,7 +55,7 @@ po::options_description GowinCommandHandler::getArchOptions()
 
 std::unique_ptr<Context> GowinCommandHandler::createContext(dict<std::string, Property> &values)
 {
-    std::regex devicere = std::regex("GW1N(S?)[A-Z]*-(LV|UV|UX)([0-9])(C?).*");
+    std::regex devicere = std::regex("GW1N([SZ]?)[A-Z]*-(LV|UV|UX)([0-9])(C?).*");
     std::smatch match;
     std::string device = vm["device"].as<std::string>();
     if (!std::regex_match(device, match, devicere)) {


### PR DESCRIPTION
The model should be recognized by the partnumber, --family is needed
only if the same partnumbers belong to different models.
This is done in order to automatically generate parameters for calling
nextpnr from Gowin files without problems: there also only partnumber is
used and only in some cases the model is specified with the -name
parameter and GW1NZ-1 is not such a case.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>