### PR TITLE
Timeout when legal placement can't be found for cell

### DIFF
--- a/common/kernel/command.cc
+++ b/common/kernel/command.cc
@@ -189,6 +189,7 @@ po::options_description CommandHandler::getGeneralOptions()
     general.add_options()("placer-heap-critexp", po::value<int>(),
                           "placer heap criticality exponent (int, default: 2)");
     general.add_options()("placer-heap-timingweight", po::value<int>(), "placer heap timing weight (int, default: 10)");
+    general.add_options()("no-placer-timeout", "allow the placer to attempt placement without timeout");
 
 #if !defined(__wasm)
     general.add_options()("parallel-refine", "use new experimental parallelised engine for placement refinement");
@@ -327,6 +328,9 @@ void CommandHandler::setupContext(Context *ctx)
 
     if (vm.count("placer-heap-timingweight"))
         ctx->settings[ctx->id("placerHeap/timingWeight")] = std::to_string(vm["placer-heap-timingweight"].as<int>());
+
+    if (vm.count("no-placer-timeout"))
+        ctx->settings[ctx->id("placerHeap/noTimeout")] = true;
 
     if (vm.count("parallel-refine"))
         ctx->settings[ctx->id("placerHeap/parallelRefine")] = true;

--- a/common/kernel/command.cc
+++ b/common/kernel/command.cc
@@ -189,7 +189,8 @@ po::options_description CommandHandler::getGeneralOptions()
     general.add_options()("placer-heap-critexp", po::value<int>(),
                           "placer heap criticality exponent (int, default: 2)");
     general.add_options()("placer-heap-timingweight", po::value<int>(), "placer heap timing weight (int, default: 10)");
-    general.add_options()("no-placer-timeout", "allow the placer to attempt placement without timeout");
+    general.add_options()("placer-heap-cell-placement-timeout", po::value<int>(),
+            "allow placer to attempt up to the given number of iterations to place the cell (int, default: design size^2 / 8, 0 for no timeout)");
 
 #if !defined(__wasm)
     general.add_options()("parallel-refine", "use new experimental parallelised engine for placement refinement");
@@ -329,8 +330,9 @@ void CommandHandler::setupContext(Context *ctx)
     if (vm.count("placer-heap-timingweight"))
         ctx->settings[ctx->id("placerHeap/timingWeight")] = std::to_string(vm["placer-heap-timingweight"].as<int>());
 
-    if (vm.count("no-placer-timeout"))
-        ctx->settings[ctx->id("placerHeap/noTimeout")] = true;
+    if (vm.count("placer-heap-cell-placement-timeout"))
+        ctx->settings[ctx->id("placerHeap/cellPlacementTimeout")] =
+            std::to_string(std::max(0, vm["placer-heap-cell-placement-timeout"].as<int>()));
 
     if (vm.count("parallel-refine"))
         ctx->settings[ctx->id("placerHeap/parallelRefine")] = true;

--- a/common/kernel/command.cc
+++ b/common/kernel/command.cc
@@ -190,7 +190,7 @@ po::options_description CommandHandler::getGeneralOptions()
                           "placer heap criticality exponent (int, default: 2)");
     general.add_options()("placer-heap-timingweight", po::value<int>(), "placer heap timing weight (int, default: 10)");
     general.add_options()("placer-heap-cell-placement-timeout", po::value<int>(),
-            "allow placer to attempt up to the given number of iterations to place the cell (int, default: design size^2 / 8, 0 for no timeout)");
+            "allow placer to attempt up to max(10000, total cells^2 / N) iterations to place a cell (int N, default: 8, 0 for no timeout)");
 
 #if !defined(__wasm)
     general.add_options()("parallel-refine", "use new experimental parallelised engine for placement refinement");

--- a/common/place/placer_heap.cc
+++ b/common/place/placer_heap.cc
@@ -862,6 +862,7 @@ class HeAPPlacer
             int radius = 0;
             int iter = 0;
             int iter_at_radius = 0;
+            int total_iters_for_cell = 0;
             bool placed = false;
             BelId bestBel;
             int best_inp_len = std::numeric_limits<int>::max();
