### PR TITLE
Correct Not Equal operator implementation in ice40

### DIFF
--- a/ice40/archdefs.h
+++ b/ice40/archdefs.h
@@ -97,7 +97,7 @@ struct GroupId
     int8_t x = 0, y = 0;
 
     bool operator==(const GroupId &other) const { return (type == other.type) && (x == other.x) && (y == other.y); }
-    bool operator!=(const GroupId &other) const { return (type != other.type) || (x != other.x) || (y == other.y); }
+    bool operator!=(const GroupId &other) const { return (type != other.type) || (x != other.x) || (y != other.y); }
     unsigned int hash() const { return mkhash(mkhash(x, y), int(type)); }
 };
 


### PR DESCRIPTION
I noticed this during my work reimplementing nextpnr, and it seems to be dead and wrong, or at least dead. Either way I think this is what was intended unless anyone can correct me.