### PR TITLE
Support windows line endings in constraints for nextpnr-gowin

### DIFF
--- a/gowin/arch.cc
+++ b/gowin/arch.cc
@@ -876,12 +876,12 @@ void Arch::read_cst(std::istream &in)
     // If two locations are specified separated by commas (for differential I/O buffers),
     // only the first location is actually recognized and used.
     // And pin A will be Positive and pin B will be Negative in any case.
-    std::regex iobre = std::regex("IO_LOC +\"([^\"]+)\" +([^ ,;]+)(, *[^ ;]+)? *;.*");
-    std::regex portre = std::regex("IO_PORT +\"([^\"]+)\" +([^;]+;).*");
+    std::regex iobre = std::regex("IO_LOC +\"([^\"]+)\" +([^ ,;]+)(, *[^ ;]+)? *;.*[\\s\\S]*");
+    std::regex portre = std::regex("IO_PORT +\"([^\"]+)\" +([^;]+;).*[\\s\\S]*");
     std::regex port_attrre = std::regex("([^ =;]+=[^ =;]+) *([^;]*;)");
     std::regex iobelre = std::regex("IO([TRBL])([0-9]+)\\[?([A-Z])\\]?");
-    std::regex inslocre = std::regex("INS_LOC +\"([^\"]+)\" +R([0-9]+)C([0-9]+)\\[([0-9])\\]\\[([AB])\\] *;.*");
-    std::regex clockre = std::regex("CLOCK_LOC +\"([^\"]+)\" +BUF([GS])(\\[([0-7])\\])?[^;]*;.*");
+    std::regex inslocre = std::regex("INS_LOC +\"([^\"]+)\" +R([0-9]+)C([0-9]+)\\[([0-9])\\]\\[([AB])\\] *;.*[\\s\\S]*");
+    std::regex clockre = std::regex("CLOCK_LOC +\"([^\"]+)\" +BUF([GS])(\\[([0-7])\\])?[^;]*;.*[\\s\\S]*");
     std::smatch match, match_attr, match_pinloc;
     std::string line, pinline;
     enum


### PR DESCRIPTION
When using `nextpnr-gowin` with a constraints file that has windows line endings the CR character (ASCII 13) would be left in the string from std::getline and it would fail the regular expression as .* doesn't match newline characters.

This would cause none of the constraints to be loaded and would give a warning like the following:
```
Warning: Invalid constraint:
Warning: Invalid constraint: IO_LOC "clk" 35;
Warning: Invalid constraint: IO_LOC "rst" 77;
Warning: Invalid constraint: IO_LOC "led[0]" 86;
Warning: Invalid constraint: IO_LOC "led[1]" 85;
Warning: Invalid constraint: IO_LOC "led[2]" 84;
Warning: Invalid constraint: IO_LOC "led[3]" 83;
Warning: Invalid constraint: IO_LOC "led[4]" 82;
Warning: Invalid constraint: IO_LOC "led[5]" 81;
Warning: Invalid constraint: IO_LOC "led[6]" 80;
```

This proposed change adds an optional \s\S to the end of the regular expressions which should match any character including the carriage return character making it work on files created with windows line endings