### PR TITLE
Bump minimum CMake to 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.13)
 project(nextpnr CXX C)
 
 # Allow family.cmake add additional dependencies to gui_${family}.


### PR DESCRIPTION
f4dc678 implicitly raised the minimum CMake version from 3.5 to 3.13 (which introduced that CMake policy).

There was #778 raised about it, but this is the only complaint in the past year, which suggests that compatibility with Ubuntu 18.04 LTS isn't so important to people.

Hence, explicitly raise the minimum CMake version, rather than implicitly breaking.