### PR TITLE
interchange: lut map cache: remove hardcoded values

### DIFF
--- a/fpga_interchange/arch.cc
+++ b/fpga_interchange/arch.cc
@@ -224,10 +224,14 @@ Arch::Arch(ArchArgs args) : args(args), disallow_site_routing(false)
 
     // Initially LutElement vectors for each tile type.
     tile_type_index = 0;
+    max_lut_cells = 0;
+    max_lut_pins = 0;
     lut_elements.resize(chip_info->tile_types.size());
     for (const TileTypeInfoPOD &tile_type : chip_info->tile_types) {
         std::vector<LutElement> &elements = lut_elements[tile_type_index++];
         elements.reserve(tile_type.lut_elements.size());
+
+        int lut_cells_count = 0;
         for (auto &lut_element : tile_type.lut_elements) {
             elements.emplace_back();
 
@@ -252,10 +256,15 @@ Arch::Arch(ArchArgs args) : args(args), disallow_site_routing(false)
                 }
 
                 lut.output_pin = IdString(lut_bel.out_pin);
+                lut_cells_count++;
+
+                max_lut_pins = std::max((int)lut_bel.pins.size(), max_lut_pins);
             }
 
             element.compute_pin_order();
         }
+
+        max_lut_cells = std::max(lut_cells_count, max_lut_cells);
     }
 
     // Map lut cell types to their LutCellPOD

--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -1134,6 +1134,11 @@ struct Arch : ArchAPI<ArchRanges>
     IdString vcc_cell_pin;
     std::vector<std::vector<LutElement>> lut_elements;
     dict<IdString, const LutCellPOD *> lut_cells;
+    
+    // Defines the max number of LUT cells in a site and LUT pins
+    // to allow a correct functioning of the site lut mapping cache
+    int max_lut_cells;
+    int max_lut_pins;
 
     // Of the LUT cells, which is used for wires?
     // Note: May be null in arch's without wire LUT types.  Assumption is

--- a/fpga_interchange/site_lut_mapping_cache.cc
+++ b/fpga_interchange/site_lut_mapping_cache.cc
@@ -58,6 +58,7 @@ SiteLutMappingKey SiteLutMappingKey::create(const SiteInformation &siteInfo)
     key.tileType = siteInfo.tile_type;
     key.siteType = ctx->chip_info->sites[siteInfo.site].site_type;
     key.numCells = 0;
+    key.cells.resize(ctx->max_lut_cells);
 
     // Get bound nets. Store localized (to the LUT cluster) net indices only
     // to get always the same key for the same LUT port configuration even
@@ -65,13 +66,13 @@ SiteLutMappingKey SiteLutMappingKey::create(const SiteInformation &siteInfo)
     dict<IdString, int32_t> netMap;
     for (CellInfo *cellInfo : lutCells) {
 
-        NPNR_ASSERT(key.numCells < SiteLutMappingKey::MAX_LUT_CELLS);
+        NPNR_ASSERT(key.numCells < key.cells.size());
         auto &cell = key.cells[key.numCells++];
 
         cell.type = cellInfo->type;
         cell.belIndex = cellInfo->bel.index;
 
-        cell.conns.fill(0);
+        cell.conns.resize(ctx->max_lut_pins, 0);
 
         size_t portId = 0;
         for (const auto &port : cellInfo->ports) {
@@ -96,7 +97,7 @@ SiteLutMappingKey SiteLutMappingKey::create(const SiteInformation &siteInfo)
                 }
             }
 
-            NPNR_ASSERT(portId < SiteLutMappingKey::MAX_LUT_INPUTS);
+            NPNR_ASSERT(portId < cell.conns.size());
             cell.conns[portId++] = netId;
         }
     }

--- a/fpga_interchange/site_lut_mapping_cache.h
+++ b/fpga_interchange/site_lut_mapping_cache.h
@@ -29,12 +29,6 @@ NEXTPNR_NAMESPACE_BEGIN
 // Key structure used in site LUT mapping cache
 struct SiteLutMappingKey
 {
-
-    // Maximum number of LUT cells per site
-    static constexpr size_t MAX_LUT_CELLS = 8;
-    // Maximum number of LUT inputs per cell
-    static constexpr size_t MAX_LUT_INPUTS = 6;
-
     // LUT Cell data
     struct Cell
     {
@@ -44,7 +38,7 @@ struct SiteLutMappingKey
         // Port to net assignments. These are local net ids generated during
         // key creation. This is to abstract connections from actual design
         // net names. the Id 0 means unconnected.
-        std::array<int32_t, MAX_LUT_INPUTS> conns;
+        std::vector<int32_t> conns;
 
         bool operator==(const Cell &other) const
         {
@@ -60,7 +54,7 @@ struct SiteLutMappingKey
     int32_t tileType;                      // Tile type
     int32_t siteType;                      // Site type in that tile type
     size_t numCells;                       // LUT cell count
-    std::array<Cell, MAX_LUT_CELLS> cells; // LUT cell data
+    std::vector<Cell> cells; // LUT cell data
 
     unsigned int hash_; // Precomputed hash
 
@@ -80,7 +74,7 @@ struct SiteLutMappingKey
             const auto &cell = cells[j];
             hash_ = mkhash(hash_, cell.type.index);
             hash_ = mkhash(hash_, cell.belIndex);
-            for (size_t i = 0; i < MAX_LUT_INPUTS; ++i) {
+            for (size_t i = 0; i < cell.conns.size(); ++i) {
                 hash_ = mkhash(hash_, cell.conns[i]);
             }
         }


### PR DESCRIPTION
This PR removes some hardcoded values which cause failures when using larger devices such as US+ which have double the count of lut cells placeable in a site.

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>