### PR TITLE
gowin: Add the Global Set/Reset primitive

### DIFF
--- a/gowin/arch.cc
+++ b/gowin/arch.cc
@@ -991,6 +991,14 @@ Arch::Arch(ArchArgs args) : args(args)
             int z = 0;
             bool dff = true;
             switch (static_cast<ConstIds>(bel->type_id)) {
+            case ID_GSR0:
+                snprintf(buf, 32, "R%dC%d_GSR0", row + 1, col + 1);
+                belname = id(buf);
+                addBel(belname, id_GSR, Loc(col, row, 0), false);
+                portname = IdString(pairLookup(bel->ports.get(), bel->num_ports, ID_GSRI)->src_id);
+                snprintf(buf, 32, "R%dC%d_%s", row + 1, col + 1, portname.c_str(this));
+                addBelInput(belname, id_GSRI, id(buf));
+                break;
             // fall through the ++
             case ID_LUT7:
                 z++;

--- a/gowin/cells.cc
+++ b/gowin/cells.cc
@@ -63,6 +63,8 @@ std::unique_ptr<CellInfo> create_generic_cell(Context *ctx, IdString type, std::
         new_cell->addInput(id_I);
         new_cell->addInput(id_OEN);
         new_cell->addOutput(id_O);
+    } else if (type == id_GSR) {
+        new_cell->addInput(id_GSRI);
     } else {
         log_error("unable to create generic cell of type %s\n", type.c_str(ctx));
     }

--- a/gowin/constids.inc
+++ b/gowin/constids.inc
@@ -739,6 +739,11 @@ X(IOBUF)
 X(TBUF)
 X(TLVDS_OBUF)
 
+// global set/reset
+X(GSR)
+X(GSR0)
+X(GSRI)
+
 // primitive attributes
 X(INIT)
 X(FF_USED)


### PR DESCRIPTION
GSR is added automatically if it was not instantiated by the user explicitly.

Compatible with old apicula bases, the functionality does not work, but
the crash does not happen --- just a warning.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>