### PR TITLE
[interchange] Tying unused LUT inputs according to architecture

### DIFF
--- a/fpga_interchange/arch.cc
+++ b/fpga_interchange/arch.cc
@@ -301,6 +301,12 @@ void Arch::init()
     for (size_t tile_type = 0; tile_type < chip_info->tile_types.size(); ++tile_type) {
         pseudo_pip_data.init_tile_type(getCtx(), tile_type);
     }
+
+    // Warn if there is no preferred constant net defined in the architecture
+    IdString const_net_name(getCtx()->chip_info->constants->best_constant_net);
+    if (const_net_name == IdString()) {
+        log_warning("The architecture does not specify preferred constant net. Using VCC as default.\n");
+    }
 }
 
 // -----------------------------------------------------------------------
@@ -877,7 +883,12 @@ static void prepare_sites_for_routing(Context *ctx)
     IdString gnd_net_name(ctx->chip_info->constants->gnd_net_name);
 
     IdString const_net_name(ctx->chip_info->constants->best_constant_net);
-    NPNR_ASSERT(const_net_name == vcc_net_name || const_net_name == gnd_net_name);
+    NPNR_ASSERT(const_net_name == IdString() || const_net_name == vcc_net_name || const_net_name == gnd_net_name);
+
+    // FIXME: Use VCC if the architecture does not device the best constant
+    if (const_net_name == IdString()) {
+        const_net_name = vcc_net_name;
+    }
 
     for (BelId bel : ctx->getBels()) {
         CellInfo *cell = ctx->getBoundBelCell(bel);

--- a/fpga_interchange/luts.cc
+++ b/fpga_interchange/luts.cc
@@ -429,8 +429,7 @@ bool LutMapper::remap_luts(const Context *ctx, SiteLutMappingResult *lut_mapping
                 if ((used_pins & (1 << bel_pin_idx)) == 0) {
                     NPNR_ASSERT(bel_to_cell_pin_remaps[cell_idx][bel_pin_idx] == -1);
                     cell.lutCell.pin_connections.emplace(lutBel.pins.at(bel_pin_idx), LutCell::PinConnection::Const);
-                }
-                else {
+                } else {
                     cell.lutCell.pin_connections.emplace(lutBel.pins.at(bel_pin_idx), LutCell::PinConnection::Signal);
                 }
             }
@@ -442,8 +441,7 @@ bool LutMapper::remap_luts(const Context *ctx, SiteLutMappingResult *lut_mapping
                     NPNR_ASSERT(bel_to_cell_pin_remaps[cell_idx][bel_pin_idx] == -1);
                     auto pin = lutBel.pins.at(bel_pin_idx);
                     cell.lutCell.pin_connections.emplace(pin, LutCell::PinConnection::Const);
-                }
-                else {
+                } else {
                     cell.lutCell.pin_connections.emplace(lutBel.pins.at(bel_pin_idx), LutCell::PinConnection::Signal);
                 }
             }

--- a/fpga_interchange/luts.cc
+++ b/fpga_interchange/luts.cc
@@ -428,7 +428,10 @@ bool LutMapper::remap_luts(const Context *ctx, SiteLutMappingResult *lut_mapping
             for (size_t bel_pin_idx = 0; bel_pin_idx < lutBel.pins.size(); ++bel_pin_idx) {
                 if ((used_pins & (1 << bel_pin_idx)) == 0) {
                     NPNR_ASSERT(bel_to_cell_pin_remaps[cell_idx][bel_pin_idx] == -1);
-                    cell.lutCell.pin_connections.emplace(lutBel.pins.at(bel_pin_idx), LutCell::PinConnection::Vcc);
+                    cell.lutCell.pin_connections.emplace(lutBel.pins.at(bel_pin_idx), LutCell::PinConnection::Const);
+                }
+                else {
+                    cell.lutCell.pin_connections.emplace(lutBel.pins.at(bel_pin_idx), LutCell::PinConnection::Signal);
                 }
             }
         }
