### PR TITLE
Router fix

### DIFF
--- a/common/kernel/nextpnr_types.h
+++ b/common/kernel/nextpnr_types.h
@@ -205,9 +205,9 @@ struct RegionPlug : PseudoCell
     WireId getPortWire(IdString port) const override { return port_wires.at(port); }
 
     // TODO: partial reconfiguration region timing
-    bool getDelay(IdString fromPort, IdString toPort, DelayQuad &delay) const { return false; }
-    TimingPortClass getPortTimingClass(IdString port, int &clockInfoCount) const { return TMG_IGNORE; }
-    virtual TimingClockingInfo getPortClockingInfo(IdString port, int index) const { return TimingClockingInfo{}; }
+    bool getDelay(IdString fromPort, IdString toPort, DelayQuad &delay) const override { return false; }
+    TimingPortClass getPortTimingClass(IdString port, int &clockInfoCount) const override { return TMG_IGNORE; }
+    TimingClockingInfo getPortClockingInfo(IdString port, int index) const override { return TimingClockingInfo{}; }
 
     dict<IdString, WireId> port_wires;
     Loc loc;

--- a/common/route/router2.cc
+++ b/common/route/router2.cc
@@ -373,8 +373,7 @@ struct Router2
         return base_cost * hist_cost * present_cost / (1 + (source_uses * crit_weight)) + bias_cost;
     }
 
-    float get_togo_cost(NetInfo *net, store_index<PortRef> user, int wire, WireId src_sink, float crit_weight,
-                        bool bwd = false)
+    float get_togo_cost(NetInfo *net, store_index<PortRef> user, int wire, WireId src_sink, bool bwd, float crit_weight)
     {
         auto &nd = nets.at(net->udata);
         auto &wd = flat_wires[wire];


### PR DESCRIPTION
get_togo_cost is used with parameters in different order than defined. Noticed error when using clang as compiler.