### PR TITLE
cmake: properly include TBB libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,7 +257,7 @@ if(PROFILER)
     list(APPEND EXTRA_LIB_DEPS profiler)
 endif()
 if(TBB_FOUND)
-    list(APPEND EXTRA_LIB_DEPS tbb)
+    list(APPEND EXTRA_LIB_DEPS TBB::tbb)
 endif()
 
 foreach (family ${ARCH})


### PR DESCRIPTION
This fixes #803 by properly following the libraries for TBB. I have not been able to test this against anything other than macOS and Linux.