### PR TITLE
gowin: bugfix and improved clock router

### DIFF
--- a/gowin/arch.cc
+++ b/gowin/arch.cc
@@ -2016,6 +2016,16 @@ static bool is_PLL_T_FB_iob(const Context *ctx, const CellInfo *cell)
     return is_spec_iob(ctx, cell, ctx->id("RPLL_T_FB"));
 }
 
+bool Arch::is_GCLKT_iob(const CellInfo *cell)
+{
+    for (int i = 0; i < 6; ++i) {
+        if (is_spec_iob(getCtx(), cell, idf("GCLKT_%d", i))) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // If the PLL input can be connected using a direct wire, then do so,
 // bypassing conventional routing.
 void Arch::fix_pll_nets(Context *ctx)

--- a/gowin/arch.cc
+++ b/gowin/arch.cc
@@ -698,17 +698,28 @@ template <class T, class C> const T *genericLookup(const T *first, int len, cons
     }
 }
 
+template <class T, class C> const T *timingLookup(const T *first, int len, const T val, C compare)
+{
+    for (int i = 0; i < len; ++i) {
+        auto res = &first[i];
+        if (!(compare(*res, val) || compare(val, *res))) {
+            return res;
+        }
+    }
+    return nullptr;
+}
+
 DelayQuad delayLookup(const TimingPOD *first, int len, IdString name)
 {
     TimingPOD needle;
     needle.name_id = name.index;
-    const TimingPOD *timing = genericLookup(first, len, needle, timingCompare);
+    const TimingPOD *timing = timingLookup(first, len, needle, timingCompare);
     DelayQuad delay;
     if (timing != nullptr) {
-        delay.fall.max_delay = std::max(timing->ff, timing->rf) / 1000;
-        delay.fall.min_delay = std::min(timing->ff, timing->rf) / 1000;
-        delay.rise.max_delay = std::max(timing->rr, timing->fr) / 1000;
-        delay.rise.min_delay = std::min(timing->rr, timing->fr) / 1000;
+        delay.fall.max_delay = std::max(timing->ff, timing->rf) / 1000.;
+        delay.fall.min_delay = std::min(timing->ff, timing->rf) / 1000.;
+        delay.rise.max_delay = std::max(timing->rr, timing->fr) / 1000.;
+        delay.rise.min_delay = std::min(timing->rr, timing->fr) / 1000.;
     } else {
         delay = DelayQuad(0);
     }

--- a/gowin/arch.h
+++ b/gowin/arch.h
@@ -480,6 +480,7 @@ struct Arch : BaseArch<ArchRanges>
     void auto_longwires();
     void add_plla_ports(BelsPOD const *bel, IdString belname, int row, int col);
     void fix_pll_nets(Context *ctx);
+    bool is_GCLKT_iob(const CellInfo *cell);
 
     GowinGlobalRouter globals_router;
     void mark_gowin_globals(Context *ctx);

--- a/gowin/globals.h
+++ b/gowin/globals.h
@@ -39,32 +39,32 @@ class GowinGlobalRouter
     {
         IdString name;
         int clock_ports;
-        BelId clock_io_bel;
-        WireId clock_io_wire; // IO wire if there is one
-        int clock;            // clock #
+        BelId clock_bel;
+        WireId clock_wire; // clock wire if there is one
+        int clock;         // clock #
 
         globalnet_t()
         {
             name = IdString();
             clock_ports = 0;
-            clock_io_bel = BelId();
-            clock_io_wire = WireId();
+            clock_bel = BelId();
+            clock_wire = WireId();
             clock = -1;
         }
         globalnet_t(IdString _name)
         {
             name = _name;
             clock_ports = 0;
-            clock_io_bel = BelId();
-            clock_io_wire = WireId();
+            clock_bel = BelId();
+            clock_wire = WireId();
             clock = -1;
         }
 
         // sort
         bool operator<(const globalnet_t &other) const
         {
-            if ((clock_io_wire != WireId()) ^ (other.clock_io_wire != WireId())) {
-                return !(clock_io_wire != WireId());
+            if ((clock_wire != WireId()) ^ (other.clock_wire != WireId())) {
+                return !(clock_wire != WireId());
             }
             return clock_ports < other.clock_ports;
         }
@@ -76,7 +76,7 @@ class GowinGlobalRouter
     std::vector<globalnet_t> nets;
 
     bool is_clock_port(PortRef const &user);
-    std::pair<WireId, BelId> clock_io(Context *ctx, PortRef const &driver);
+    std::pair<WireId, BelId> clock_src(Context *ctx, PortRef const &driver);
     void gather_clock_nets(Context *ctx, std::vector<globalnet_t> &clock_nets);
     IdString route_to_non_clock_port(Context *ctx, WireId const dstWire, int clock, pool<IdString> &used_pips,
                                      pool<IdString> &undo_wires);

--- a/gowin/main.cc
+++ b/gowin/main.cc
@@ -51,7 +51,8 @@ po::options_description GowinCommandHandler::getArchOptions()
     specific.add_options()("device", po::value<std::string>(), "device name");
     specific.add_options()("family", po::value<std::string>(), "family name");
     specific.add_options()("cst", po::value<std::string>(), "physical constraints file");
-    specific.add_options()("enable-globals", "separate routing of the clocks");
+    specific.add_options()("enable-globals", "enable separate routing of the clocks");
+    specific.add_options()("disable-globals", "disable separate routing of the clocks");
     specific.add_options()("enable-auto-longwires", "automatic detection and routing of long wires");
     return specific;
 }
@@ -84,11 +85,10 @@ std::unique_ptr<Context> GowinCommandHandler::createContext(dict<std::string, Pr
 
     auto ctx = std::unique_ptr<Context>(new Context(chipArgs));
     // routing options
-    // the default values will change in the future
-    ctx->settings[ctx->id("arch.enable-globals")] = 0;
+    ctx->settings[ctx->id("arch.enable-globals")] = 1;
     ctx->settings[ctx->id("arch.enable-auto-longwires")] = 0;
-    if (vm.count("enable-globals")) {
-        ctx->settings[ctx->id("arch.enable-globals")] = 1;
+    if (vm.count("disable-globals")) {
+        ctx->settings[ctx->id("arch.enable-globals")] = 0;
     }
     if (vm.count("enable-auto-longwires")) {
         ctx->settings[ctx->id("arch.enable-auto-longwires")] = 1;


### PR DESCRIPTION
The dedicated router for clock wires now understands not only the IO pins but also the rPLL outputs as clock sources.

This simple router sets an optimal route, so it is now the default router. It can be disabled with the --disable-globals command line flag if desired, but this is not recommended due to possible clock skew.

Still for GW1N-4C there is no good router for clock wires as there external quartz resonator is connected via PLL.

The calculation of delays has also been fixed.