### PR TITLE
gowin: Name the constants

### DIFF
--- a/gowin/arch.cc
+++ b/gowin/arch.cc
@@ -952,10 +952,10 @@ Arch::Arch(ArchArgs args) : args(args)
 
     // setup db
     // add global VCC and GND bels
-    addBel(id_GND, id_GND, Loc(0, 0, 998), true);
+    addBel(id_GND, id_GND, Loc(0, 0, BelZ::gnd_0_z), true);
     addWire(id_VSS, id_VSS, 0, 0);
     addBelOutput(id_GND, id_G, id_VSS);
-    addBel(id_VCC, id_VCC, Loc(0, 0, 999), true);
+    addBel(id_VCC, id_VCC, Loc(0, 0, BelZ::vcc_0_z), true);
     addWire(id_VCC, id_VCC, 0, 0);
     addBelOutput(id_VCC, id_V, id_VCC);
     char buf[32];


### PR DESCRIPTION
Place arbitrary constants side by side to avoid conflicts.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>