### PR TITLE
[WIP] Support cross-domain clock relations in timing analyser

### DIFF
--- a/common/kernel/command.cc
+++ b/common/kernel/command.cc
@@ -172,6 +172,7 @@ po::options_description CommandHandler::getGeneralOptions()
     general.add_options()("no-pack", "process design without packing");
 
     general.add_options()("ignore-loops", "ignore combinational loops in timing analysis");
+    general.add_options()("ignore-rel-clk", "ignore clock-to-clock relations in timing checks");
 
     general.add_options()("version,V", "show version");
     general.add_options()("test", "check architecture database integrity");
@@ -268,6 +269,10 @@ void CommandHandler::setupContext(Context *ctx)
 
     if (vm.count("ignore-loops")) {
         ctx->settings[ctx->id("timing/ignoreLoops")] = true;
+    }
+
+    if (vm.count("ignore-rel-clk")) {
+        ctx->settings[ctx->id("timing/ignoreRelClk")] = true;
     }
 
     if (vm.count("timing-allow-fail")) {

--- a/common/kernel/timing.h
+++ b/common/kernel/timing.h
@@ -92,9 +92,7 @@ struct TimingAnalyser
         return slack;
     }
 
-    auto get_clock_delays () const {
-        return clock_delays;
-    }
+    auto get_clock_delays() const { return clock_delays; }
 
     bool setup_only = false;
     bool verbose_mode = false;

--- a/common/kernel/timing.h
+++ b/common/kernel/timing.h
@@ -92,6 +92,10 @@ struct TimingAnalyser
         return slack;
     }
 
+    auto get_clock_delays () const {
+        return clock_delays;
+    }
+
     bool setup_only = false;
     bool verbose_mode = false;
     bool have_loops = false;
@@ -103,6 +107,7 @@ struct TimingAnalyser
     void get_route_delays();
     void topo_sort();
     void setup_port_domains();
+    void identify_related_domains();
 
     void reset_times();
 
@@ -217,6 +222,7 @@ struct TimingAnalyser
     dict<ClockDomainPairKey, domain_id_t> pair_to_id;
     std::vector<PerDomain> domains;
     std::vector<PerDomainPair> domain_pairs;
+    dict<std::pair<IdString, IdString>, delay_t> clock_delays;
 
     std::vector<CellPortKey> topological_order;
 

--- a/nexus/arch.cc
+++ b/nexus/arch.cc
@@ -495,10 +495,10 @@ bool Arch::getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort
     } else if (cell->type == id_DCC) {
         if (fromPort == id_CLKI && toPort == id_CLKO) {
             // TODO: Use actual DCC delays
-            delay.rise.min_delay = 1000;
-            delay.rise.max_delay = 1000;
-            delay.fall.min_delay = 1000;
-            delay.fall.max_delay = 1000;
+            delay.rise.min_delay = 1;
+            delay.rise.max_delay = 1;
+            delay.fall.min_delay = 1;
+            delay.fall.max_delay = 1;
             return true;
         }
     }

--- a/nexus/arch.cc
+++ b/nexus/arch.cc
@@ -492,6 +492,15 @@ bool Arch::getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort
         }
         int index = get_cell_timing_idx(id_DCS, id_DCS);
         return lookup_cell_delay(index, fromPort, toPort, delay);
+    } else if (cell->type == id_DCC) {
+        if (fromPort == id_CLKI && toPort == id_CLKO) {
+            // TODO: Use actual DCC delays
+            delay.rise.min_delay = 1000;
+            delay.rise.max_delay = 1000;
+            delay.fall.min_delay = 1000;
+            delay.fall.max_delay = 1000;
+            return true;
+        }
     }
     return false;
 }
@@ -560,11 +569,9 @@ TimingPortClass Arch::getPortTimingClass(const CellInfo *cell, IdString port, in
         return type;
     } else if (cell->type == id_DCC) {
         if (port == id_CLKI)
-            return TMG_CLOCK_INPUT;
-        else if (port == id_CLKO)
-            return TMG_GEN_CLOCK;
-        else if (port == id_CE)
             return TMG_COMB_INPUT;
+        else if (port == id_CLKO)
+            return TMG_COMB_OUTPUT;
     } else if (cell->type == id_DCS) {
         // FIXME: Making inputs TMG_CLOCK_INPUT and the output TMG_CLOCK_GEN
         // yielded in error in the timing analyzer. For now keep those as


### PR DESCRIPTION
This PR is a proof of concept of doing cross-domain timing checks. In general case two clock domains are independent. However, if both clocks come from the same source their frequencies are equal and they differ just in phase (or delay). This can be used to do timing checks for cross-domain paths whenever they are related.

The implemented algorithm looks for a common driver for each clock pair. If one is found then those clocks are considered related and a delay difference from that driver to their nets is stored. The delay is then taken into account when doing timing checks. A check is performed for cross-domain path only if its clocks are related.