### PR TITLE
mistral: M10K initialisation support

### DIFF
--- a/mistral/constids.inc
+++ b/mistral/constids.inc
@@ -100,6 +100,7 @@ X(cyclonev_oscillator)
 X(cyclonev_hps_interface_mpu_general_purpose)
 
 X(MISTRAL_M10K)
+X(INIT)
 X(ADDRSTALLA)
 X(ADDRSTALLB)
 X(CFG_ABITS)


### PR DESCRIPTION
Maybe there are cleaner ways of doing this, but this works fine*.

\* Sometimes. That needs to be investigated.