### PR TITLE
Fix "implicit copy constructor for 'Property' is deprecated"

### DIFF
--- a/common/kernel/property.h
+++ b/common/kernel/property.h
@@ -46,6 +46,7 @@ struct Property
     Property(const std::string &strval);
     Property(State bit);
     Property &operator=(const Property &other) = default;
+    Property(const Property &other) = default;
 
     bool is_string;
 


### PR DESCRIPTION
Signed-off-by: gatecat <gatecat@ds0.me>