### PR TITLE
gowin: add information about pin configurations

### DIFF
--- a/gowin/arch.cc
+++ b/gowin/arch.cc
@@ -666,6 +666,17 @@ const PairPOD *pairLookup(const PairPOD *list, const size_t len, const int dest)
     return nullptr;
 }
 
+const PinPOD *pinLookup(const PinPOD *list, const size_t len, const int idx)
+{
+    for (size_t i = 0; i < len; i++) {
+        const PinPOD *pin = &list[i];
+        if (pin->index_id == idx) {
+            return pin;
+        }
+    }
+    return nullptr;
+}
+
 bool aliasCompare(GlobalAliasPOD i, GlobalAliasPOD j)
 {
     return (i.dest_row < j.dest_row) || (i.dest_row == j.dest_row && i.dest_col < j.dest_col) ||
@@ -947,9 +958,9 @@ void Arch::read_cst(std::istream &in)
         case ioloc: { // IO_LOC name pin
             IdString pinname = id(match[2]);
             pinline = match[2];
-            const PairPOD *belname = pairLookup(package->pins.get(), package->num_pins, pinname.index);
+            const PinPOD *belname = pinLookup(package->pins.get(), package->num_pins, pinname.index);
             if (belname != nullptr) {
-                std::string bel = IdString(belname->src_id).str(this);
+                std::string bel = IdString(belname->loc_id).str(this);
                 it->second->setAttr(IdString(ID_BEL), bel);
             } else {
                 if (std::regex_match(pinline, match_pinloc, iobelre)) {

--- a/gowin/arch.h
+++ b/gowin/arch.h
@@ -140,10 +140,17 @@ NPNR_PACKED_STRUCT(struct PartnumberPOD {
     uint32_t speed_id;
 });
 
+NPNR_PACKED_STRUCT(struct PinPOD {
+    uint16_t index_id;
+    uint16_t loc_id;
+    uint32_t num_cfgs;
+    RelPtr<uint32_t> cfgs;
+});
+
 NPNR_PACKED_STRUCT(struct PackagePOD {
     uint32_t name_id;
     uint32_t num_pins;
-    RelPtr<PairPOD> pins;
+    RelPtr<PinPOD> pins;
 });
 
 NPNR_PACKED_STRUCT(struct VariantPOD {
@@ -475,7 +482,7 @@ struct Arch : BaseArch<ArchRanges>
     void route_gowin_globals(Context *ctx);
 
     // chip db version
-    unsigned int const chipdb_version = 1;
+    unsigned int const chipdb_version = 2;
 
     std::vector<IdString> cell_types;
 


### PR DESCRIPTION
Includes information on additional pin functions such as RPLL_C_IN, GCLKC_3, SCLK and others. This allows a decision to be made about special network routing of such pins

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>