### PR TITLE
Use CMake's Python3 rather than PythonInterp in subdirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ sudo make install
 On Windows, you may specify paths explicitly:
 
 ```
-cmake . -DARCH=ice40 -DICESTORM_INSTALL_PREFIX=C:/ProgramData/icestorm -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -G "Visual Studio 15 2017 Win64" -DPYTHON_EXECUTABLE=C:/Python364/python.exe -DPYTHON_LIBRARY=C:/vcpkg/packages/python3_x64-windows/lib/python36.lib -DPYTHON_INCLUDE_DIR=C:/vcpkg/packages/python3_x64-windows/include/python3.6 .
+cmake . -DARCH=ice40 -DICESTORM_INSTALL_PREFIX=C:/ProgramData/icestorm -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -G "Visual Studio 15 2017 Win64" -DPython3_EXECUTABLE=C:/Python364/python.exe -DPython3_LIBRARY=C:/vcpkg/packages/python3_x64-windows/lib/python36.lib -DPython3_INCLUDE_DIR=C:/vcpkg/packages/python3_x64-windows/include/python3.6 .
 cmake --build . --config Release
 ```
 

--- a/ecp5/CMakeLists.txt
+++ b/ecp5/CMakeLists.txt
@@ -9,7 +9,7 @@ message(STATUS "Enabled ECP5 devices: ${ECP5_DEVICES}")
 if(DEFINED ECP5_CHIPDB)
     add_custom_target(chipdb-ecp5-bbas ALL)
 else()
