### PR TITLE
generic: Use arch_pybindings_shared

### DIFF
--- a/common/kernel/arch_pybindings_shared.h
+++ b/common/kernel/arch_pybindings_shared.h
@@ -145,3 +145,9 @@ fn_wrapper_1a<Context, decltype(&Context::getBelsInBucket), &Context::getBelsInB
 // bool isValidBelForCellType(IdString cell\_type, BelId bel) const
 fn_wrapper_2a<Context, decltype(&Context::isValidBelForCellType), &Context::isValidBelForCellType, pass_through<bool>,
               conv_from_str<IdString>, conv_from_str<BelId>>::def_wrap(ctx_cls, "isValidBelForCellType");
+
+fn_wrapper_1a<Context, decltype(&Context::getDelayFromNS), &Context::getDelayFromNS, pass_through<delay_t>,
+              pass_through<double>>::def_wrap(ctx_cls, "getDelayFromNS");
+
+fn_wrapper_1a<Context, decltype(&Context::getDelayNS), &Context::getDelayNS, pass_through<double>,
+              pass_through<delay_t>>::def_wrap(ctx_cls, "getDelayNS");

--- a/generic/arch_pybindings.cc
+++ b/generic/arch_pybindings.cc
@@ -46,6 +46,13 @@ void arch_wrap_python(py::module &m)
     typedef linear_range<WireId> WireRange;
     typedef linear_range<PipId> AllPipRange;
 
+    typedef const std::vector<PipId> &UphillPipRange;
+    typedef const std::vector<PipId> &DownhillPipRange;
+
+    typedef const std::vector<BelBucketId> &BelBucketRange;
+    typedef const std::vector<BelId> &BelRangeForBelBucket;
+    typedef const std::vector<BelPin> &BelPinRange;
+
     auto arch_cls = py::class_<Arch, BaseCtx>(m, "Arch").def(py::init<ArchArgs>());
 
     auto dxy_cls = py::class_<ContextualWrapper<DecalXY>>(m, "DecalXY_");
@@ -62,82 +69,8 @@ void arch_wrap_python(py::module &m)
                            .def("place", &Context::place)
                            .def("route", &Context::route);
 
