### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ An example of how to use the generic flow is in [generic/examples](generic/examp
 
 The nextpnr GUI is not built by default, to reduce the number of dependencies for a standard headless build. To enable it, add `-DBUILD_GUI=ON` to the CMake command line and ensure that Qt5 and OpenGL are available:
 
- - On Ubuntu, install `qt5-default`
+ - On Ubuntu 22.04 LTS, install `qtcreator qtbase5-dev qt5-qmake` 
+ - On other Ubuntu versions, install `qt5-default`
  - For MSVC vcpkg, install `qt5-base` (32-bit) or `qt5-base:x64-windows` (64-bit)
  - For Homebrew, install `qt5` and add qt5 in path: `echo 'export PATH="/usr/local/opt/qt/bin:$PATH"' >> ~/.bash_profile`
 ` - this change is effective in next terminal session, so please re-open terminal window before building


### PR DESCRIPTION
Cannot build nextpnr with GUI in Ubuntu 22.04 LTS because there is no `qt5-default` package in Official Repositories, updated README.md with the new packages.