### PR TITLE
gowin: BUGFIX: Correctly handle resets

### DIFF
--- a/gowin/arch.cc
+++ b/gowin/arch.cc
@@ -2051,19 +2051,6 @@ void Arch::fix_pll_nets(Context *ctx)
             // This is general routing through CLK2 pip
             ci->setParam(id_FBSEL, Property("CLKFB0"));
         } while (0);
-
-        // resets
-        Property pr_enable("ENABLE"), pr_disable("DISABLE");
-        NetInfo *net = ci->getPort(id_RESET);
-        ci->setParam(id_RSTEN, pr_enable);
-        if (!port_used(ci, id_RESET) || net->name == id("$PACKER_VCC_NET") || net->name == id("$PACKER_GND_NET")) {
-            ci->setParam(id_RSTEN, pr_disable);
-        }
-        ci->setParam(id_PWDEN, pr_enable);
-        net = ci->getPort(id_RESET_P);
-        if (!port_used(ci, id_RESET_P) || net->name == id("$PACKER_VCC_NET") || net->name == id("$PACKER_GND_NET")) {
-            ci->setParam(id_PWDEN, pr_disable);
-        }
     }
 }
 

--- a/gowin/pack.cc
+++ b/gowin/pack.cc
@@ -1026,6 +1026,20 @@ static void pack_plls(Context *ctx)
                     for (int i = 0; i < 4; ++i) {
                         ci->setParam(ports[i][1], port_used(ci, ports[i][0]) ? pr_enable : pr_disable);
                     }
+                    // resets
+                    NetInfo *net = ci->getPort(id_RESET);
+                    ci->setParam(id_RSTEN, pr_enable);
+                    if (!port_used(ci, id_RESET) || net->name == ctx->id("$PACKER_VCC_NET") ||
+                        net->name == ctx->id("$PACKER_GND_NET")) {
+                        ci->setParam(id_RSTEN, pr_disable);
+                    }
+                    ci->setParam(id_PWDEN, pr_enable);
+                    net = ci->getPort(id_RESET_P);
+                    if (!port_used(ci, id_RESET_P) || net->name == ctx->id("$PACKER_VCC_NET") ||
+                        net->name == ctx->id("$PACKER_GND_NET")) {
+                        ci->setParam(id_PWDEN, pr_disable);
+                    }
+
                     // B half
                     std::unique_ptr<CellInfo> cell = create_generic_cell(ctx, id_RPLLB, ci->name.str(ctx) + "$rpllb");
                     reconnect_rpllb(ctx, ci, cell.get());


### PR DESCRIPTION
When a single primitive occupies several cells, care must be taken when manipulating the parameters of that primitive: when creating cells, each cell must receive a copy of all the parameters and not modify them unnecessarily.  That is, if possible, it is better to make all parameter changes before dividing the primitive into cells.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>