### PR TITLE
Gowin: use global VCC and VSS nets

### DIFF
--- a/gowin/arch.cc
+++ b/gowin/arch.cc
@@ -440,7 +440,9 @@ IdString Arch::wireToGlobal(int &row, int &col, const DatabasePOD *db, IdString 
 {
     const std::string &wirename = wire.str(this);
     char buf[32];
-    if (wirename == "VCC" || wirename == "GND") {
+    if (wirename == "VCC" || wirename == "VSS") {
+        row = 0;
+        col = 0;
         return wire;
     }
     if (!isdigit(wirename[1]) || !isdigit(wirename[2]) || !isdigit(wirename[3])) {
@@ -949,6 +951,13 @@ Arch::Arch(ArchArgs args) : args(args)
              package_name.c_str(this), speed_id.c_str(this));
 
     // setup db
+    // add global VCC and GND bels
+    addBel(id_GND, id_GND, Loc(0, 0, 998), true);
+    addWire(id_VSS, id_VSS, 0, 0);
+    addBelOutput(id_GND, id_G, id_VSS);
+    addBel(id_VCC, id_VCC, Loc(0, 0, 999), true);
+    addWire(id_VCC, id_VCC, 0, 0);
+    addBelOutput(id_VCC, id_V, id_VCC);
     char buf[32];
     // The reverse order of the enumeration simplifies the creation
     // of MUX2_LUT8s: they need the existence of the wire on the right.

--- a/gowin/cells.cc
+++ b/gowin/cells.cc
@@ -66,9 +66,9 @@ std::unique_ptr<CellInfo> create_generic_cell(Context *ctx, IdString type, std::
     } else if (type == id_GSR) {
         new_cell->addInput(id_GSRI);
     } else if (type == id_GND) {
-        new_cell->addInput(id_G);
+        new_cell->addOutput(id_G);
     } else if (type == id_VCC) {
-        new_cell->addInput(id_V);
+        new_cell->addOutput(id_V);
     } else {
         log_error("unable to create generic cell of type %s\n", type.c_str(ctx));
     }

--- a/gowin/cells.cc
+++ b/gowin/cells.cc
@@ -65,6 +65,10 @@ std::unique_ptr<CellInfo> create_generic_cell(Context *ctx, IdString type, std::
         new_cell->addOutput(id_O);
     } else if (type == id_GSR) {
         new_cell->addInput(id_GSRI);
+    } else if (type == id_GND) {
+        new_cell->addInput(id_G);
+    } else if (type == id_VCC) {
+        new_cell->addInput(id_V);
     } else {
         log_error("unable to create generic cell of type %s\n", type.c_str(ctx));
     }

--- a/gowin/constids.inc
+++ b/gowin/constids.inc
@@ -787,6 +787,8 @@ X(SUM)
 X(CIN)
 X(COUT)
 X(OF)
+X(V)
+X(G)
 
 // timing
 X(X0)

--- a/gowin/pack.cc
+++ b/gowin/pack.cc
@@ -612,15 +612,12 @@ static void pack_constants(Context *ctx)
     log_info("Packing constants..\n");
 
     std::unique_ptr<CellInfo> gnd_cell = create_generic_cell(ctx, id_GND, "$PACKER_GND");
-    gnd_cell->params[id_INIT] = Property(0, 1 << 4);
     auto gnd_net = std::make_unique<NetInfo>(ctx->id("$PACKER_GND_NET"));
     gnd_net->driver.cell = gnd_cell.get();
     gnd_net->driver.port = id_G;
     gnd_cell->ports.at(id_G).net = gnd_net.get();
 
     std::unique_ptr<CellInfo> vcc_cell = create_generic_cell(ctx, id_VCC, "$PACKER_VCC");
-    // Fill with 1s
-    vcc_cell->params[id_INIT] = Property(Property::S1).extract(0, (1 << 4), Property::S1);
     auto vcc_net = std::make_unique<NetInfo>(ctx->id("$PACKER_VCC_NET"));
     vcc_net->driver.cell = vcc_cell.get();
     vcc_net->driver.port = id_V;

--- a/gowin/pack.cc
+++ b/gowin/pack.cc
@@ -611,20 +611,20 @@ static void pack_constants(Context *ctx)
 {
     log_info("Packing constants..\n");
 
-    std::unique_ptr<CellInfo> gnd_cell = create_generic_cell(ctx, id_SLICE, "$PACKER_GND");
+    std::unique_ptr<CellInfo> gnd_cell = create_generic_cell(ctx, id_GND, "$PACKER_GND");
     gnd_cell->params[id_INIT] = Property(0, 1 << 4);
     auto gnd_net = std::make_unique<NetInfo>(ctx->id("$PACKER_GND_NET"));
     gnd_net->driver.cell = gnd_cell.get();
-    gnd_net->driver.port = id_F;
-    gnd_cell->ports.at(id_F).net = gnd_net.get();
+    gnd_net->driver.port = id_G;
+    gnd_cell->ports.at(id_G).net = gnd_net.get();
 
-    std::unique_ptr<CellInfo> vcc_cell = create_generic_cell(ctx, id_SLICE, "$PACKER_VCC");
+    std::unique_ptr<CellInfo> vcc_cell = create_generic_cell(ctx, id_VCC, "$PACKER_VCC");
     // Fill with 1s
     vcc_cell->params[id_INIT] = Property(Property::S1).extract(0, (1 << 4), Property::S1);
     auto vcc_net = std::make_unique<NetInfo>(ctx->id("$PACKER_VCC_NET"));
     vcc_net->driver.cell = vcc_cell.get();
-    vcc_net->driver.port = id_F;
-    vcc_cell->ports.at(id_F).net = vcc_net.get();
+    vcc_net->driver.port = id_V;
+    vcc_cell->ports.at(id_V).net = vcc_net.get();
 
     std::vector<IdString> dead_nets;
 


### PR DESCRIPTION
Gowin has a VCC and VSS input to almost every pip, which so far we've not been using, relying instead of a special LUT that's routed to all the VCC/VSS pins.

This PR adds a virtual VCC/GND bel that can contain the corresponding vendor primitive, and then sets up the pips correctly.

The constant packing step is now a bit silly maybe? It basically removes the global vendor primitive and then adds a new one, just with a predictable name so that other things can connect to it. Maybe it would be more sensible to either rename or store the existing primitive, but "if it aint broke dont fix it" so I just changed the packing from SLICE to VCC/GND.