-    py::class_<BelPin>(m, "BelPin").def_readwrite("bel", &BelPin::bel).def_readwrite("pin", &BelPin::pin);
-
-    fn_wrapper_1a<Context, decltype(&Context::getBelType), &Context::getBelType, conv_to_str<IdString>,
-                  conv_from_str<BelId>>::def_wrap(ctx_cls, "getBelType");
-    fn_wrapper_1a<Context, decltype(&Context::checkBelAvail), &Context::checkBelAvail, pass_through<bool>,
-                  conv_from_str<BelId>>::def_wrap(ctx_cls, "checkBelAvail");
-    fn_wrapper_1a<Context, decltype(&Context::getBelChecksum), &Context::getBelChecksum, pass_through<uint32_t>,
-                  conv_from_str<BelId>>::def_wrap(ctx_cls, "getBelChecksum");
-    fn_wrapper_3a_v<Context, decltype(&Context::bindBel), &Context::bindBel, conv_from_str<BelId>,
-                    addr_and_unwrap<CellInfo>, pass_through<PlaceStrength>>::def_wrap(ctx_cls, "bindBel");
-    fn_wrapper_1a_v<Context, decltype(&Context::unbindBel), &Context::unbindBel, conv_from_str<BelId>>::def_wrap(
-            ctx_cls, "unbindBel");
-    fn_wrapper_1a<Context, decltype(&Context::getBoundBelCell), &Context::getBoundBelCell, deref_and_wrap<CellInfo>,
-                  conv_from_str<BelId>>::def_wrap(ctx_cls, "getBoundBelCell");
-    fn_wrapper_1a<Context, decltype(&Context::getConflictingBelCell), &Context::getConflictingBelCell,
-                  deref_and_wrap<CellInfo>, conv_from_str<BelId>>::def_wrap(ctx_cls, "getConflictingBelCell");
-    fn_wrapper_0a<Context, decltype(&Context::getBels), &Context::getBels, wrap_context<BelRange>>::def_wrap(ctx_cls,
-                                                                                                             "getBels");
-
-    fn_wrapper_2a<Context, decltype(&Context::getBelPinWire), &Context::getBelPinWire, conv_to_str<WireId>,
-                  conv_from_str<BelId>, conv_from_str<IdString>>::def_wrap(ctx_cls, "getBelPinWire");
-    fn_wrapper_1a<Context, decltype(&Context::getWireBelPins), &Context::getWireBelPins,
-                  wrap_context<const std::vector<BelPin> &>, conv_from_str<WireId>>::def_wrap(ctx_cls,
-                                                                                              "getWireBelPins");
-
-    fn_wrapper_1a<Context, decltype(&Context::getWireChecksum), &Context::getWireChecksum, pass_through<uint32_t>,
-                  conv_from_str<WireId>>::def_wrap(ctx_cls, "getWireChecksum");
-    fn_wrapper_3a_v<Context, decltype(&Context::bindWire), &Context::bindWire, conv_from_str<WireId>,
-                    addr_and_unwrap<NetInfo>, pass_through<PlaceStrength>>::def_wrap(ctx_cls, "bindWire");
-    fn_wrapper_1a_v<Context, decltype(&Context::unbindWire), &Context::unbindWire, conv_from_str<WireId>>::def_wrap(
-            ctx_cls, "unbindWire");
-    fn_wrapper_1a<Context, decltype(&Context::checkWireAvail), &Context::checkWireAvail, pass_through<bool>,
-                  conv_from_str<WireId>>::def_wrap(ctx_cls, "checkWireAvail");
-    fn_wrapper_1a<Context, decltype(&Context::getBoundWireNet), &Context::getBoundWireNet, deref_and_wrap<NetInfo>,
-                  conv_from_str<WireId>>::def_wrap(ctx_cls, "getBoundWireNet");
-    fn_wrapper_1a<Context, decltype(&Context::getConflictingWireNet), &Context::getConflictingWireNet,
-                  deref_and_wrap<NetInfo>, conv_from_str<WireId>>::def_wrap(ctx_cls, "getConflictingWireNet");
-
-    fn_wrapper_0a<Context, decltype(&Context::getWires), &Context::getWires, wrap_context<WireRange>>::def_wrap(
-            ctx_cls, "getWires");
-
-    fn_wrapper_0a<Context, decltype(&Context::getPips), &Context::getPips, wrap_context<AllPipRange>>::def_wrap(
-            ctx_cls, "getPips");
-    fn_wrapper_1a<Context, decltype(&Context::getPipChecksum), &Context::getPipChecksum, pass_through<uint32_t>,
-                  conv_from_str<PipId>>::def_wrap(ctx_cls, "getPipChecksum");
-    fn_wrapper_3a_v<Context, decltype(&Context::bindPip), &Context::bindPip, conv_from_str<PipId>,
-                    addr_and_unwrap<NetInfo>, pass_through<PlaceStrength>>::def_wrap(ctx_cls, "bindPip");
-    fn_wrapper_1a_v<Context, decltype(&Context::unbindPip), &Context::unbindPip, conv_from_str<PipId>>::def_wrap(
-            ctx_cls, "unbindPip");
-    fn_wrapper_1a<Context, decltype(&Context::checkPipAvail), &Context::checkPipAvail, pass_through<bool>,
-                  conv_from_str<PipId>>::def_wrap(ctx_cls, "checkPipAvail");
-    fn_wrapper_1a<Context, decltype(&Context::getBoundPipNet), &Context::getBoundPipNet, deref_and_wrap<NetInfo>,
-                  conv_from_str<PipId>>::def_wrap(ctx_cls, "getBoundPipNet");
-    fn_wrapper_1a<Context, decltype(&Context::getConflictingPipNet), &Context::getConflictingPipNet,
-                  deref_and_wrap<NetInfo>, conv_from_str<PipId>>::def_wrap(ctx_cls, "getConflictingPipNet");
-
-    fn_wrapper_1a<Context, decltype(&Context::getPipsDownhill), &Context::getPipsDownhill,
-                  wrap_context<const std::vector<PipId> &>, conv_from_str<WireId>>::def_wrap(ctx_cls,
-                                                                                             "getPipsDownhill");
-    fn_wrapper_1a<Context, decltype(&Context::getPipsUphill), &Context::getPipsUphill,
-                  wrap_context<const std::vector<PipId> &>, conv_from_str<WireId>>::def_wrap(ctx_cls, "getPipsUphill");
-
-    fn_wrapper_1a<Context, decltype(&Context::getPipSrcWire), &Context::getPipSrcWire, conv_to_str<WireId>,
-                  conv_from_str<PipId>>::def_wrap(ctx_cls, "getPipSrcWire");
-    fn_wrapper_1a<Context, decltype(&Context::getPipDstWire), &Context::getPipDstWire, conv_to_str<WireId>,
-                  conv_from_str<PipId>>::def_wrap(ctx_cls, "getPipDstWire");
-    fn_wrapper_1a<Context, decltype(&Context::getPipDelay), &Context::getPipDelay, pass_through<DelayQuad>,
-                  conv_from_str<PipId>>::def_wrap(ctx_cls, "getPipDelay");
-
-    fn_wrapper_1a<Context, decltype(&Context::getDelayFromNS), &Context::getDelayFromNS, pass_through<delay_t>,
-                  pass_through<double>>::def_wrap(ctx_cls, "getDelayFromNS");
-
-    fn_wrapper_0a<Context, decltype(&Context::getChipName), &Context::getChipName, pass_through<std::string>>::def_wrap(
-            ctx_cls, "getChipName");
-    fn_wrapper_0a<Context, decltype(&Context::archId), &Context::archId, conv_to_str<IdString>>::def_wrap(ctx_cls,
-                                                                                                          "archId");
+    auto belpin_cls =
+            py::class_<BelPin>(m, "BelPin").def_readwrite("bel", &BelPin::bel).def_readwrite("pin", &BelPin::pin);
 
     fn_wrapper_3a<Context, decltype(&Context::constructDecalXY), &Context::constructDecalXY, wrap_context<DecalXY>,
                   conv_from_str<DecalId>, pass_through<float>, pass_through<float>>::def_wrap(ctx_cls, "DecalXY");
