### PR TITLE
netlist: Add PseudoCell API

### DIFF
--- a/common/kernel/arch_pybindings_shared.h
+++ b/common/kernel/arch_pybindings_shared.h
@@ -151,3 +151,9 @@ fn_wrapper_1a<Context, decltype(&Context::getDelayFromNS), &Context::getDelayFro
 
 fn_wrapper_1a<Context, decltype(&Context::getDelayNS), &Context::getDelayNS, pass_through<double>,
               pass_through<delay_t>>::def_wrap(ctx_cls, "getDelayNS");
+
+fn_wrapper_3a_v<Context, decltype(&Context::createRegionPlug), &Context::createRegionPlug, conv_from_str<IdString>,
+                conv_from_str<IdString>, pass_through<Loc>>::def_wrap(ctx_cls, "createRegionPlug");
+fn_wrapper_4a_v<Context, decltype(&Context::addPlugPin), &Context::addPlugPin, conv_from_str<IdString>,
+                conv_from_str<IdString>, pass_through<PortType>, conv_from_str<WireId>>::def_wrap(ctx_cls,
+                                                                                                  "addPlugPin");

--- a/common/kernel/basectx.cc
+++ b/common/kernel/basectx.cc
@@ -131,6 +131,30 @@ void BaseCtx::constrainCellToRegion(IdString cell, IdString region_name)
     if (!matched)
         log_warning("No cell matched '%s' when constraining to region '%s'\n", nameOf(cell), nameOf(region_name));
 }
+
+void BaseCtx::createRegionPlug(IdString name, IdString type, Loc approx_loc)
+{
+    CellInfo *cell = nullptr;
+    if (cells.count(name))
+        cell = cells.at(name).get();
+    else
+        cell = createCell(name, type);
+    cell->pseudo_cell = std::make_unique<RegionPlug>(approx_loc);
+}
+
+void BaseCtx::addPlugPin(IdString plug, IdString pin, PortType dir, WireId wire)
+{
+    if (!cells.count(plug))
+        log_error("no cell named '%s' found\n", plug.c_str(this));
+    CellInfo *ci = cells.at(plug).get();
+    RegionPlug *rplug = dynamic_cast<RegionPlug *>(ci->pseudo_cell.get());
+    if (!rplug)
+        log_error("cell '%s' is not a RegionPlug\n", plug.c_str(this));
+    rplug->port_wires[pin] = wire;
+    ci->ports[pin].name = pin;
+    ci->ports[pin].type = dir;
+}
+
 DecalXY BaseCtx::constructDecalXY(DecalId decal, float x, float y)
 {
     DecalXY dxy;

--- a/common/kernel/basectx.h
+++ b/common/kernel/basectx.h
@@ -220,6 +220,10 @@ struct BaseCtx
     void addBelToRegion(IdString name, BelId bel);
     void constrainCellToRegion(IdString cell, IdString region_name);
 
+    // Helper functions for the partial reconfiguration plug API using PseudoCells
+    void createRegionPlug(IdString name, IdString type, Loc approx_loc);
+    void addPlugPin(IdString plug, IdString pin, PortType dir, WireId wire);
+
     // Helper functions for Python bindings
     NetInfo *createNet(IdString name);
     void connectPort(IdString net, IdString cell, IdString port);

--- a/common/kernel/context.cc
+++ b/common/kernel/context.cc
@@ -30,6 +30,9 @@ WireId Context::getNetinfoSourceWire(const NetInfo *net_info) const
     if (net_info->driver.cell == nullptr)
         return WireId();
 
+    if (net_info->driver.cell->isPseudo())
+        return net_info->driver.cell->pseudo_cell->getPortWire(net_info->driver.port);
+
     auto src_bel = net_info->driver.cell->bel;
 
     if (src_bel == BelId())
@@ -47,6 +50,8 @@ WireId Context::getNetinfoSourceWire(const NetInfo *net_info) const
 
 SSOArray<WireId, 2> Context::getNetinfoSinkWires(const NetInfo *net_info, const PortRef &user_info) const
 {
+    if (user_info.cell->isPseudo())
+        return SSOArray<WireId, 2>(1, user_info.cell->pseudo_cell->getPortWire(user_info.port));
     auto dst_bel = user_info.cell->bel;
     if (dst_bel == BelId())
         return SSOArray<WireId, 2>(0, WireId());

--- a/common/kernel/context.h
+++ b/common/kernel/context.h
@@ -65,6 +65,24 @@ struct Context : Arch, DeterministicRNG
                              dict<WireId, PipId> *route = nullptr, bool useEstimate = true);
 
     // --------------------------------------------------------------
+    // Dispatch to the Arch API or pseudo-cell API accordingly
+    bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const override
+    {
+        return cell->pseudo_cell ? cell->pseudo_cell->getDelay(fromPort, toPort, delay)
+                                 : Arch::getCellDelay(cell, fromPort, toPort, delay);
+    }
+    TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const override
+    {
+        return cell->pseudo_cell ? cell->pseudo_cell->getPortTimingClass(port, clockInfoCount)
+                                 : Arch::getPortTimingClass(cell, port, clockInfoCount);
+    }
+    TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const override
+    {
+        return cell->pseudo_cell ? cell->pseudo_cell->getPortClockingInfo(port, index)
+                                 : Arch::getPortClockingInfo(cell, port, index);
+    }
+
+    // --------------------------------------------------------------
     // call after changing hierpath or adding/removing nets and cells
     void fixupHierarchy();
 

--- a/common/kernel/nextpnr_types.cc
+++ b/common/kernel/nextpnr_types.cc
@@ -177,4 +177,14 @@ void CellInfo::copyPortBusTo(IdString old_name, int old_offset, bool old_bracket
     }
 }
 