@@ -438,7 +441,10 @@ bool LutMapper::remap_luts(const Context *ctx, SiteLutMappingResult *lut_mapping
                 if ((pin_mask & (1 << bel_pin_idx)) != 0) {
                     NPNR_ASSERT(bel_to_cell_pin_remaps[cell_idx][bel_pin_idx] == -1);
                     auto pin = lutBel.pins.at(bel_pin_idx);
-                    cell.lutCell.pin_connections.emplace(pin, LutCell::PinConnection::Vcc);
+                    cell.lutCell.pin_connections.emplace(pin, LutCell::PinConnection::Const);
+                }
+                else {
+                    cell.lutCell.pin_connections.emplace(lutBel.pins.at(bel_pin_idx), LutCell::PinConnection::Signal);
                 }
             }
         }

--- a/fpga_interchange/luts.h
+++ b/fpga_interchange/luts.h
@@ -42,11 +42,22 @@ enum LogicLevel
 
 struct LutCell
 {
+    enum class PinConnection
+    {
+        Unconnected,
+        Gnd,
+        Vcc,
+        Const,
+        Signal
+    };
+
     // LUT cell pins for equation, LSB first.
     std::vector<IdString> pins;
     pool<IdString> lut_pins;
-    pool<IdString> vcc_pins;
+    dict<IdString, PinConnection> pin_connections;
     DynamicBitarray<> equation;
+
+    static const std::string nameOfPinConnection(PinConnection conn);
 };
 
 struct LutBel

--- a/fpga_interchange/site_arch.cc
+++ b/fpga_interchange/site_arch.cc
@@ -133,8 +133,15 @@ SiteArch::SiteArch(const SiteInformation *site_info)
     }
 
     // Create list of out of site sources and sinks.
-
     bool have_vcc_pins = false;
+    bool have_gnd_pins = false;
+
+    IdString vcc_net_name(ctx->chip_info->constants->vcc_net_name);
+    IdString gnd_net_name(ctx->chip_info->constants->gnd_net_name);
+
+    IdString const_net_name(ctx->chip_info->constants->best_constant_net);
+    NPNR_ASSERT(const_net_name == vcc_net_name || const_net_name == gnd_net_name);
+
     for (CellInfo *cell : site_info->cells_in_site) {
         for (const auto &pin_pair : cell->cell_bel_pins) {
             if (!cell->ports.count(pin_pair.first))
@@ -145,8 +152,18 @@ SiteArch::SiteArch(const SiteInformation *site_info)
             }
         }
 
-        if (!cell->lut_cell.vcc_pins.empty()) {
-            have_vcc_pins = true;
+        for (const auto &conn : cell->lut_cell.pin_connections) {
+            if (conn.second == LutCell::PinConnection::Vcc) {
+                have_vcc_pins = true;
+            } else if (conn.second == LutCell::PinConnection::Gnd) {
+                have_gnd_pins = true;
+            } else if (conn.second == LutCell::PinConnection::Const) {
+                if (const_net_name == vcc_net_name) {
+                    have_vcc_pins = true;
+                } else if (const_net_name == gnd_net_name) {
+                    have_gnd_pins = true;
+                }
+            }
         }
     }
 
@@ -239,10 +256,9 @@ SiteArch::SiteArch(const SiteInformation *site_info)
         }
     }
 
-    IdString vcc_net_name(ctx->chip_info->constants->vcc_net_name);
     NetInfo *vcc_net = ctx->nets.at(vcc_net_name).get();
