### PR TITLE
nexus: DCCs cannot be cascaded

### DIFF
--- a/nexus/pack.cc
+++ b/nexus/pack.cc
@@ -883,7 +883,7 @@ struct NexusPacker
         for (size_t i = 0; i < std::min<size_t>(clk_fanout.size(), available_globals); i++) {
             NetInfo *net = ctx->nets.at(clk_fanout.at(i).second).get();
             log_info("     promoting clock net '%s'\n", ctx->nameOf(net));
-            insert_buffer(net, id_DCC, "glb_clk", id_CLKI, id_CLKO, [](const PortRef &port) { return true; });
+            insert_buffer(net, id_DCC, "glb_clk", id_CLKI, id_CLKO, [&](const PortRef &port) { return port.cell->type != id_DCC; });
         }
     }
 


### PR DESCRIPTION
This commit solves implicit cascading when clock signal drives DCC and logic

Signed-off-by: Maciej Dudek <mdudek@antmicro.com>