### PR TITLE
ice40: Fix wirenames containing / which is the list separator

### DIFF
--- a/ice40/chipdb.py
+++ b/ice40/chipdb.py
@@ -1312,7 +1312,7 @@ for t in range(num_tile_types):
 
 bba.l("wire_data_%s" % dev_name, "WireInfoPOD")
 for wire, info in enumerate(wireinfo):
-    bba.s(info["name"], "name")
+    bba.s(info["name"].replace('/', ':'), "name") # / is used as an IdStringList separator; can't also be within name
     bba.u8(info["name_x"], "name_x")
     bba.u8(info["name_y"], "name_y")
     bba.u16(0, "padding")


### PR DESCRIPTION
`/` is used to split elements in IdStringLists, but we treat the wirename part as one element so it won't roundtrip string conversion correctly if it has a `/` in it...