-    auto iter = nets.find(vcc_net);
-    if (iter == nets.end() && have_vcc_pins) {
+    auto vcc_iter = nets.find(vcc_net);
+    if (vcc_iter == nets.end() && have_vcc_pins) {
         // VCC net isn't present, add it.
         SiteNetInfo net_info;
         net_info.net = vcc_net;
@@ -250,13 +266,53 @@ SiteArch::SiteArch(const SiteInformation *site_info)
         net_info.driver.net = vcc_net;
         auto result = nets.emplace(vcc_net, net_info);
         NPNR_ASSERT(result.second);
-        iter = result.first;
+        vcc_iter = result.first;
+    }
+
+    NetInfo *gnd_net = ctx->nets.at(gnd_net_name).get();
+    auto gnd_iter = nets.find(gnd_net);
+    if (gnd_iter == nets.end() && have_gnd_pins) {
+        // GND net isn't present, add it.
+        SiteNetInfo net_info;
+        net_info.net = gnd_net;
+        net_info.driver.type = SiteWire::OUT_OF_SITE_SOURCE;
+        net_info.driver.net = gnd_net;
+        auto result = nets.emplace(gnd_net, net_info);
+        NPNR_ASSERT(result.second);
+        gnd_iter = result.first;
     }
 
     for (CellInfo *cell : site_info->cells_in_site) {
-        for (IdString vcc_pin : cell->lut_cell.vcc_pins) {
-            SiteWire wire = getBelPinWire(cell->bel, vcc_pin);
-            iter->second.users.emplace(wire);
+        for (const auto &it : cell->lut_cell.pin_connections) {
+            const auto &pin = it.first;
+            const auto &conn = it.second;
+
+            if (conn == LutCell::PinConnection::Unconnected || conn == LutCell::PinConnection::Signal) {
+                continue;
+            }
+
+            if (conn == LutCell::PinConnection::Vcc) {
+                SiteWire wire = getBelPinWire(cell->bel, pin);
+                vcc_iter->second.users.emplace(wire);
+            } else if (conn == LutCell::PinConnection::Gnd) {
+                SiteWire wire = getBelPinWire(cell->bel, pin);
+                gnd_iter->second.users.emplace(wire);
+            } else if (conn == LutCell::PinConnection::Const) {
+                SiteWire wire = getBelPinWire(cell->bel, pin);
+                if (const_net_name == vcc_net_name) {
+                    vcc_iter->second.users.emplace(wire);
+                }
+                if (const_net_name == gnd_net_name) {
+                    gnd_iter->second.users.emplace(wire);
+                }
+            }
+
+#ifdef DEBUG_LUT_MAPPING
+            if (ctx->verbose) {
+                log_info("Tying %s.%s to %s\n", cell->name.c_str(ctx), pin.c_str(ctx),
+                         LutCell::nameOfPinConnection(conn).c_str());
+            }
+#endif
         }
     }
 

--- a/fpga_interchange/site_arch.cc
+++ b/fpga_interchange/site_arch.cc
@@ -140,7 +140,12 @@ SiteArch::SiteArch(const SiteInformation *site_info)
     IdString gnd_net_name(ctx->chip_info->constants->gnd_net_name);
 
     IdString const_net_name(ctx->chip_info->constants->best_constant_net);
-    NPNR_ASSERT(const_net_name == vcc_net_name || const_net_name == gnd_net_name);
+    NPNR_ASSERT(const_net_name == IdString() || const_net_name == vcc_net_name || const_net_name == gnd_net_name);
+
+    // FIXME: Use VCC if the architecture does not device the best constant
+    if (const_net_name == IdString()) {
+        const_net_name = vcc_net_name;
+    }
 
     for (CellInfo *cell : site_info->cells_in_site) {
         for (const auto &pin_pair : cell->cell_bel_pins) {

--- a/fpga_interchange/site_lut_mapping_cache.cc
+++ b/fpga_interchange/site_lut_mapping_cache.cc
@@ -138,8 +138,8 @@ bool SiteLutMappingResult::apply(const SiteInformation &siteInfo)
         }
 
         // LUT data
-        // FIXME: Is there any other info that is being updated than vcc_pins ?
-        cellInfo->lut_cell.vcc_pins = std::move(cell.lutCell.vcc_pins);
+        // FIXME: Is there any other info that is being updated than pin_connections ?
+        cellInfo->lut_cell.pin_connections = std::move(cell.lutCell.pin_connections);
     }
 
     return true;


### PR DESCRIPTION
This PR makes nextpnr use the preferred constant net for unused LUT inputs as specified in FPGA interchange device resources. In code the `VCC` pin mask is now replaced by a vector of `PinConnection` which stores how a particular pin should be tied.