+Loc CellInfo::getLocation() const
+{
+    if (pseudo_cell) {
+        return pseudo_cell->getLocation();
+    } else {
+        NPNR_ASSERT(bel != BelId());
+        return ctx->getBelLocation(bel);
+    }
+}
+
 NEXTPNR_NAMESPACE_END

--- a/common/place/parallel_refine.cc
+++ b/common/place/parallel_refine.cc
@@ -390,6 +390,8 @@ struct ParallelRefine
         // Setup fast bels map
         pool<IdString> cell_types_in_use;
         for (auto &cell : ctx->cells) {
+            if (cell.second->isPseudo())
+                continue;
             IdString cell_type = cell.second->type;
             cell_types_in_use.insert(cell_type);
             if (cell.second->cluster != ClusterId())

--- a/common/place/place_common.cc
+++ b/common/place/place_common.cc
@@ -293,6 +293,8 @@ class ConstraintLegaliseWorker
     {
         if (cell->cluster != ClusterId() && ctx->getClusterRootCell(cell->cluster) != cell)
             return true; // Only process chain roots
+        if (cell->isPseudo())
+            return true;
         if (constraints_satisfied(cell)) {
             if (cell->cluster != ClusterId())
                 lockdown_chain(cell);
@@ -415,7 +417,7 @@ class ConstraintLegaliseWorker
     {
         log_info("Legalising relative constraints...\n");
         for (auto &cell : ctx->cells) {
-            oldLocations[cell.first] = ctx->getBelLocation(cell.second->bel);
+            oldLocations[cell.first] = cell.second->getLocation();
         }
         for (auto &cell : ctx->cells) {
             bool res = legalise_cell(cell.second.get());
@@ -448,6 +450,8 @@ bool legalise_relative_constraints(Context *ctx) { return ConstraintLegaliseWork
 int get_constraints_distance(const Context *ctx, const CellInfo *cell)
 {
     int dist = 0;
+    if (cell->isPseudo())
+        return 0;
     if (cell->bel == BelId())
         return 100000;
     Loc loc = ctx->getBelLocation(cell->bel);

--- a/common/route/router2.cc
+++ b/common/route/router2.cc
@@ -128,7 +128,7 @@ struct Router2
             nets.at(i).cy = 0;
 
             if (ni->driver.cell != nullptr) {
-                Loc drv_loc = ctx->getBelLocation(ni->driver.cell->bel);
+                Loc drv_loc = ni->driver.cell->getLocation();
                 nets.at(i).cx += drv_loc.x;
                 nets.at(i).cy += drv_loc.y;
             }
@@ -159,7 +159,7 @@ struct Router2
                     nets.at(i).bb.y1 = std::max(nets.at(i).bb.y1, ad.bb.y1);
                 }
                 // Add location to centroid sum
-                Loc usr_loc = ctx->getBelLocation(usr.value.cell->bel);
+                Loc usr_loc = usr.value.cell->getLocation();
                 nets.at(i).cx += usr_loc.x;
                 nets.at(i).cy += usr_loc.y;
             }

--- a/docs/netlist.md
+++ b/docs/netlist.md
@@ -25,10 +25,24 @@ Other structures used by these basic structures include:
  - `params` and `attrs` store parameters and attributes - from the input JSON or assigned in flows to add metadata - by mapping from parameter name `IdString` to `Property`.
  - `cluster` is used to specify that the cell is inside a placement cluster, with the details of the placement within the cluster provided by the architecture.
  - `region` is a reference to a `Region` if the cell is constrained to a placement region (e.g. for partial reconfiguration or out-of-context flows) or `nullptr` otherwise.
+ - `pseudo_cell` is an optional pointer to an implementation of the pseudo-cell API, used for cells implementing virtual functions such as partition pins without a mapped bel. `bel` will always be `BelId()` for pseudo-cells.
+
+## PseudoCellAPI
+
+Pseudo-cells can be used to implement cells with runtime-defined cell pin to wire mappings. This means they don't have to be a fixed part of the architecture, example use cases could be for implementing partition pins for partial reconfiguration regions; or forcing splits between SLRs. Pseudo-cells implement a series of virtual functions to provide data that for an ordinary cell would be obtained by calling 'bel' ArchAPI functions
+
+The pseudo-cell API is as follows:
+ - `Loc getLocation() const` : get an approximate location of the pseudocell
+ - `WireId getPortWire(IdString port) const`: gets the wire corresponding to a port (or WireId if it has no wire)
+
+It also implements functions for getting timing data, mirroring that of the Arch API:
+ - `bool getDelay(IdString fromPort, IdString toPort, DelayQuad &delay) const`
+ - `TimingPortClass getPortTimingClass(IdString port, int &clockInfoCount) const`
+ - `TimingClockingInfo getPortClockingInfo(IdString port, int index) const`
 
 ## NetInfo
 
-`NetInfo` instances have the following fields:
+`NetInfo` instances have the following fields:\
 
  - `name` is the IdString name of the net - for nets with multiple names, one name is chosen according to a set of rules by the JSON frontend
  - `hierpath` is name of the hierarchical cell containing the instance, for designs with hierarchy

--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -748,11 +748,11 @@ struct Arch : ArchAPI<ArchRanges>
 
     // Get the delay through a cell from one port to another, returning false
     // if no path exists. This only considers combinational delays, as required by the Arch API
-    bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const final;
+    bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const;
     // Get the port class, also setting clockInfoCount to the number of TimingClockingInfos associated with a port
-    TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const final;
+    TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const;
     // Get the TimingClockingInfo of a port
-    TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const final;
+    TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const;
 
     // -------------------------------------------------
 

--- a/generic/arch.cc
+++ b/generic/arch.cc
@@ -605,7 +605,7 @@ bool Arch::place()
         bool have_iobuf_or_constr = false;
         for (auto &cell : cells) {
             CellInfo *ci = cell.second.get();
-            if (ci->type == id("GENERIC_IOB") || ci->bel != BelId() || ci->attrs.count(id("BEL"))) {
+            if (ci->isPseudo() || ci->type == id("GENERIC_IOB") || ci->bel != BelId() || ci->attrs.count(id("BEL"))) {
                 have_iobuf_or_constr = true;
                 break;
             }


### PR DESCRIPTION
When implementing concepts such as partition pins or deliberately split nets, there's a need for something that looks like a cell (starts/ends routing with pins on nets, has timing data) but isn't mapped to a fixed bel in the architecture, but instead can have pin mappings defined at runtime.

The PseudoCell allows this by providing an alternate, virtual-function based API for such cells. When a cell has `pseudo_cell` used, instead of calling functions such as getBelPinWire, getBelLocation or getCellDelay in the Arch API; such data is provided by the cell itself, fully flexible at runtime regardless of arch, via methods on the `PseudoCell` implementation.

In the common use case RegionPlug will be the desired PseudoCell but the API gives flexibility for other options, too.

Supersedes #490, but with more flexibility and less breakage (nets still have a user/driver cell, most of the core netlist API users will see almost no change).