### PR TITLE
gowin: auto allocation of long wires

### DIFF
--- a/gowin/arch.h
+++ b/gowin/arch.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "base_arch.h"
+#include "globals.h"
 #include "idstring.h"
 #include "nextpnr_namespaces.h"
 #include "nextpnr_types.h"
@@ -463,6 +464,7 @@ struct Arch : BaseArch<ArchRanges>
     void assignArchInfo() override;
     bool cellsCompatible(const CellInfo **cells, int count) const;
     bool haveBelType(int x, int y, IdString bel_type);
+    void create_l2g_bel(const DatabasePOD *db, int row, int col, IdString lw_id);
     bool allocate_longwire(NetInfo *ni, int lw_idx = -1);
     void fix_longwire_bels();
     void pre_pack(Context *ctx);
@@ -507,7 +509,8 @@ enum
     gnd_0_z = 278,    // virtual VSS bel Z
     osc_z = 280,      // Z for the oscillator bels
     bufs_0_z = 281,   // Z for long wire buffer bel
-    free_z = 289      // Must be the last, one can use z starting from this value, adjust accordingly.
+    l2g_z = 289,      // Z for logic to global network gate
+    free_z = 290      // Must be the last, one can use z starting from this value, adjust accordingly.
 };
 }
 

--- a/gowin/archdefs.h
+++ b/gowin/archdefs.h
@@ -65,6 +65,8 @@ struct ArchCellInfo : BaseClusterInfo
     IdString ff_type;
     // Is a slice type primitive
     bool is_slice;
+    // if its logic to global network
+    IdString lw;
 
     // Only packing rule for slice type primitives is a single clock per tile
     const NetInfo *slice_clk;

--- a/gowin/cells.cc
+++ b/gowin/cells.cc
@@ -80,6 +80,9 @@ std::unique_ptr<CellInfo> create_generic_cell(Context *ctx, IdString type, std::
     } else if (type == id_BUFS) {
         new_cell->addInput(id_I);
         new_cell->addOutput(id_O);
+    } else if (type == id_DUMMY_L2G) {
+        new_cell->addInput(id_I);
+        new_cell->addOutput(id_O);
     } else {
         log_error("unable to create generic cell of type %s\n", type.c_str(ctx));
     }

--- a/gowin/constids.inc
+++ b/gowin/constids.inc
@@ -680,6 +680,8 @@ X(IOBIS)
 X(IOBJS)
 
 // long wires
+X(DUMMY_L2G)
+X(L2GO)
 X(BUFS)
 X(BUFS0)
 X(BUFS1)

--- a/gowin/pack.cc
+++ b/gowin/pack.cc
@@ -23,6 +23,7 @@
 #include <iterator>
 #include "cells.h"
 #include "design_utils.h"
+#include "globals.h"
 #include "log.h"
 #include "util.h"
 
@@ -30,6 +31,7 @@
 
 NEXTPNR_NAMESPACE_BEGIN
 
+// ---------------------------------------------------------------
 static void make_dummy_alu(Context *ctx, int alu_idx, CellInfo *ci, CellInfo *packed_head,
                            std::vector<std::unique_ptr<CellInfo>> &new_cells)
 {
@@ -1096,6 +1098,7 @@ bool Arch::pack()
 {
     Context *ctx = getCtx();
     try {
+        pre_pack(ctx);
         log_break();
         pre_pack(ctx);
         pack_constants(ctx);


### PR DESCRIPTION
A simple long line router is added. Only the CE ports are handled so
far.

The router searches for all networks with such ports and assigns the
available long lines to the networks with the most ports.

The router is disabled by default, enabled by the command line key
--enable-auto-longwires

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>