@@ -880,9 +881,9 @@ class HeAPPlacer
             while (!placed) {
 
                 // Set a conservative timeout
-                if (iter > std::max(10000, 3 * int(ctx->cells.size())))
-                    log_error("Unable to find legal placement for cell '%s', check constraints and utilisation.\n",
-                              ctx->nameOf(ci));
+                if (total_iters_for_cell > std::max(10000, 3 * int(ctx->cells.size())))
+                    log_error("Unable to find legal placement for cell '%s' after %d attempts, check constraints and utilisation.\n",
+                              ctx->nameOf(ci), total_iters_for_cell);
 
                 // Determine a search radius around the solver location (which increases over time) that is clamped to
                 // the region constraint for the cell (if applicable)
@@ -1084,6 +1085,8 @@ class HeAPPlacer
                         break;
                     }
                 }
+
+                total_iters_for_cell++;
             }
         }
         auto endt = std::chrono::high_resolution_clock::now();

--- a/common/place/placer_heap.cc
+++ b/common/place/placer_heap.cc
@@ -1817,10 +1817,15 @@ PlacerHeapCfg::PlacerHeapCfg(Context *ctx)
     timing_driven = ctx->setting<bool>("timing_driven");
     solverTolerance = 1e-5;
     placeAllAtOnce = false;
-    cell_placement_timeout = ctx->setting<int>("placerHeap/cellPlacementTimeout",
-            // Set a conservative default. This is a rather large number and could probably
-            // be shaved down, but for now it will keep the process from running indefinite.
-            std::max(10000, (int(ctx->cells.size()) * int(ctx->cells.size()) / 8) + 1));
+
+    int timeout_divisor = ctx->setting<int>("placerHeap/cellPlacementTimeout", 8);
+    if (timeout_divisor > 0) {
+        // Set a conservative default. This is a rather large number and could probably
+        // be shaved down, but for now it will keep the process from running indefinite.
+        cell_placement_timeout = std::max(10000, (int(ctx->cells.size()) * int(ctx->cells.size()) / timeout_divisor));
+    } else {
+        cell_placement_timeout = 0;
+    }
 
     hpwl_scale_x = 1;
     hpwl_scale_y = 1;

--- a/common/place/placer_heap.cc
+++ b/common/place/placer_heap.cc
@@ -218,7 +218,10 @@ class HeAPPlacer
 
         heap_runs.push_back(all_buckets);
         // The main HeAP placer loop