-    find_package(PythonInterp 3.5 REQUIRED)
+    find_package(Python3 3.5 REQUIRED COMPONENTS Interpreter)
 
     # shared among all families
     set(SERIALIZE_CHIPDBS TRUE CACHE BOOL
@@ -81,7 +81,7 @@ else()
         set(device_bba chipdb/chipdb-${device}.bba)
         add_custom_command(
             OUTPUT ${device_bba}
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/trellis_import.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/trellis_import.py
                 -L ${TRELLIS_LIBDIR}
                 -L ${TRELLIS_DATADIR}/util/common
                 -L ${TRELLIS_DATADIR}/timing/util

--- a/fpga_interchange/examples/chipdb.cmake
+++ b/fpga_interchange/examples/chipdb.cmake
@@ -57,7 +57,7 @@ function(create_patched_device_db)
     add_custom_command(
         OUTPUT ${output_device_file}
         COMMAND
-            ${PYTHON_EXECUTABLE} -mfpga_interchange.patch
+            ${Python3_EXECUTABLE} -mfpga_interchange.patch
                 --schema_dir ${INTERCHANGE_SCHEMA_PATH}
                 --schema device
                 --patch_path ${patch_path}
@@ -76,7 +76,7 @@ function(create_patched_device_db)
 
     add_custom_target(${patch_name}-${device}-device-yaml
         COMMAND
-            ${PYTHON_EXECUTABLE} -mfpga_interchange.convert
+            ${Python3_EXECUTABLE} -mfpga_interchange.convert
                 --schema_dir ${INTERCHANGE_SCHEMA_PATH}
                 --schema device
                 --input_format capnp
@@ -145,7 +145,7 @@ function(patch_device_with_prim_lib)
     add_custom_command(
         OUTPUT ${output_device_file}
         COMMAND
-            ${PYTHON_EXECUTABLE} -mfpga_interchange.add_prim_lib
+            ${Python3_EXECUTABLE} -mfpga_interchange.add_prim_lib
                 --schema_dir ${INTERCHANGE_SCHEMA_PATH}
                 ${input_device_loc}
                 ${output_json_file}
@@ -227,7 +227,7 @@ function(generate_chipdb)
     add_custom_command(
         OUTPUT ${chipdb_bba}
         COMMAND
-            ${PYTHON_EXECUTABLE} -mfpga_interchange.nextpnr_emit
+            ${Python3_EXECUTABLE} -mfpga_interchange.nextpnr_emit
                 --schema_dir ${INTERCHANGE_SCHEMA_PATH}
                 --output_dir ${CMAKE_CURRENT_BINARY_DIR}
                 --device_config ${device_config}

--- a/fpga_interchange/examples/chipdb_xilinx.cmake
+++ b/fpga_interchange/examples/chipdb_xilinx.cmake
@@ -53,7 +53,7 @@ function(create_rapidwright_device_db)
 
     add_custom_target(rapidwright-${device}-device-yaml
         COMMAND
-            ${PYTHON_EXECUTABLE} -mfpga_interchange.convert
+            ${Python3_EXECUTABLE} -mfpga_interchange.convert
                 --schema_dir ${INTERCHANGE_SCHEMA_PATH}
                 --schema device
                 --input_format capnp

--- a/fpga_interchange/examples/tests.cmake
+++ b/fpga_interchange/examples/tests.cmake
@@ -98,7 +98,7 @@ function(add_interchange_test)
     add_custom_command(
         OUTPUT ${netlist}
         COMMAND
-            ${PYTHON_EXECUTABLE} -mfpga_interchange.yosys_json
+            ${Python3_EXECUTABLE} -mfpga_interchange.yosys_json
                 --schema_dir ${INTERCHANGE_SCHEMA_PATH}
                 --device ${device_loc}
                 --top ${top}
@@ -117,7 +117,7 @@ function(add_interchange_test)
     add_custom_command(
         OUTPUT ${netlist_yaml}
         COMMAND
-            ${PYTHON_EXECUTABLE} -mfpga_interchange.convert
+            ${Python3_EXECUTABLE} -mfpga_interchange.convert
                 --schema_dir ${INTERCHANGE_SCHEMA_PATH}
                 --schema logical
                 --input_format capnp
@@ -248,7 +248,7 @@ function(add_interchange_test)
     add_custom_command(
         OUTPUT ${phys_yaml}
         COMMAND
-            ${PYTHON_EXECUTABLE} -mfpga_interchange.convert
+            ${Python3_EXECUTABLE} -mfpga_interchange.convert
                 --schema_dir ${INTERCHANGE_SCHEMA_PATH}
                 --schema physical
                 --input_format capnp
@@ -296,7 +296,7 @@ function(add_interchange_test)
         add_custom_command(
             OUTPUT ${fasm}
             COMMAND
-                ${PYTHON_EXECUTABLE} -mfpga_interchange.fasm_generator
+                ${Python3_EXECUTABLE} -mfpga_interchange.fasm_generator
                     --schema_dir ${INTERCHANGE_SCHEMA_PATH}
                     --family ${device_family}
                     ${device_loc}

--- a/ice40/CMakeLists.txt
+++ b/ice40/CMakeLists.txt
@@ -9,7 +9,7 @@ message(STATUS "Enabled iCE40 devices: ${ICE40_DEVICES}")
 if(DEFINED ICE40_CHIPDB)
     add_custom_target(chipdb-ice40-bbas ALL)
 else()
-    find_package(PythonInterp 3.5 REQUIRED)
+    find_package(Python3 3.5 REQUIRED COMPONENTS Interpreter)
 
     # shared among all families
     set(SERIALIZE_CHIPDBS TRUE CACHE BOOL
@@ -57,7 +57,7 @@ else()
         set(device_bba chipdb/chipdb-${device}.bba)
         add_custom_command(
             OUTPUT ${device_bba}
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/chipdb.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/chipdb.py
                 -p ${CMAKE_CURRENT_SOURCE_DIR}/constids.inc
                 -g ${CMAKE_CURRENT_SOURCE_DIR}/gfx.h
                 ${timing_opts}

--- a/machxo2/CMakeLists.txt
+++ b/machxo2/CMakeLists.txt
@@ -10,7 +10,7 @@ message(STATUS "Enabled MachXO2 devices: ${MACHXO2_DEVICES}")
 if(DEFINED MACHXO2_CHIPDB)
     add_custom_target(chipdb-machxo2-bbas ALL)
 else()
-    find_package(PythonInterp 3.5 REQUIRED)
+    find_package(Python3 3.5 REQUIRED COMPONENTS Interpreter)
 
     # shared among all families
     set(SERIALIZE_CHIPDBS TRUE CACHE BOOL
@@ -58,7 +58,7 @@ else()
         set(device_bba chipdb/chipdb-${device}.bba)
         add_custom_command(
             OUTPUT ${device_bba}
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/facade_import.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/facade_import.py
                 -L ${TRELLIS_LIBDIR}
                 -L ${TRELLIS_DATADIR}/util/common
                 -L ${TRELLIS_DATADIR}/timing/util


### PR DESCRIPTION
ae8966040bc7f148958d4ac0b989e04059b6ba06 converted the top-level CMakeLists.txt to use the Python3 module rather than PythonInterp, but there are also uses of it - and the variables it defines - in subdirectories.

I haven't tested the Windows command in the README.