### PR TITLE
gowin: fix build for wasm

### DIFF
--- a/gowin/arch.cc
+++ b/gowin/arch.cc
@@ -523,6 +523,7 @@ void Arch::setBelDecal(BelId bel, DecalXY active, DecalXY inactive)
 
 void Arch::setDefaultDecals(void)
 {
+#ifndef NO_GUI
     for (BelId bel : getBels()) {
         gfxSetBelDefaultDecal(this, bel_info(bel));
     }
@@ -533,6 +534,7 @@ void Arch::setDefaultDecals(void)
         gfxSetWireDefaultDecal(this, wire_info(wire));
     }
     fixClockSpineDecals();
+#endif
 }
 
 void Arch::setGroupDecal(GroupId group, DecalXY decalxy)
@@ -1125,8 +1127,10 @@ Arch::Arch(ArchArgs args) : args(args)
     addDecalGraphic(IdString(), GraphicElement());
 
     if (args.gui) {
+#ifndef NO_GUI
         // decals
         gfxCreateBelDecals(this);
+#endif
     }
 
     // setup package
@@ -1216,11 +1220,13 @@ Arch::Arch(ArchArgs args) : args(args)
         int col = i % db->cols;
         const TilePOD *tile = db->grid[i].get();
         if (args.gui) {
+#ifndef NO_GUI
             // CRU decal
             snprintf(buf, 32, "R%dC%d_CRU", row + 1, col + 1);
             grpname = id(buf);
             addGroup(grpname);
             setGroupDecal(grpname, gfxGetCruGroupDecalXY(col, row));
+#endif
         }
         // setup wires
         const PairPOD *pips[2] = {tile->pips.get(), tile->clock_pips.get()};
@@ -1420,8 +1426,10 @@ Arch::Arch(ArchArgs args) : args(args)
                     snprintf(buf, 32, "R%dC%d_LUT_GRP%d", row + 1, col + 1, z);
                     grpname = id(buf);
                     if (args.gui) {
+#ifndef NO_GUI
                         addGroup(grpname);
                         setGroupDecal(grpname, gfxGetLutGroupDecalXY(col, row, z >> 1));
+#endif
                     }
                 }
                 break;

--- a/gowin/gfx.cc
+++ b/gowin/gfx.cc
@@ -24,6 +24,7 @@
 
 NEXTPNR_NAMESPACE_BEGIN
 
+#ifndef NO_GUI
 // LUTs
 const float lut_w = 0.6732 - 0.6386;
 const float lut_h = 0.9392 - 0.9074;
@@ -5824,5 +5825,6 @@ DecalXY gfxGetCruGroupDecalXY(int x, int y)
     decalxy.y = y;
     return decalxy;
 }
+#endif // NO_GUI
 
 NEXTPNR_NAMESPACE_END

--- a/gowin/gfx.h
+++ b/gowin/gfx.h
@@ -24,6 +24,7 @@
 
 NEXTPNR_NAMESPACE_BEGIN
 
+#ifndef NO_GUI
 void gfxCreateBelDecals(Arch *arch);
 void gfxSetBelDefaultDecal(Arch *arch, BelInfo &bel);
 void gfxSetIOBWireDecals(Arch *arch, BelInfo &bel);
@@ -32,6 +33,7 @@ void gfxSetPipDefaultDecal(Arch *arch, PipInfo &pip);
 void gfxSetWireDefaultDecal(Arch *arch, WireInfo &wire);
 DecalXY gfxGetLutGroupDecalXY(int x, int y, int z);
 DecalXY gfxGetCruGroupDecalXY(int x, int y);
+#endif
 
 NEXTPNR_NAMESPACE_END
 


### PR DESCRIPTION
A large number of global variables are not suitable for WASM, so completely disable the graphics part where the main array of them is used.  For other architectures GUI is still possible.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>