### PR TITLE
ice40: Merge driving LUT<=2s into carry-only LCs

### DIFF
--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -923,9 +923,20 @@ std::vector<GraphicElement> Arch::getDecalGraphics(DecalId decal) const
 
 bool Arch::getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const
 {
-    if (cell->type == id_ICESTORM_LC && cell->lcInfo.dffEnable) {
-        if (toPort == id_O)
-            return false;
+    if (cell->type == id_ICESTORM_LC) {
+        if (toPort == id_O) {
+            if (cell->lcInfo.dffEnable)
+                return false;
+            // "false paths"
+            if (fromPort == id_I0 && ((cell->lcInfo.lutInputMask & 0x1U) == 0))
+                return false;
+            if (fromPort == id_I1 && ((cell->lcInfo.lutInputMask & 0x2U) == 0))
+                return false;
+            if (fromPort == id_I2 && ((cell->lcInfo.lutInputMask & 0x4U) == 0))
+                return false;
+            if (fromPort == id_I3 && ((cell->lcInfo.lutInputMask & 0x8U) == 0))
+                return false;
+        }
     } else if (cell->type == id_ICESTORM_RAM || cell->type == id_ICESTORM_SPRAM) {
         return false;
     }
@@ -1231,6 +1242,21 @@ void Arch::assignCellInfo(CellInfo *cell)
             cell->lcInfo.inputCount++;
         if (cell->getPort(id_I3))
             cell->lcInfo.inputCount++;
+        // Find don't care LUT inputs to mask for timing analysis
+        cell->lcInfo.lutInputMask = 0x0;
+        unsigned init = int_or_default(cell->params, id_LUT_INIT);
+        for (unsigned k = 0; k < 4; k++) {
+            bool care = false;
+            for (unsigned i = 0; i < 16; i++) {
+                // If toggling the LUT input makes a difference it's not a don't care
+                if (((init >> i) & 0x1U) != ((init >> (i ^ (1U << k))) & 0x1U)) {
+                    care = true;
+                    break;
+                }
+            }
+            if (care)
+                cell->lcInfo.lutInputMask |= (1U << k);
+        }
     } else if (cell->type == id_SB_IO) {
         cell->ioInfo.lvds = str_or_default(cell->params, id_IO_STANDARD, "SB_LVCMOS") == "SB_LVDS_INPUT";
         cell->ioInfo.global = bool_or_default(cell->attrs, id_GLOBAL);

--- a/ice40/archdefs.h
+++ b/ice40/archdefs.h
@@ -137,6 +137,7 @@ struct ArchCellInfo : BaseClusterInfo
             bool carryEnable;
             bool negClk;
             int inputCount;
+            unsigned lutInputMask;
             const NetInfo *clk, *cen, *sr;
         } lcInfo;
         struct

--- a/ice40/pack.cc
+++ b/ice40/pack.cc
@@ -266,6 +266,75 @@ static void pack_carries(Context *ctx)
     log_info("    %4d LCs used as CARRY only\n", carry_only);
 }
 
+static void merge_carry_luts(Context *ctx)
+{
+    // Find carrys
+    log_info("Packing indirect carry+LUT pairs...\n");
+    // Find cases where a less-than-LUT2 is driving a carry and pack them together
+    //    +----+    +-----+ |
+    // A--|LUT2|----|CARRY| |
+    // B--|    |  C-|     |-+
+    //    +----+  +-|     |
+    //            | +-----+
+    //            |
+    pool<IdString> packed_cells;
+    auto rewrite_init = [](unsigned lut_init) {
+        // I0 -> LUT I2
+        // I1, I2 -> carry; don't care
+        // I3 -> LUT I3
+        unsigned result = 0;
+        for (unsigned i = 0; i < 16; i++) {
+            unsigned j = 0;
+            if ((i & 1))
+                j |= 4;
+            if ((i & 8))
+                j |= 8;
+            if (lut_init & (1 << j))
+                result |= (1 << i);
+        }
+        return result;
+    };
+    for (auto &cell : ctx->cells) {
+        CellInfo *ci = cell.second.get();
+        if (ci->type != id_ICESTORM_LC || !bool_or_default(ci->params, id_CARRY_ENABLE))
+            continue; // not a carry LC
+        if (ci->getPort(id_O))
+            continue;                      // LUT output is already used
+        for (auto port : {id_I1, id_I2}) { // check carry inputs
+            NetInfo *i = ci->getPort(port);
+            if (!i)
+                continue;
+            CellInfo *drv = i->driver.cell;
+            if (i->driver.port != id_O)
+                continue;
+            if (!drv || drv->type != id_ICESTORM_LC || packed_cells.count(drv->name) ||
+                bool_or_default(drv->params, id_CARRY_ENABLE) || bool_or_default(drv->params, id_DFF_ENABLE))
+                continue; // not driven by a LUT, or driver already swallowed
+            // Check cardinality
+            bool lut2_or_less = true;
+            for (auto lut_port : {id_I1, id_I0}) { // NOTE: LUT MSBs used first
+                if (drv->getPort(lut_port)) {
+                    lut2_or_less = false;
+                    break;
+                }
+            }
+            if (!lut2_or_less)
+                continue;
+            // Pack into carry
+            drv->movePortTo(id_I2, ci, id_I0);
+            drv->movePortTo(id_I3, ci, id_I3);
+            drv->movePortTo(id_O, ci, id_O);
+            ci->params[id_LUT_INIT] = Property(rewrite_init(int_or_default(drv->params, id_LUT_INIT)), 16);
+            packed_cells.insert(drv->name);
+            break;
+        }
+    }
+    for (auto pcell : packed_cells) {
+        ctx->cells.erase(pcell);
+    }
+    log_info("    %4d LUTs merged into carry LCs\n", int(packed_cells.size()));
+}
+
 // "Pack" RAMs
 static void pack_ram(Context *ctx)
 {
@@ -1642,6 +1711,7 @@ bool Arch::pack()
         pack_lut_lutffs(ctx);
         pack_nonlut_ffs(ctx);
         pack_carries(ctx);
+        merge_carry_luts(ctx);
         pack_ram(ctx);
         place_plls(ctx);
         pack_special(ctx);

--- a/ice40/smoketest/attosoc/smoketest.sh
+++ b/ice40/smoketest/attosoc/smoketest.sh
@@ -2,7 +2,6 @@
 set -ex
 yosys -q -p 'synth_ice40 -json attosoc.json -top attosoc' attosoc.v picorv32.v
 $NEXTPNR --hx8k --json attosoc.json --pcf attosoc.pcf --asc attosoc.asc --freq 50
-icetime -tmd hx8k -c 50 attosoc.asc
 icebox_vlog -L -l -p attosoc.pcf -c -n attosoc attosoc.asc > attosoc_pnr.v
 iverilog -o attosoc_pnr_tb attosoc_pnr.v attosoc_tb.v `yosys-config --datdir/ice40/cells_sim.v`
 vvp attosoc_pnr_tb


### PR DESCRIPTION
This is an optimisation that relies on that fact that carry-only LCs have a LUT, 2 LUT inputs and the LUT output spare for a LUT2 to be packed into them (looking at LUT2s driving them is a simple heuristic to find these ahead of placement).

Unfortunately this sometimes creates what appear to be combinational loops, if you don't realise the LUT output only depends on the two inputs that aren't "don't care" in its function; so icetime will need to be fixed to handle this (although the need for icetime with nextpnr's timing analysis being more capable in general is marginal at best...). Handling of this is already implemented for nextpnr's own timing data.