### PR TITLE
nexus: DCC support fixups

### DIFF
--- a/nexus/arch.cc
+++ b/nexus/arch.cc
@@ -546,6 +546,14 @@ TimingPortClass Arch::getPortTimingClass(const CellInfo *cell, IdString port, in
         if (type == TMG_REGISTER_INPUT || type == TMG_REGISTER_OUTPUT)
             clockInfoCount = 1;
         return type;
+    } else if (cell->type == id_DCC) {
+        if (port == id_CLKI)
+            return TMG_CLOCK_INPUT;
+        else if (port == id_CLKO)
+            return TMG_GEN_CLOCK;
+        else if (port == id_CE)
+            return TMG_COMB_INPUT;
+        return TMG_IGNORE;
     }
     return TMG_IGNORE;
 }

--- a/nexus/fasm.cc
+++ b/nexus/fasm.cc
@@ -526,6 +526,16 @@ struct NexusFasmWriter
         write_cell_muxes(cell);
         pop(2);
     }
+    // Write config for DCC
+    void write_dcc(const CellInfo *cell)
+    {
+        BelId bel = cell->bel;
+        push_tile(bel.tile);
+        push_belname(bel);
+        write_bit("DCCEN.1"); // Explicit DCC cell implies a clock buffer
+        write_cell_muxes(cell);
+        pop(2);
+    }
     // Write config for an OXIDE_EBR cell
     void write_bram(const CellInfo *cell)
     {
@@ -927,6 +937,8 @@ struct NexusFasmWriter
                 write_dphy(ci);
             else if (ci->type == id_IOLOGIC || ci->type == id_SIOLOGIC)
                 write_iol(ci);
+            else if (ci->type == id_DCC)
+                write_dcc(ci);
             blank();
         }
         // Handle DCC route-throughs


### PR DESCRIPTION
Added FASM feature emission for `DCC` and port timing class info. There is no point in adding `DCC` propagation delay to `getCellDelay` as the timing fuzzer from `prjoxide` reports it to be 0.

The added FASM feature emission has been successfully tested on hardware (LIFCL-40) where a `DCC` was used as a clock gate.