### PR TITLE
[fpga_interchange] FIX: Don't hold reference to current visit in route_global_arc

### DIFF
--- a/fpga_interchange/globals.cc
+++ b/fpga_interchange/globals.cc
@@ -76,7 +76,7 @@ static int route_global_arc(Context *ctx, NetInfo *net, store_index<PortRef> usr
     while (!visit_queue.empty()) {
         WireId cursor = visit_queue.front();
         visit_queue.pop();
-        auto &curr_visit = visits.at(cursor);
+        auto curr_visit = visits.at(cursor);
         // We're now at least one layer deeper than a valid visit, any further exploration is futile
         if (startpoint != WireId() && curr_visit.total_hops > best_visit.total_hops)
             break;


### PR DESCRIPTION
This reference can become invalid after modifying the dict at line 109, because the dict implementation may reallocate it. Copy by value instead to ensure the validity of visit data.