### PR TITLE
router2: Reserve source wire, too; ice40 fixes

### DIFF
--- a/common/route/router2.cc
+++ b/common/route/router2.cc
@@ -453,6 +453,13 @@ struct Router2
     {
         bool did_something = false;
         WireId src = ctx->getNetinfoSourceWire(net);
+        {
+            auto &src_wd = wire_data(src);
+            if (src_wd.reserved_net != -1 && src_wd.reserved_net != net->udata)
+                log_error("attempting to reserve src wire '%s' for nets '%s' and '%s'\n", ctx->nameOfWire(src),
+                          ctx->nameOf(nets_by_udata.at(src_wd.reserved_net)), ctx->nameOf(net));
+            src_wd.reserved_net = net->udata;
+        }
         auto &usr = net->users.at(i);
         for (auto sink : ctx->getNetinfoSinkWires(net, usr)) {
             pool<WireId> rsv;

--- a/ice40/arch.h
+++ b/ice40/arch.h
@@ -680,6 +680,16 @@ struct Arch : BaseArch<ArchRanges>
         return switches_locked[pi.switch_index] == WireId();
     }
 
+    bool checkPipAvailForNet(PipId pip, NetInfo *net) const override
+    {
+        if (ice40_pip_hard_unavail(pip))
+            return false;
+
+        auto &pi = chip_info->pip_data[pip.index];
+        auto swl = switches_locked[pi.switch_index];
+        return swl == WireId() || (swl == getPipDstWire(pip) && wire_to_net[swl.index] == net);
+    }
+
     NetInfo *getBoundPipNet(PipId pip) const override
     {
         NPNR_ASSERT(pip != PipId());


### PR DESCRIPTION
Congestion at the source can occur in any arch that chooses to provide LUT-route-through psuedo-pips, including iCE40. Although the reason router2 can't then resolve the congestion easily needs to be investigated longer term, at least this resolves the some cases of router2 getting totally stuck on some iCE40 designs.
It also makes me think more arches might want to see if LUT-through-pips are useful things in general...