### PR TITLE
gowin: BUGFIX temporarily disable the budget

### DIFF
--- a/gui/gowin/mainwindow.cc
+++ b/gui/gowin/mainwindow.cc
@@ -74,6 +74,9 @@ void MainWindow::createMenu()
 
     menuDesign->addSeparator();
     menuDesign->addAction(actionLoadCST);
+
+	// XXX
+	actionAssignBudget->setEnabled(false);
 }
 
 void MainWindow::new_proj() {}
@@ -99,5 +102,7 @@ void MainWindow::onUpdateActions()
     if (ctx->settings.find(ctx->id("pack")) != ctx->settings.end()) {
         actionLoadCST->setEnabled(false);
     }
+	// XXX
+	actionAssignBudget->setEnabled(false);
 }
 NEXTPNR_NAMESPACE_END

--- a/gui/gowin/mainwindow.cc
+++ b/gui/gowin/mainwindow.cc
@@ -75,8 +75,8 @@ void MainWindow::createMenu()
     menuDesign->addSeparator();
     menuDesign->addAction(actionLoadCST);
 
-	// XXX
-	actionAssignBudget->setEnabled(false);
+    // XXX
+    actionAssignBudget->setEnabled(false);
 }
 
 void MainWindow::new_proj() {}
@@ -102,7 +102,7 @@ void MainWindow::onUpdateActions()
     if (ctx->settings.find(ctx->id("pack")) != ctx->settings.end()) {
         actionLoadCST->setEnabled(false);
     }
-	// XXX
-	actionAssignBudget->setEnabled(false);
+    // XXX
+    actionAssignBudget->setEnabled(false);
 }
 NEXTPNR_NAMESPACE_END


### PR DESCRIPTION
GUI. Temporarily disable the button until the cause of the random crash is found.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>