### PR TITLE
Switch to potentially-sparse net users array

### DIFF
--- a/common/context.cc
+++ b/common/context.cc
@@ -334,13 +334,13 @@ void Context::check() const
                                    nameOf(port.first), nameOf(net));
                     }
                 } else if (port.second.type == PORT_IN) {
-                    int usr_count = std::count_if(net->users.begin(), net->users.end(), [&](const PortRef &pr) {
-                        return pr.cell == c.second.get() && pr.port == port.first;
-                    });
-                    if (usr_count != 1)
-                        CHECK_FAIL("input cell port '%s.%s' appears %d rather than expected 1 times in users vector of "
-                                   "net '%s'\n",
-                                   nameOf(c.first), nameOf(port.first), usr_count, nameOf(net));
+                    if (!port.second.user_idx)
+                        CHECK_FAIL("input cell port '%s.%s' on net '%s' has no user index\n", nameOf(c.first),
+                                   nameOf(port.first), nameOf(net));
+                    auto net_user = net->users.at(port.second.user_idx);
+                    if (net_user.cell != c.second.get() || net_user.port != port.first)
+                        CHECK_FAIL("input cell port '%s.%s' not in associated user entry of net '%s'\n",
+                                   nameOf(c.first), nameOf(port.first), nameOf(net));
                 }
             }
         }

