### PR TITLE
gowin: add support for a more common chip

### DIFF
--- a/gowin/pack.cc
+++ b/gowin/pack.cc
@@ -1018,7 +1018,7 @@ static void pack_plls(Context *ctx)
 
             switch (ci->type.hash()) {
             case ID_rPLL: {
-                if (parm_device == "GW1N-1") {
+                if (parm_device == "GW1N-1" || parm_device == "GW1NZ-1") {
                     // B half
                     std::unique_ptr<CellInfo> cell = create_generic_cell(ctx, id_RPLLB, ci->name.str(ctx) + "$rpllb");
                     reconnect_rpllb(ctx, ci, cell.get());


### PR DESCRIPTION
The GW1N-1 and GW1NZ-1 have a similar PLL, but the board with the former chip is already very hard to buy, so let's experiment with a more affordable chip.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>