### PR TITLE
use eigen as an IMPORTED target in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,8 +225,7 @@ include_directories(common/kernel/ common/place/ common/route/ json/ frontend/ 3
 
 if(BUILD_HEAP)
     find_package (Eigen3 REQUIRED NO_MODULE)
-    include_directories(${EIGEN3_INCLUDE_DIRS})
-    add_definitions(${EIGEN3_DEFINITIONS})
+    link_libraries(Eigen3::Eigen)
     add_definitions(-DWITH_HEAP)
 endif()
 


### PR DESCRIPTION
Eigen considers the EIGEN3_INCLUDE_DIRS and EIGEN3_DEFINITIONS variables to be deprecated and they will no longer be exported in the next release after 3.4.0:
https://gitlab.com/libeigen/eigen/-/commit/f2984cd0778dd0a1d7e74216d826eaff2bc6bfab

Use the IMPORTED target instead, which seems to be the preferred way of consuming third-party CMake libraries.