--- a/common/design_utils.h
+++ b/common/design_utils.h
@@ -47,14 +47,18 @@ CellInfo *net_only_drives(const Context *ctx, NetInfo *net, F1 cell_pred, IdStri
         return nullptr;
     if (exclusive) {
         if (exclude == nullptr) {
-            if (net->users.size() != 1)
+            if (net->users.entries() != 1)
                 return nullptr;
         } else {
-            if (net->users.size() > 2) {
+            if (net->users.entries() > 2) {
                 return nullptr;
-            } else if (net->users.size() == 2) {
-                if (std::find_if(net->users.begin(), net->users.end(),
-                                 [exclude](const PortRef &ref) { return ref.cell == exclude; }) == net->users.end())
+            } else if (net->users.entries() == 2) {
+                bool found = false;
+                for (auto &usr : net->users) {
+                    if (usr.cell == exclude)
+                        found = true;
+                }
+                if (!found)
                     return nullptr;
             }
         }

--- a/common/indexed_store.h
+++ b/common/indexed_store.h
@@ -1,0 +1,266 @@
+/*
+ *  nextpnr -- Next Generation Place and Route
+ *
+ *  Copyright (C) 2021-22  gatecat <gatecat@ds0.me>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#ifndef INDEXED_STORE_H
+#define INDEXED_STORE_H
+
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+#include "nextpnr_assertions.h"
+#include "nextpnr_namespaces.h"
+
+NEXTPNR_NAMESPACE_BEGIN
+
+template <typename T> struct store_index
+{
+    int32_t m_index = -1;
+    store_index() = default;
+    explicit store_index(int32_t index) : m_index(index){};
+    int32_t idx() const { return m_index; }
+    void set(int32_t index) { m_index = index; }
+    bool empty() const { return m_index == -1; }
+    bool operator==(const store_index<T> &other) const { return m_index == other.m_index; }
+    bool operator!=(const store_index<T> &other) const { return m_index != other.m_index; }
+    bool operator<(const store_index<T> &other) const { return m_index < other.m_index; }
+    unsigned int hash() const { return m_index; }
+
+    operator bool() const { return !empty(); }
+    bool operator!() const { return empty(); }
+};
+
+// "Slotted" indexed object store
+template <typename T> class indexed_store
+{
+  private:
+    // This should move to using std::optional at some point
+    class slot
+    {
+      private:
+        alignas(T) unsigned char storage[sizeof(T)];
+        int32_t next_free;
+        bool active;
+        inline T &obj() { return reinterpret_cast<T &>(storage); }
+        inline const T &obj() const { return reinterpret_cast<const T &>(storage); }
+        friend class indexed_store<T>;
+
+      public:
+        slot() : active(false), next_free(std::numeric_limits<int32_t>::max()){};
+        slot(slot &&other) : active(other.active), next_free(other.next_free)
+        {
+            if (active)
+                ::new (static_cast<void *>(&storage)) T(std::move(other.obj()));
+        };
+
+        template <class... Args> void create(Args &&...args)
+        {
+            NPNR_ASSERT(!active);
+            active = true;
+            ::new (static_cast<void *>(&storage)) T(std::forward<Args &&>(args)...);
+        }
+        bool empty() const { return !active; }
+        T &get()
+        {
+            NPNR_ASSERT(active);
+            return reinterpret_cast<T &>(storage);
+        }
+        const T &get() const
+        {
+            NPNR_ASSERT(active);
+            return reinterpret_cast<const T &>(storage);
+        }
+        void free(int32_t first_free)
+        {
+            NPNR_ASSERT(active);
+            obj().~T();
+            active = false;
+            next_free = first_free;
+        }
+        ~slot()
+        {
+            if (active)
+                obj().~T();
+        }
+    };
+
+    std::vector<slot> slots;
+    int32_t first_free = 0;
+    int32_t active_count = 0;
+
+  public:
+    // Create a new entry and return its index
+    template <class... Args> store_index<T> add(Args &&...args)
+    {
+        ++active_count;
+        if (first_free == int32_t(slots.size())) {
+            slots.emplace_back();
+            slots.back().create(std::forward<Args &&>(args)...);
+            ++first_free;
+            return store_index<T>(int32_t(slots.size()) - 1);
+        } else {
+            int32_t idx = first_free;
+            auto &slot = slots.at(idx);
+            first_free = slot.next_free;
+            slot.create(std::forward<Args &&>(args)...);
+            return store_index<T>(idx);
+        }
+    }
+
+    // Remove an entry at an index
+    void remove(store_index<T> idx)
+    {
+        --active_count;
+        slots.at(idx.m_index).free(first_free);
+        first_free = idx.m_index;
+    }
+
+    // Number of live entries
+    int32_t entries() const { return active_count; }
+
+    // Reserve a certain amount of space
+    void reserve(int32_t size) { slots.reserve(size); }
+
+    // Check if an index exists
+    int32_t count(store_index<T> idx)
+    {
+        if (idx.m_index < 0 || idx.m_index >= int32_t(slots.size()))
+            return 0;
+        return slots.at(idx.m_index).empty() ? 0 : 1;
+    }
+
+    // Get an item by index
+    T &at(store_index<T> idx) { return slots.at(idx.m_index).get(); }
+    const T &at(store_index<T> idx) const { return slots.at(idx.m_index).get(); }
+    T &operator[](store_index<T> idx) { return slots.at(idx.m_index).get(); }
+    const T &operator[](store_index<T> idx) const { return slots.at(idx.m_index).get(); }
+
+    // Total size of the container
+    int32_t capacity() const { return int32_t(slots.size()); }
+
+    // Iterate over items
+    class iterator
+    {
+      private:
+        indexed_store *base;
+        int32_t index = 0;
+
+      public:
+        iterator(indexed_store *base, int32_t index) : base(base), index(index){};
+        inline bool operator!=(const iterator &other) const { return other.index != index; }
+        inline bool operator==(const iterator &other) const { return other.index == index; }
+        inline iterator operator++()
+        {
+            // skip over unused slots
+            do {
+                index++;
+            } while (index < int32_t(base->slots.size()) && !base->slots.at(index).active);
+            return *this;
+        }
+        inline iterator operator++(int)
+        {
+            iterator prior(*this);
+            do {
+                index++;
+            } while (index < int32_t(base->slots.size()) && !base->slots.at(index).active);
+            return prior;
+        }
+        T &operator*() { return base->at(store_index<T>(index)); }
+        template <typename It, typename S> friend class enumerated_iterator;
+    };
+    iterator begin() { return iterator{this, 0}; }
+    iterator end() { return iterator{this, int32_t(slots.size())}; }
+
+    class const_iterator
+    {
+      private:
+        const indexed_store *base;
+        int32_t index = 0;
+
+      public:
+        const_iterator(const indexed_store *base, int32_t index) : base(base), index(index){};
+        inline bool operator!=(const const_iterator &other) const { return other.index != index; }
+        inline bool operator==(const const_iterator &other) const { return other.index == index; }
+        inline const_iterator operator++()
+        {
+            // skip over unused slots
+            do {
+                index++;
+            } while (index < int32_t(base->slots.size()) && !base->slots.at(index).active);
+            return *this;
+        }
+        inline const_iterator operator++(int)
+        {
+            iterator prior(*this);
+            do {
+                index++;
+            } while (index < int32_t(base->slots.size()) && !base->slots.at(index).active);
+            return prior;
+        }
+        const T &operator*() { return base->at(store_index<T>(index)); }
+        template <typename It, typename S> friend class enumerated_iterator;
+    };
+    const_iterator begin() const { return const_iterator{this, 0}; }
+    const_iterator end() const { return const_iterator{this, int32_t(slots.size())}; }
+
+    template <typename S> struct enumerated_item
+    {
+        enumerated_item(int32_t index, T &value) : index(index), value(value){};
+        store_index<std::remove_const<S>> index;
+        S &value;
+    };
+
+    template <typename It, typename S> class enumerated_iterator
+    {
+      private:
+        It base;
+
+      public:
+        enumerated_iterator(const It &base) : base(base){};
+        inline bool operator!=(const enumerated_iterator<It, S> &other) const { return other.base != base; }
+        inline bool operator==(const enumerated_iterator<It, S> &other) const { return other.base == base; }
+        inline enumerated_iterator<It, S> operator++()
+        {
+            ++base;
+            return *this;
+        }
+        inline enumerated_iterator<It, S> operator++(int)
+        {
+            iterator prior(*this);
+            ++base;
+            return prior;
+        }
+        enumerated_item<S> operator*() { return enumerated_item<S>{base.index, *base}; }
+    };
+
+    template <typename It, typename S> struct enumerated_range
+    {
+        enumerated_range(const It &begin, const It &end) : m_begin(begin), m_end(end){};
+        enumerated_iterator<It, S> m_begin, m_end;
+        enumerated_iterator<It, S> begin() { return m_begin; }
+        enumerated_iterator<It, S> end() { return m_end; }
+    };
+
+    enumerated_range<iterator, T> enumerate() { return enumerated_range<iterator, T>{begin(), end()}; }
+    enumerated_range<const_iterator, const T> enumerate() const { return enumerated_range<iterator, T>{begin(), end()}; }
+};
+
+NEXTPNR_NAMESPACE_END
+
+#endif

--- a/common/nextpnr_types.h
+++ b/common/nextpnr_types.h
@@ -29,6 +29,7 @@
 
 #include "archdefs.h"
 #include "hashlib.h"
+#include "indexed_store.h"
 #include "nextpnr_base_types.h"
 #include "nextpnr_namespaces.h"
 #include "property.h"

--- a/common/nextpnr_types.h
+++ b/common/nextpnr_types.h
@@ -130,7 +130,7 @@ struct NetInfo : ArchNetInfo
     int32_t udata = 0;
 
     PortRef driver;
-    std::vector<PortRef> users;
+    indexed_store<PortRef> users;
     dict<IdString, Property> attrs;
 
     // wire -> uphill_pip
@@ -155,6 +155,7 @@ struct PortInfo
     IdString name;
     NetInfo *net;
     PortType type;
+    store_index<PortRef> user_idx{};
 };
 
 struct Context;

--- a/common/pybindings.cc
+++ b/common/pybindings.cc
@@ -220,7 +220,7 @@ PYBIND11_EMBEDDED_MODULE(MODULE_NAME, m)
     readwrite_wrapper<PortInfo &, decltype(&PortInfo::type), &PortInfo::type, pass_through<PortType>,
                       pass_through<PortType>>::def_wrap(pi_cls, "type");
 
-    typedef std::vector<PortRef> PortRefVector;
+    typedef indexed_store<PortRef> PortRefVector;
     typedef dict<WireId, PipMap> WireMap;
     typedef pool<BelId> BelSet;
     typedef pool<WireId> WireSet;
@@ -288,7 +288,7 @@ PYBIND11_EMBEDDED_MODULE(MODULE_NAME, m)
     WRAP_MAP(m, WireMap, wrap_context<PipMap &>, "WireMap");
     WRAP_MAP_UPTR(m, RegionMap, "RegionMap");
 
-    WRAP_VECTOR(m, PortRefVector, wrap_context<PortRef>);
+    WRAP_INDEXSTORE(m, PortRefVector, wrap_context<PortRef>);
 
     typedef dict<IdString, ClockFmax> ClockFmaxMap;
     WRAP_MAP(m, ClockFmaxMap, pass_through<ClockFmax>, "ClockFmaxMap");

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -117,7 +117,7 @@ struct Router2
             NetInfo *ni = net.second.get();
             ni->udata = i;
             nets_by_udata.at(i) = ni;
-            nets.at(i).arcs.resize(ni->users.size());
+            nets.at(i).arcs.resize(ni->users.capacity());
 
             // Start net bounding box at overall min/max
             nets.at(i).bb.x0 = std::numeric_limits<int>::max();
@@ -133,10 +133,9 @@ struct Router2
                 nets.at(i).cy += drv_loc.y;
             }
 
-            for (size_t j = 0; j < ni->users.size(); j++) {
-                auto &usr = ni->users.at(j);
+            for (auto usr : ni->users.enumerate()) {
                 WireId src_wire = ctx->getNetinfoSourceWire(ni);
-                for (auto &dst_wire : ctx->getNetinfoSinkWires(ni, usr)) {
+                for (auto &dst_wire : ctx->getNetinfoSinkWires(ni, usr.value)) {
                     nets.at(i).src_wire = src_wire;
                     if (ni->driver.cell == nullptr)
                         src_wire = dst_wire;
@@ -146,10 +145,10 @@ struct Router2
                         log_error("No wire found for port %s on source cell %s.\n", ctx->nameOf(ni->driver.port),
                                   ctx->nameOf(ni->driver.cell));
                     if (dst_wire == WireId())
-                        log_error("No wire found for port %s on destination cell %s.\n", ctx->nameOf(usr.port),
-                                  ctx->nameOf(usr.cell));
-                    nets.at(i).arcs.at(j).emplace_back();
-                    auto &ad = nets.at(i).arcs.at(j).back();
+                        log_error("No wire found for port %s on destination cell %s.\n", ctx->nameOf(usr.value.port),
+                                  ctx->nameOf(usr.value.cell));
+                    nets.at(i).arcs.at(usr.index.idx()).emplace_back();
+                    auto &ad = nets.at(i).arcs.at(usr.index.idx()).back();
                     ad.sink_wire = dst_wire;
                     // Set bounding box for this arc
                     ad.bb = ctx->getRouteBoundingBox(src_wire, dst_wire);
@@ -160,14 +159,14 @@ struct Router2
                     nets.at(i).bb.y1 = std::max(nets.at(i).bb.y1, ad.bb.y1);
                 }
                 // Add location to centroid sum
-                Loc usr_loc = ctx->getBelLocation(usr.cell->bel);
+                Loc usr_loc = ctx->getBelLocation(usr.value.cell->bel);
                 nets.at(i).cx += usr_loc.x;
                 nets.at(i).cy += usr_loc.y;
             }
             nets.at(i).hpwl = std::max(
                     std::abs(nets.at(i).bb.y1 - nets.at(i).bb.y0) + std::abs(nets.at(i).bb.x1 - nets.at(i).bb.x0), 1);
-            nets.at(i).cx /= int(ni->users.size() + 1);
-            nets.at(i).cy /= int(ni->users.size() + 1);
+            nets.at(i).cx /= int(ni->users.entries() + 1);
+            nets.at(i).cy /= int(ni->users.entries() + 1);
             if (ctx->debug)
                 log_info("%s: bb=(%d, %d)->(%d, %d) c=(%d, %d) hpwl=%d\n", ctx->nameOf(ni), nets.at(i).bb.x0,
                          nets.at(i).bb.y0, nets.at(i).bb.x1, nets.at(i).bb.y1, nets.at(i).cx, nets.at(i).cy,
@@ -218,11 +217,11 @@ struct Router2
         for (auto &net_pair : ctx->nets) {
             auto *net = net_pair.second.get();
             auto &nd = nets.at(net->udata);
-            for (size_t usr = 0; usr < net->users.size(); usr++) {
-                auto &ad = nd.arcs.at(usr);
+            for (auto usr : net->users.enumerate()) {
+                auto &ad = nd.arcs.at(usr.index.idx());
                 for (size_t phys_pin = 0; phys_pin < ad.size(); phys_pin++) {
-                    if (check_arc_routing(net, usr, phys_pin)) {
-                        record_prerouted_net(net, usr, phys_pin);
+                    if (check_arc_routing(net, usr.index, phys_pin)) {
+                        record_prerouted_net(net, usr.index, phys_pin);
                     }
                 }
             }
@@ -261,7 +260,7 @@ struct Router2
         // Nets that failed routing
         std::vector<NetInfo *> failed_nets;
 
-        std::vector<std::pair<size_t, size_t>> route_arcs;
+        std::vector<std::pair<store_index<PortRef>, size_t>> route_arcs;
 
         std::priority_queue<QueuedWire, std::vector<QueuedWire>, QueuedWire::Greater> fwd_queue, bwd_queue;
         // Special case where one net has multiple logical arcs to the same physical sink
@@ -305,7 +304,7 @@ struct Router2
             log(__VA_ARGS__);                                                                                          \
     } while (0)
 
-    void bind_pip_internal(PerNetData &net, size_t user, int wire, PipId pip)
+    void bind_pip_internal(PerNetData &net, store_index<PortRef> user, int wire, PipId pip)
     {
         auto &wd = flat_wires.at(wire);
         auto found = net.wires.find(wd.w);
@@ -323,7 +322,7 @@ struct Router2
         }
     }
 
-    void unbind_pip_internal(PerNetData &net, size_t user, WireId wire)
+    void unbind_pip_internal(PerNetData &net, store_index<PortRef> user, WireId wire)
     {
         auto &wd = wire_data(wire);
         auto &b = net.wires.at(wd.w);
@@ -335,10 +334,10 @@ struct Router2
         }
     }
 
-    void ripup_arc(NetInfo *net, size_t user, size_t phys_pin)
+    void ripup_arc(NetInfo *net, store_index<PortRef> user, size_t phys_pin)
     {
         auto &nd = nets.at(net->udata);
-        auto &ad = nd.arcs.at(user).at(phys_pin);
+        auto &ad = nd.arcs.at(user.idx()).at(phys_pin);
         if (!ad.routed)
             return;
         WireId src = nets.at(net->udata).src_wire;
@@ -351,7 +350,8 @@ struct Router2
         ad.routed = false;
     }
 
-    float score_wire_for_arc(NetInfo *net, size_t user, size_t phys_pin, WireId wire, PipId pip, float crit_weight)
+    float score_wire_for_arc(NetInfo *net, store_index<PortRef> user, size_t phys_pin, WireId wire, PipId pip,
+                             float crit_weight)
     {
         auto &wd = wire_data(wire);
         auto &nd = nets.at(net->udata);
@@ -367,13 +367,14 @@ struct Router2
         float present_cost = 1.0f + overuse * curr_cong_weight * crit_weight;
         if (pip != PipId()) {
             Loc pl = ctx->getPipLocation(pip);
-            bias_cost = cfg.bias_cost_factor * (base_cost / int(net->users.size())) *
+            bias_cost = cfg.bias_cost_factor * (base_cost / int(net->users.entries())) *
                         ((std::abs(pl.x - nd.cx) + std::abs(pl.y - nd.cy)) / float(nd.hpwl));
         }
         return base_cost * hist_cost * present_cost / (1 + (source_uses * crit_weight)) + bias_cost;
     }
 
-    float get_togo_cost(NetInfo *net, size_t user, int wire, WireId src_sink, float crit_weight, bool bwd = false)
+    float get_togo_cost(NetInfo *net, store_index<PortRef> user, int wire, WireId src_sink, float crit_weight,
+                        bool bwd = false)
     {
         auto &nd = nets.at(net->udata);
         auto &wd = flat_wires[wire];
@@ -386,10 +387,10 @@ struct Router2
         return (ctx->getDelayNS(est_delay) / (1 + source_uses * crit_weight)) + cfg.ipin_cost_adder;
     }
 
-    bool check_arc_routing(NetInfo *net, size_t usr, size_t phys_pin)
+    bool check_arc_routing(NetInfo *net, store_index<PortRef> usr, size_t phys_pin)
     {
         auto &nd = nets.at(net->udata);
-        auto &ad = nd.arcs.at(usr).at(phys_pin);
+        auto &ad = nd.arcs.at(usr.idx()).at(phys_pin);
         WireId src_wire = nets.at(net->udata).src_wire;
         WireId cursor = ad.sink_wire;
         while (nd.wires.count(cursor)) {
@@ -404,10 +405,10 @@ struct Router2
         return (cursor == src_wire);
     }
 
-    void record_prerouted_net(NetInfo *net, size_t usr, size_t phys_pin)
+    void record_prerouted_net(NetInfo *net, store_index<PortRef> usr, size_t phys_pin)
     {
         auto &nd = nets.at(net->udata);
-        auto &ad = nd.arcs.at(usr).at(phys_pin);
+        auto &ad = nd.arcs.at(usr.idx()).at(phys_pin);
         ad.routed = true;
 
         WireId src = nets.at(net->udata).src_wire;
@@ -449,7 +450,7 @@ struct Router2
     }
 
     // Find all the wires that must be used to route a given arc
-    bool reserve_wires_for_arc(NetInfo *net, size_t i)
+    bool reserve_wires_for_arc(NetInfo *net, store_index<PortRef> i)
     {
         bool did_something = false;
         WireId src = ctx->getNetinfoSourceWire(net);
@@ -459,7 +460,7 @@ struct Router2
             WireId cursor = sink;
             bool done = false;
             if (ctx->debug)
-                log("reserving wires for arc %d (%s.%s) of net %s\n", int(i), ctx->nameOf(usr.cell),
+                log("reserving wires for arc %d (%s.%s) of net %s\n", i.idx(), ctx->nameOf(usr.cell),
                     ctx->nameOf(usr.port), ctx->nameOf(net));
             while (!done) {
                 auto &wd = wire_data(cursor);
@@ -501,8 +502,8 @@ struct Router2
                 WireId src = ctx->getNetinfoSourceWire(net);
                 if (src == WireId())
                     continue;
-                for (size_t i = 0; i < net->users.size(); i++)
-                    did_something |= reserve_wires_for_arc(net, i);
+                for (auto usr : net->users.enumerate())
+                    did_something |= reserve_wires_for_arc(net, usr.index);
             }
         } while (did_something);
     }
@@ -529,12 +530,12 @@ struct Router2
         return false;
     }
 
-    void update_wire_by_loc(ThreadContext &t, NetInfo *net, size_t i, size_t phys_pin, bool is_mt)
+    void update_wire_by_loc(ThreadContext &t, NetInfo *net, store_index<PortRef> i, size_t phys_pin, bool is_mt)
     {
         if (is_pseudo_const_net(net))
             return;
         auto &nd = nets.at(net->udata);
-        auto &ad = nd.arcs.at(i).at(phys_pin);
+        auto &ad = nd.arcs.at(i.idx()).at(phys_pin);
         WireId cursor = ad.sink_wire;
         if (!nd.wires.count(cursor))
             return;
@@ -571,28 +572,29 @@ struct Router2
     bool was_visited_fwd(int wire) { return flat_wires.at(wire).visited_fwd; }
     bool was_visited_bwd(int wire) { return flat_wires.at(wire).visited_bwd; }
 
-    float get_arc_crit(NetInfo *net, size_t i)
+    float get_arc_crit(NetInfo *net, store_index<PortRef> i)
     {
         if (!timing_driven)
             return 0;
         return tmg.get_criticality(CellPortKey(net->users.at(i)));
     }
 
-    bool arc_failed_slack(NetInfo *net, size_t usr_idx)
+    bool arc_failed_slack(NetInfo *net, store_index<PortRef> usr_idx)
     {
         return timing_driven_ripup &&
                (tmg.get_setup_slack(CellPortKey(net->users.at(usr_idx))) < (2 * ctx->getDelayEpsilon()));
     }
 
-    ArcRouteResult route_arc(ThreadContext &t, NetInfo *net, size_t i, size_t phys_pin, bool is_mt, bool is_bb = true)
+    ArcRouteResult route_arc(ThreadContext &t, NetInfo *net, store_index<PortRef> i, size_t phys_pin, bool is_mt,
+                             bool is_bb = true)
     {
         // Do some initial lookups and checks
         auto arc_start = std::chrono::high_resolution_clock::now();
         auto &nd = nets[net->udata];
-        auto &ad = nd.arcs.at(i).at(phys_pin);
+        auto &ad = nd.arcs.at(i.idx()).at(phys_pin);
         auto &usr = net->users.at(i);
-        ROUTE_LOG_DBG("Routing arc %d of net '%s' (%d, %d) -> (%d, %d)\n", int(i), ctx->nameOf(net), ad.bb.x0, ad.bb.y0,
-                      ad.bb.x1, ad.bb.y1);
+        ROUTE_LOG_DBG("Routing arc %d of net '%s' (%d, %d) -> (%d, %d)\n", i.idx(), ctx->nameOf(net), ad.bb.x0,
+                      ad.bb.y0, ad.bb.x1, ad.bb.y1);
         WireId src_wire = ctx->getNetinfoSourceWire(net), dst_wire = ctx->getNetinfoSinkWire(net, usr, phys_pin);
         if (src_wire == WireId())
             ARC_LOG_ERR("No wire found for port %s on source cell %s.\n", ctx->nameOf(net->driver.port),
@@ -614,7 +616,7 @@ struct Router2
         //     0. starting within a small range of existing routing
         //     1. expanding from all routing
         int mode = 0;
-        if (net->users.size() < 4 || nd.wires.empty() || (crit > 0.95))
+        if (net->users.entries() < 4 || nd.wires.empty() || (crit > 0.95))
             mode = 1;
 
         // This records the point where forwards and backwards routing met
@@ -844,11 +846,11 @@ struct Router2
             t.processed_sinks.insert(dst_wire);
             ad.routed = true;
             auto arc_end = std::chrono::high_resolution_clock::now();
-            ROUTE_LOG_DBG("Routing arc %d of net '%s' (is_bb = %d) took %02fs\n", int(i), ctx->nameOf(net), is_bb,
+            ROUTE_LOG_DBG("Routing arc %d of net '%s' (is_bb = %d) took %02fs\n", i.idx(), ctx->nameOf(net), is_bb,
                           std::chrono::duration<float>(arc_end - arc_start).count());
         } else {
             auto arc_end = std::chrono::high_resolution_clock::now();
-            ROUTE_LOG_DBG("Failed routing arc %d of net '%s' (is_bb = %d) took %02fs\n", int(i), ctx->nameOf(net),
+            ROUTE_LOG_DBG("Failed routing arc %d of net '%s' (is_bb = %d) took %02fs\n", i.idx(), ctx->nameOf(net),
                           is_bb, std::chrono::duration<float>(arc_end - arc_start).count());
             result = ARC_RETRY_WITHOUT_BB;
         }
@@ -880,26 +882,26 @@ struct Router2
         t.in_wire_by_loc.clear();
         auto &nd = nets.at(net->udata);
         bool failed_slack = false;
-        for (size_t i = 0; i < net->users.size(); i++)
-            failed_slack |= arc_failed_slack(net, i);
-        for (size_t i = 0; i < net->users.size(); i++) {
-            auto &ad = nd.arcs.at(i);
+        for (auto usr : net->users.enumerate())
+            failed_slack |= arc_failed_slack(net, usr.index);
+        for (auto usr : net->users.enumerate()) {
+            auto &ad = nd.arcs.at(usr.index.idx());
             for (size_t j = 0; j < ad.size(); j++) {
                 // Ripup failed arcs to start with
                 // Check if arc is already legally routed
-                if (!failed_slack && check_arc_routing(net, i, j)) {
-                    update_wire_by_loc(t, net, i, j, true);
+                if (!failed_slack && check_arc_routing(net, usr.index, j)) {
+                    update_wire_by_loc(t, net, usr.index, j, true);
                     continue;
                 }
 
                 // Ripup arc to start with
-                ripup_arc(net, i, j);
-                t.route_arcs.emplace_back(i, j);
+                ripup_arc(net, usr.index, j);
+                t.route_arcs.emplace_back(usr.index, j);
             }
         }
         // Route most critical arc first
         std::stable_sort(t.route_arcs.begin(), t.route_arcs.end(),
-                         [&](std::pair<size_t, size_t> a, std::pair<size_t, size_t> b) {
+                         [&](std::pair<store_index<PortRef>, size_t> a, std::pair<store_index<PortRef>, size_t> b) {
                              return get_arc_crit(net, a.first) > get_arc_crit(net, b.first);
                          });
         for (auto a : t.route_arcs) {
@@ -913,7 +915,7 @@ struct Router2
                 } else {
                     // Attempt a re-route without the bounding box constraint
                     ROUTE_LOG_DBG("Rerouting arc %d.%d of net '%s' without bounding box, possible tricky routing...\n",
-                                  int(a.first), int(a.second), ctx->nameOf(net));
+                                  a.first.idx(), int(a.second), ctx->nameOf(net));
                     auto res2 = route_arc(t, net, a.first, a.second, is_mt, false);
                     // If this also fails, no choice but to give up
                     if (res2 != ARC_SUCCESS) {
@@ -926,7 +928,7 @@ struct Router2
                                 log("\n");
                             }
                         }
-                        log_error("Failed to route arc %d.%d of net '%s', from %s to %s.\n", int(a.first),
+                        log_error("Failed to route arc %d.%d of net '%s', from %s to %s.\n", a.first.idx(),
                                   int(a.second), ctx->nameOf(net), ctx->nameOfWire(ctx->getNetinfoSourceWire(net)),
                                   ctx->nameOfWire(ctx->getNetinfoSinkWire(net, net->users.at(a.first), a.second)));
                     }
@@ -991,7 +993,7 @@ struct Router2
         }
     }
 
-    bool bind_and_check(NetInfo *net, int usr_idx, int phys_pin)
+    bool bind_and_check(NetInfo *net, store_index<PortRef> usr_idx, int phys_pin)
     {
 #ifdef ARCH_ECP5
         if (net->is_global)
@@ -999,7 +1001,7 @@ struct Router2
 #endif
         bool success = true;
         auto &nd = nets.at(net->udata);
-        auto &ad = nd.arcs.at(usr_idx).at(phys_pin);
+        auto &ad = nd.arcs.at(usr_idx.idx()).at(phys_pin);
         auto &usr = net->users.at(usr_idx);
         WireId src = ctx->getNetinfoSourceWire(net);
         // Skip routes with no source
@@ -1043,7 +1045,8 @@ struct Router2
             if (!nd.wires.count(cursor)) {
                 log("Failure details:\n");
                 log("    Cursor: %s\n", ctx->nameOfWire(cursor));
-                log_error("Internal error; incomplete route tree for arc %d of net %s.\n", usr_idx, ctx->nameOf(net));
+                log_error("Internal error; incomplete route tree for arc %d of net %s.\n", usr_idx.idx(),
+                          ctx->nameOf(net));
             }
             PipId p = nd.wires.at(cursor).first;
             if (ctx->checkPipAvailForNet(p, net)) {
@@ -1104,9 +1107,9 @@ struct Router2
             }
 
             // Bind the arcs using the routes we have discovered
-            for (size_t i = 0; i < net->users.size(); i++) {
-                for (size_t phys_pin = 0; phys_pin < nets.at(net->udata).arcs.at(i).size(); phys_pin++) {
-                    if (!bind_and_check(net, i, phys_pin)) {
+            for (auto usr : net->users.enumerate()) {
+                for (size_t phys_pin = 0; phys_pin < nets.at(net->udata).arcs.at(usr.index.idx()).size(); phys_pin++) {
+                    if (!bind_and_check(net, usr.index, phys_pin)) {
                         ++arch_fail;
                         success = false;
                     }
@@ -1313,10 +1316,10 @@ struct Router2
                 route_net(tcs.at(N), fail, false);
     }
 
-    delay_t get_route_delay(int net, int usr_idx, int phys_idx)
+    delay_t get_route_delay(int net, store_index<PortRef> usr_idx, int phys_idx)
     {
         auto &nd = nets.at(net);
-        auto &ad = nd.arcs.at(usr_idx).at(phys_idx);
+        auto &ad = nd.arcs.at(usr_idx.idx()).at(phys_idx);
         WireId cursor = ad.sink_wire;
         if (cursor == WireId() || nd.src_wire == WireId())
             return 0;
@@ -1344,11 +1347,11 @@ struct Router2
                 continue;
 #endif
             auto &nd = nets.at(net);
-            for (int i = 0; i < int(nd.arcs.size()); i++) {
+            for (auto usr : ni->users.enumerate()) {
                 delay_t arc_delay = 0;
-                for (int j = 0; j < int(nd.arcs.at(i).size()); j++)
-                    arc_delay = std::max(arc_delay, get_route_delay(net, i, j));
-                tmg.set_route_delay(CellPortKey(ni->users.at(i)), DelayPair(arc_delay));
+                for (int j = 0; j < int(nd.arcs.at(usr.index.idx()).size()); j++)
+                    arc_delay = std::max(arc_delay, get_route_delay(net, usr.index, j));
+                tmg.set_route_delay(CellPortKey(usr.value), DelayPair(arc_delay));
             }
         }
     }
@@ -1416,8 +1419,8 @@ struct Router2
             if (timing_driven_ripup && iter < 500) {
                 for (size_t i = 0; i < nets_by_udata.size(); i++) {
                     NetInfo *ni = nets_by_udata.at(i);
-                    for (size_t j = 0; j < ni->users.size(); j++) {
-                        if (arc_failed_slack(ni, j)) {
+                    for (auto usr : ni->users.enumerate()) {
+                        if (arc_failed_slack(ni, usr.index)) {
                             failed_nets.insert(i);
                             ++tmgfail;
                         }
@@ -1451,7 +1454,7 @@ struct Router2
             log_info("1000 slowest nets by runtime:\n");
             for (int i = 0; i < std::min(int(nets_by_runtime.size()), 1000); i++) {
                 log("        %80s %6d %.1fms\n", nets_by_runtime.at(i).second.c_str(ctx),
-                    int(ctx->nets.at(nets_by_runtime.at(i).second)->users.size()),
+                    int(ctx->nets.at(nets_by_runtime.at(i).second)->users.entries()),
                     nets_by_runtime.at(i).first / 1000.0);
             }
         }

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -60,14 +60,6 @@ void TimingAnalyser::init_ports()
             data.cell_port = CellPortKey(ci->name, port.first);
         }
     }
-    // Cell port to net port mapping
-    for (auto &net : ctx->nets) {
-        NetInfo *ni = net.second.get();
-        if (ni->driver.cell != nullptr)
-            ports[CellPortKey(ni->driver)].net_port = NetPortKey(ni->name);
-        for (size_t i = 0; i < ni->users.size(); i++)
-            ports[CellPortKey(ni->users.at(i))].net_port = NetPortKey(ni->name, i);
-    }
 }
 
 void TimingAnalyser::get_cell_delays()
@@ -79,7 +71,7 @@ void TimingAnalyser::get_cell_delays()
 
         IdString name = port.first.port;
         // Ignore dangling ports altogether for timing purposes
-        if (pd.net_port.net == IdString())
+        if (!pi.net)
             continue;
         pd.cell_arcs.clear();
         int clkInfoCount = 0;

--- a/common/timing.h
+++ b/common/timing.h
@@ -44,28 +44,6 @@ struct CellPortKey
     }
 };
 
-struct NetPortKey
-{
-    IdString net;
-    size_t idx;
-    NetPortKey(){};
-    explicit NetPortKey(IdString net) : net(net), idx(DRIVER_IDX){};        // driver
-    explicit NetPortKey(IdString net, size_t user) : net(net), idx(user){}; // user
-
-    static const size_t DRIVER_IDX = std::numeric_limits<size_t>::max();
-
-    inline bool is_driver() const { return (idx == DRIVER_IDX); }
-    inline size_t user_idx() const
-    {
-        NPNR_ASSERT(idx != DRIVER_IDX);
-        return idx;
-    }
-
-    unsigned int hash() const { return mkhash(net.hash(), idx); }
-
-    inline bool operator==(const NetPortKey &other) const { return (net == other.net) && (idx == other.idx); }
-};
-
 struct ClockDomainKey
 {
     IdString clock;
@@ -194,7 +172,6 @@ struct TimingAnalyser
     struct PerPort
     {
         CellPortKey cell_port;
-        NetPortKey net_port;
         PortType type;
         // per domain timings
         dict<domain_id_t, ArrivReqTime> arrival;

--- a/ecp5/cells.cc
+++ b/ecp5/cells.cc
@@ -212,10 +212,7 @@ static void replace_port_safe(bool has_ff, CellInfo *ff, IdString ff_port, CellI
         NPNR_ASSERT(lc->ports.at(lc_port).net == ff->ports.at(ff_port).net);
         NetInfo *ffnet = ff->ports.at(ff_port).net;
         if (ffnet != nullptr)
-            ffnet->users.erase(
-                    std::remove_if(ffnet->users.begin(), ffnet->users.end(),
-                                   [ff, ff_port](PortRef port) { return port.cell == ff && port.port == ff_port; }),
-                    ffnet->users.end());
+            ffnet->users.remove(ff->ports.at(ff_port).user_idx);
     } else {
         ff->movePortTo(ff_port, lc, lc_port);
     }
@@ -477,7 +474,7 @@ void nxio_to_tr(Context *ctx, CellInfo *nxio, CellInfo *trio, std::vector<std::u
         inv_lut->connectPorts(id_Z, trio, id_T);
         created_cells.push_back(std::move(inv_lut));
 
-        if (donet->users.size() > 1) {
+        if (donet->users.entries() > 1) {
             for (auto user : donet->users)
                 log_info("     remaining tristate user: %s.%s\n", user.cell->name.c_str(ctx), user.port.c_str(ctx));
             log_error("unsupported tristate IO pattern for IO buffer '%s', "

--- a/fpga_interchange/arch.cc
+++ b/fpga_interchange/arch.cc
@@ -1377,7 +1377,7 @@ void Arch::merge_constant_nets()
             }
 
             NPNR_ASSERT(net->driver.port == gnd_cell_port);
-            std::vector<PortRef> users_copy = net->users;
+            indexed_store<PortRef> users_copy = net->users;
             for (const PortRef &port_ref : users_copy) {
                 IdString cell = port_ref.cell->name;
                 disconnectPort(cell, port_ref.port);
@@ -1400,7 +1400,7 @@ void Arch::merge_constant_nets()
             }
 
             NPNR_ASSERT(net->driver.port == vcc_cell_port);
-            std::vector<PortRef> users_copy = net->users;
+            indexed_store<PortRef> users_copy = net->users;
             for (const PortRef &port_ref : users_copy) {
                 IdString cell = port_ref.cell->name;
                 disconnectPort(cell, port_ref.port);

--- a/fpga_interchange/arch_pack_clusters.cc
+++ b/fpga_interchange/arch_pack_clusters.cc
@@ -945,10 +945,10 @@ void Arch::prepare_cluster(const ClusterPOD *cluster, uint32_t index)
                 if (port_info.type == PORT_OUT) {
                     exclude_nets.insert(port_info.net->name);
                     auto &users = port_info.net->users;
-                    if (users.size() != 1)
+                    if (users.entries() != 1)
                         continue;
 
-                    CellInfo *user_cell = users[0].cell;
+                    CellInfo *user_cell = (*users.begin()).cell;
                     if (user_cell == nullptr)
                         continue;
 
@@ -978,7 +978,7 @@ void Arch::prepare_cluster(const ClusterPOD *cluster, uint32_t index)
                 } else if (port_info.type == PORT_IN) {
                     auto &driver = port_info.net->driver;
                     auto &users = port_info.net->users;
-                    if (users.size() != 1)
+                    if (users.entries() != 1)
                         continue;
 
                     CellInfo *driver_cell = driver.cell;

--- a/frontend/frontend_base.h
+++ b/frontend/frontend_base.h
@@ -690,7 +690,7 @@ template <typename FrontendType> struct GenericFrontend
         // Combine users
         for (auto &usr : mergee->users) {
             usr.cell->ports[usr.port].net = base;
-            base->users.push_back(usr);
+            usr.cell->ports[usr.port].user_idx = base->users.add(usr);
         }
         // Point aliases to the new net
         for (IdString alias : mergee->aliases) {

--- a/generic/cells.cc
+++ b/generic/cells.cc
@@ -121,7 +121,7 @@ void nxio_to_iob(Context *ctx, CellInfo *nxio, CellInfo *iob, pool<IdString> &to
         tbuf->movePortTo(ctx->id("A"), iob, ctx->id("I"));
         tbuf->movePortTo(ctx->id("E"), iob, ctx->id("EN"));
 
-        if (donet->users.size() > 1) {
+        if (donet->users.entries() > 1) {
             for (auto user : donet->users)
                 log_info("     remaining tristate user: %s.%s\n", user.cell->name.c_str(ctx), user.port.c_str(ctx));
             log_error("unsupported tristate IO pattern for IO buffer '%s', "

--- a/generic/pack.cc
+++ b/generic/pack.cc
@@ -124,9 +124,10 @@ static void set_net_constant(const Context *ctx, NetInfo *orig, NetInfo *constne
                 log_info("%s user %s\n", orig->name.c_str(ctx), uc->name.c_str(ctx));
             if ((is_lut(ctx, uc) || is_lc(ctx, uc)) && (user.port.str(ctx).at(0) == 'I') && !constval) {
                 uc->ports[user.port].net = nullptr;
+                uc->ports[user.port].user_idx = {};
             } else {
                 uc->ports[user.port].net = constnet;
-                constnet->users.push_back(user);
+                uc->ports[user.port].user_idx = constnet->users.add(user);
             }
         }
     }
@@ -224,8 +225,8 @@ static void pack_io(Context *ctx)
                          ci->type.c_str(ctx), ci->name.c_str(ctx));
                 NetInfo *net = iob->ports.at(ctx->id("PAD")).net;
                 if (((ci->type == ctx->id("$nextpnr_ibuf") || ci->type == ctx->id("$nextpnr_iobuf")) &&
-                     net->users.size() > 1) ||
-                    (ci->type == ctx->id("$nextpnr_obuf") && (net->users.size() > 2 || net->driver.cell != nullptr)))
+                     net->users.entries() > 1) ||
+                    (ci->type == ctx->id("$nextpnr_obuf") && (net->users.entries() > 2 || net->driver.cell != nullptr)))
                     log_error("PAD of %s '%s' connected to more than a single top level IO.\n", iob->type.c_str(ctx),
                               iob->name.c_str(ctx));
 

--- a/generic/viaduct/okami/okami.cc
+++ b/generic/viaduct/okami/okami.cc
@@ -511,7 +511,7 @@ struct OkamiImpl : ViaductAPI
         const auto &ff_data = fast_cell_info.at(ff->flat_index);
         // In our example arch; the FF D can either be driven from LUT F or LUT I3
         // so either; FF D must equal LUT F or LUT I3 must be unused
-        if (ff_data.ff_d == lut_data.lut_f && lut_data.lut_f->users.size() == 1)
+        if (ff_data.ff_d == lut_data.lut_f && lut_data.lut_f->users.entries() == 1)
             return true;
         // Can't route FF and LUT output separately
         return false;

--- a/generic/viaduct_helpers.cc
+++ b/generic/viaduct_helpers.cc
@@ -96,7 +96,7 @@ int ViaductHelpers::constrain_cell_pairs(const pool<CellTypePort> &src_ports, co
                 continue;
             if (!src_ports.count(CellTypePort(ci.type, port.first)))
                 continue;
-            if (!allow_fanout && port.second.net->users.size() > 1)
+            if (!allow_fanout && port.second.net->users.entries() > 1)
                 continue;
             for (auto &usr : port.second.net->users) {
                 if (!sink_ports.count(CellTypePort(usr)))
@@ -151,7 +151,7 @@ void ViaductHelpers::replace_constants(CellTypePort vcc_driver, CellTypePort gnd
         NetInfo *replace = (ni.driver.cell->type == ctx->id("VCC")) ? vcc_net : gnd_net;
         for (auto &usr : ni.users) {
             usr.cell->ports.at(usr.port).net = replace;
-            replace->users.push_back(usr);
+            usr.cell->ports.at(usr.port).user_idx = replace->users.add(usr);
         }
         trim_cells.push_back(ni.driver.cell->name);
         trim_nets.push_back(ni.name);

--- a/gowin/pack.cc
+++ b/gowin/pack.cc
@@ -68,7 +68,7 @@ static void pack_alus(Context *ctx)
                 continue;
             }
 
-            if (!is_alu(ctx, cin_ci) || cin->users.size() > 1) {
+            if (!is_alu(ctx, cin_ci) || cin->users.entries() > 1) {
                 if (ctx->verbose) {
                     log_info("ALU head found %s. CIN net is %s\n", ctx->nameOf(ci), ctx->nameOf(cin));
                 }
@@ -177,9 +177,9 @@ static void pack_alus(Context *ctx)
 
             new_cells.push_back(std::move(packed));
 
-            if (cout != nullptr && cout->users.size() > 0) {
+            if (cout != nullptr && cout->users.entries() > 0) {
                 // if COUT used by logic
-                if ((cout->users.size() > 1) || (!is_alu(ctx, cout->users.at(0).cell))) {
+                if ((cout->users.entries() > 1) || (!is_alu(ctx, (*cout->users.begin()).cell))) {
                     if (ctx->verbose) {
                         log_info("COUT is used by logic\n");
                     }
@@ -204,7 +204,7 @@ static void pack_alus(Context *ctx)
                     break;
                 }
                 // next ALU
-                ci = cout->users.at(0).cell;
+                ci = (*cout->users.begin()).cell;
                 // if ALU is too big
                 if (alu_idx == (ctx->gridDimX - 2) * 6 - 1) {
                     log_error("ALU %s is the %dth in the chain. Such long chains are not supported.\n", ctx->nameOf(ci),
@@ -596,9 +596,10 @@ static void set_net_constant(const Context *ctx, NetInfo *orig, NetInfo *constne
                 log_info("%s user %s\n", ctx->nameOf(orig), ctx->nameOf(uc));
             if ((is_lut(ctx, uc) || is_lc(ctx, uc)) && (user.port.str(ctx).at(0) == 'I') && !constval) {
                 uc->ports[user.port].net = nullptr;
+                uc->ports[user.port].user_idx = {};
             } else {
                 uc->ports[user.port].net = constnet;
-                constnet->users.push_back(user);
+                uc->ports[user.port].user_idx = constnet->users.add(user);
             }
         }
     }

--- a/ice40/bitstream.cc
+++ b/ice40/bitstream.cc
@@ -1146,7 +1146,7 @@ bool read_asc(Context *ctx, std::istream &in)
                             if (port.second.type == PORT_OUT)
                                 net->driver = ref;
                             else
-                                net->users.push_back(ref);
+                                port.second.user_idx = net->users.add(ref);
                         }
                     }
                 }

--- a/ice40/cells.cc
+++ b/ice40/cells.cc
@@ -466,7 +466,7 @@ void nxio_to_sb(Context *ctx, CellInfo *nxio, CellInfo *sbio, pool<IdString> &to
         tbuf->movePortTo(id_A, sbio, id_D_OUT_0);
         tbuf->movePortTo(id_E, sbio, id_OUTPUT_ENABLE);
 
-        if (donet->users.size() > 1) {
+        if (donet->users.entries() > 1) {
             for (auto user : donet->users)
                 log_info("     remaining tristate user: %s.%s\n", user.cell->name.c_str(ctx), user.port.c_str(ctx));
             log_error("unsupported tristate IO pattern for IO buffer '%s', "

--- a/machxo2/pack.cc
+++ b/machxo2/pack.cc
@@ -160,7 +160,7 @@ static void set_net_constant(Context *ctx, NetInfo *orig, NetInfo *constnet, boo
                 uc->ports[user.port].net = constnet;
             }
 
-            constnet->users.push_back(user);
+            user.cell->ports.at(user.port).user_idx = constnet->users.add(user);
         }
     }
     orig->users.clear();

--- a/mistral/pack.cc
+++ b/mistral/pack.cc
@@ -200,10 +200,10 @@ struct MistralPacker
                 NetInfo *o = ci->getPort(id_O);
                 if (o == nullptr)
                     ;
-                else if (o->users.size() > 1)
+                else if (o->users.entries() > 1)
                     log_error("Top level pin '%s' has multiple input buffers\n", ctx->nameOf(port.first));
-                else if (o->users.size() == 1)
-                    top_port = o->users.at(0);
+                else if (o->users.entries() == 1)
+                    top_port = *o->users.begin();
             }
             if (ci->type == ctx->id("$nextpnr_obuf") || ci->type == ctx->id("$nextpnr_iobuf")) {
                 // Might have an output buffer (OB etc) connected to it
@@ -215,9 +215,9 @@ struct MistralPacker
                     top_port = i->driver;
                 }
                 // Edge case of a bidirectional buffer driving an output pin
-                if (i->users.size() > 2) {
+                if (i->users.entries() > 2) {
                     log_error("Top level pin '%s' has illegal buffer configuration\n", ctx->nameOf(port.first));
-                } else if (i->users.size() == 2) {
+                } else if (i->users.entries() == 2) {
                     if (top_port.cell != nullptr)
                         log_error("Top level pin '%s' has illegal buffer configuration\n", ctx->nameOf(port.first));
                     for (auto &usr : i->users) {
@@ -300,9 +300,9 @@ struct MistralPacker
                 const NetInfo *co = cursor->getPort(id_CO);
                 if (co == nullptr || co->users.empty())
                     break;
-                if (co->users.size() > 1)
+                if (co->users.entries() > 1)
                     log_error("Carry net %s has more than one sink!\n", ctx->nameOf(co));
-                auto &usr = co->users.at(0);
+                auto &usr = *co->users.begin();
                 if (usr.port != id_CI)
                     log_error("Carry net %s drives port %s, expected CI\n", ctx->nameOf(co), ctx->nameOf(usr.port));
                 cursor = usr.cell;

--- a/nexus/global.cc
+++ b/nexus/global.cc
@@ -72,7 +72,7 @@ struct NexusGlobalRouter
 
     // Dedicated backwards BFS routing for global networks
     template <typename Tfilt>
-    bool backwards_bfs_route(NetInfo *net, size_t user_idx, int iter_limit, bool strict, Tfilt pip_filter)
+    bool backwards_bfs_route(NetInfo *net, store_index<PortRef> user_idx, int iter_limit, bool strict, Tfilt pip_filter)
     {
         // Queue of wires to visit
         std::queue<WireId> visit;
@@ -178,9 +178,9 @@ struct NexusGlobalRouter
 
     void route_clk_net(NetInfo *net)
     {
-        for (size_t i = 0; i < net->users.size(); i++)
-            backwards_bfs_route(net, i, 1000000, true, [&](PipId pip) {
-                return (is_relaxed_sink(net->users.at(i)) || global_pip_filter(pip)) && routeability_pip_filter(pip);
+        for (auto usr : net->users.enumerate())
+            backwards_bfs_route(net, usr.index, 1000000, true, [&](PipId pip) {
+                return (is_relaxed_sink(usr.value) || global_pip_filter(pip)) && routeability_pip_filter(pip);
             });
         log_info("    routed net '%s' using global resources\n", ctx->nameOf(net));
     }


### PR DESCRIPTION
This uses a new data structure for net.users that allows gaps, so removing a port from a net is no longer an O(n) operation on the number of users the net has.