-        log_info("Running main analytical placer.\n");
+        if (cfg.cell_placement_timeout > 0)
+            log_info("Running main analytical placer, max placement attempts per cell = %d.\n", cfg.cell_placement_timeout);
+        else
+            log_info("Running main analytical placer.\n");
         while (stalled < 5 && (solved_hpwl <= legal_hpwl * 0.8)) {
             // Alternate between particular bel types and all bels
             for (auto &run : heap_runs) {
@@ -828,11 +831,6 @@ class HeAPPlacer
     // Strict placement legalisation, performed after the initial HeAP spreading
     void legalise_placement_strict(bool require_validity = false)
     {
-        int placement_timeout = cfg.no_placement_timeout ? 0 :
-            // Set a conservative timeout. This is a rather large number and could probably be
-            // shaved down, but for now it will keep the process from running indefinite.
-            std::max(10000, (int(ctx->cells.size()) * int(ctx->cells.size()) / 8) + 1);
-
         auto startt = std::chrono::high_resolution_clock::now();
 
         // Unbind all cells placed in this solution
@@ -884,8 +882,8 @@ class HeAPPlacer
             }
 
             while (!placed) {
-                if (placement_timeout > 0 && total_iters_for_cell > placement_timeout)
-                    log_error("Unable to find legal placement for cell '%s' after %d attempts, check constraints and utilisation.\n",
+                if (cfg.cell_placement_timeout > 0 && total_iters_for_cell > cfg.cell_placement_timeout)
+                    log_error("Unable to find legal placement for cell '%s' after %d attempts, check constraints and utilisation. Use `--placer-heap-cell-placement-timeout` to change the number of attempts.\n",
                               ctx->nameOf(ci), total_iters_for_cell);
 
                 // Determine a search radius around the solver location (which increases over time) that is clamped to
@@ -1819,7 +1817,10 @@ PlacerHeapCfg::PlacerHeapCfg(Context *ctx)
     timing_driven = ctx->setting<bool>("timing_driven");
     solverTolerance = 1e-5;
     placeAllAtOnce = false;
-    no_placement_timeout = ctx->setting<bool>("placerHeap/noTimeout", false);
+    cell_placement_timeout = ctx->setting<int>("placerHeap/cellPlacementTimeout",
+            // Set a conservative default. This is a rather large number and could probably
+            // be shaved down, but for now it will keep the process from running indefinite.
+            std::max(10000, (int(ctx->cells.size()) * int(ctx->cells.size()) / 8) + 1));
 
     hpwl_scale_x = 1;
     hpwl_scale_y = 1;

--- a/common/place/placer_heap.cc
+++ b/common/place/placer_heap.cc
@@ -879,9 +879,11 @@ class HeAPPlacer
             }
 
             while (!placed) {
+                // Set a conservative timeout. This is a rather large number and could probably be
+                // shaved down, but for now it will keep the process from running indefinite.
+                int timeout_limit = (int(ctx->cells.size()) * int(ctx->cells.size()) / 8) + 1;
 
-                // Set a conservative timeout
-                if (total_iters_for_cell > std::max(10000, 3 * int(ctx->cells.size())))
+                if (total_iters_for_cell > std::max(10000, timeout_limit))
                     log_error("Unable to find legal placement for cell '%s' after %d attempts, check constraints and utilisation.\n",
                               ctx->nameOf(ci), total_iters_for_cell);
 

--- a/common/place/placer_heap.h
+++ b/common/place/placer_heap.h
@@ -42,6 +42,7 @@ struct PlacerHeapCfg
     float solverTolerance;
     bool placeAllAtOnce;
     bool parallelRefine;
+    bool no_placement_timeout;
 
     int hpwl_scale_x, hpwl_scale_y;
     int spread_scale_x, spread_scale_y;

--- a/common/place/placer_heap.h
+++ b/common/place/placer_heap.h
@@ -42,7 +42,7 @@ struct PlacerHeapCfg
     float solverTolerance;
     bool placeAllAtOnce;
     bool parallelRefine;
-    bool no_placement_timeout;
+    int cell_placement_timeout;
 
     int hpwl_scale_x, hpwl_scale_y;
     int spread_scale_x, spread_scale_y;


### PR DESCRIPTION
The `iter` variable used to generate a timeout if no valid placement can be found for a cell may get reset in https://github.com/YosysHQ/nextpnr/blob/78926b31db6dbfb465e2585ce0050bf93cb3e35c/common/place/placer_heap.cc#L930 The design in https://github.com/YosysHQ/nextpnr/issues/1062 contains a cell where the radius and ripup radius increase to 90 and after that it seems to never find a bel which satisfies the contraints. But the `notempty` label is consistently hit every 909 iterations while searching, causing `iter` to become 0 before it will ever trigger the timeout. The process will happily run for hours without going anywhere.

I think there is a reason this variable gets reset so a separate total is added to track the total number iterations allowing the timeout to be triggered. Note that this counter is only incremented when an actual coordinate is visited, allowing it to try up to 8 times the number of cells in the design.

With this patch applied the design in https://github.com/YosysHQ/nextpnr/issues/1062 properly errors providing the user with a clue that utilization may be too high.
```
Clock '$glbnet$clk_50m_fpga_refclk$TRELLIS_IO_IN' can be driven by:
 clk_50m_fpga_refclk$tr_io.O delay 0.000ns
Info: Placed 142 cells based on constraints.
Info: Creating initial analytic placement for 29349 cells, random placement wirelen = 2284884.
Info:     at initial placer iter 0, wirelen = 20720
Info:     at initial placer iter 1, wirelen = 13471
Info:     at initial placer iter 2, wirelen = 11056
Info:     at initial placer iter 3, wirelen = 11050
Info: Running main analytical placer.
Info:     at iteration #1, type ALL: wirelen solved = 11382, spread = 318213, legal = 423187; time = 4.06s
ERROR: Unable to find legal placement for cell 'MUX_controller_ignition_controllers_27_hello_expired_count_r$write_1__VAL_2_LUT4_Z_2' after 128593 attempts, check constraints and utilisation.
0 warnings, 1 error
``` 