### PR TITLE
gowin: support for locales other than en_US and C

### DIFF
--- a/common/command.cc
+++ b/common/command.cc
@@ -45,7 +45,15 @@
 
 NEXTPNR_NAMESPACE_BEGIN
 
-CommandHandler::CommandHandler(int argc, char **argv) : argc(argc), argv(argv) { log_streams.clear(); }
+CommandHandler::CommandHandler(int argc, char **argv) : argc(argc), argv(argv)
+{
+    try {
+        std::locale::global(std::locale(""));
+    } catch (const std::runtime_error &e) {
+        // the locale is broken in this system, so leave it as it is
+    }
+    log_streams.clear();
+}
 
 bool CommandHandler::parseOptions()
 {

--- a/gowin/main.cc
+++ b/gowin/main.cc
@@ -91,15 +91,6 @@ void GowinCommandHandler::customAfterLoad(Context *ctx)
 
 int main(int argc, char *argv[])
 {
-    // set the locale here because when you create a context you create several
-    // floating point strings whose representation depends on the locale. If
-    // you don't do this, the strings will be in the C locale and later when Qt
-    // starts it won't be able to read them back as numbers.
-    try {
-        std::locale::global(std::locale(""));
-    } catch (const std::runtime_error &e) {
-        // the locale is broken in this system, so leave it as it is
-    }
     GowinCommandHandler handler(argc, argv);
     return handler.exec();
 }

--- a/gowin/main.cc
+++ b/gowin/main.cc
@@ -95,7 +95,11 @@ int main(int argc, char *argv[])
     // floating point strings whose representation depends on the locale. If
     // you don't do this, the strings will be in the C locale and later when Qt
     // starts it won't be able to read them back as numbers.
-    std::locale::global(std::locale(""));
+    try {
+        std::locale::global(std::locale(""));
+    } catch (const std::runtime_error &e) {
+        // the locale is broken in this system, so leave it as it is
+    }
     GowinCommandHandler handler(argc, argv);
     return handler.exec();
 }

--- a/gowin/main.cc
+++ b/gowin/main.cc
@@ -21,6 +21,7 @@
 #ifdef MAIN_EXECUTABLE
 
 #include <fstream>
+#include <locale>
 #include <regex>
 #include "command.h"
 #include "design_utils.h"
@@ -90,6 +91,11 @@ void GowinCommandHandler::customAfterLoad(Context *ctx)
 
 int main(int argc, char *argv[])
 {
+    // set the locale here because when you create a context you create several
+    // floating point strings whose representation depends on the locale. If
+    // you don't do this, the strings will be in the C locale and later when Qt
+    // starts it won't be able to read them back as numbers.
+    std::locale::global(std::locale(""));
     GowinCommandHandler handler(argc, argv);
     return handler.exec();
 }


### PR DESCRIPTION
Specifically, those locales where the fractional part separator in
floating point numbers is not a period.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>