@@ -145,14 +78,10 @@ void arch_wrap_python(py::module &m)
     typedef dict<IdString, std::unique_ptr<CellInfo>> CellMap;
     typedef dict<IdString, std::unique_ptr<NetInfo>> NetMap;
     typedef dict<IdString, HierarchicalCell> HierarchyMap;
+    typedef dict<IdString, IdString> AliasMap;
+    typedef dict<IdString, HierarchicalCell> HierarchyMap;
 
-    readonly_wrapper<Context, decltype(&Context::cells), &Context::cells, wrap_context<CellMap &>>::def_wrap(ctx_cls,
-                                                                                                             "cells");
-    readonly_wrapper<Context, decltype(&Context::nets), &Context::nets, wrap_context<NetMap &>>::def_wrap(ctx_cls,
-                                                                                                          "nets");
-
-    fn_wrapper_2a_v<Context, decltype(&Context::addClock), &Context::addClock, conv_from_str<IdString>,
-                    pass_through<float>>::def_wrap(ctx_cls, "addClock");
+#include "arch_pybindings_shared.h"
 
     // Generic arch construction API
     fn_wrapper_4a_v<Context, decltype(&Context::addWire), &Context::addWire, conv_from_str<IdStringList>,
@@ -235,28 +164,6 @@ void arch_wrap_python(py::module &m)
                     conv_from_str<IdString>, conv_from_str<IdString>,
                     conv_from_str<IdString>>::def_wrap(ctx_cls, "addCellBelPinMapping", "cell"_a, "cell_pin"_a,
                                                        "bel_pin"_a);
-
-    // const\_range\<BelBucketId\> getBelBuckets() const
-    fn_wrapper_0a<Context, decltype(&Context::getBelBuckets), &Context::getBelBuckets,
-                  wrap_context<const std::vector<BelBucketId> &>>::def_wrap(ctx_cls, "getBelBuckets");
-
-    // BelBucketId getBelBucketForBel(BelId bel) const
-    fn_wrapper_1a<Context, decltype(&Context::getBelBucketForBel), &Context::getBelBucketForBel,
-                  conv_to_str<BelBucketId>, conv_from_str<BelId>>::def_wrap(ctx_cls, "getBelBucketForBel");
-
-    // BelBucketId getBelBucketForCellType(IdString cell\_type) const
-    fn_wrapper_1a<Context, decltype(&Context::getBelBucketForCellType), &Context::getBelBucketForCellType,
-                  conv_to_str<BelBucketId>, conv_from_str<IdString>>::def_wrap(ctx_cls, "getBelBucketForCellType");
-
-    // const\_range\<BelId\> getBelsInBucket(BelBucketId bucket) const
-    fn_wrapper_1a<Context, decltype(&Context::getBelsInBucket), &Context::getBelsInBucket,
-                  wrap_context<const std::vector<BelId> &>, conv_from_str<BelBucketId>>::def_wrap(ctx_cls,
-                                                                                                  "getBelsInBucket");
-
-    // bool isValidBelForCellType(IdString cell\_type, BelId bel) const
-    fn_wrapper_2a<Context, decltype(&Context::isValidBelForCellType), &Context::isValidBelForCellType,
-                  pass_through<bool>, conv_from_str<IdString>, conv_from_str<BelId>>::def_wrap(ctx_cls,
-                                                                                               "isValidBelForCellType");
 
     WRAP_RANGE(m, Bel, conv_to_str<BelId>);
     WRAP_RANGE(m, Wire, conv_to_str<WireId>);


### PR DESCRIPTION
This reduces the duplication, and also makes sure generic gains a few bindings that were missed off as a result of it being a special-case before.