### PR TITLE
ice40: Improve `output` handling vs pull-ups and undriven

### DIFF
--- a/ice40/cells.cc
+++ b/ice40/cells.cc
@@ -411,7 +411,12 @@ void nxio_to_sb(Context *ctx, CellInfo *nxio, CellInfo *sbio, pool<IdString> &to
         nxio->movePortTo(id_O, sbio, id_D_IN_0);
         pull_up_attr = true;
     } else if (nxio->type == ctx->id("$nextpnr_obuf")) {
-        sbio->params[id_PIN_TYPE] = 25;
+        NetInfo *i = nxio->getPort(id_I);
+        if (i == nullptr || i->driver.cell == nullptr) {
+            sbio->params[id_PIN_TYPE] = 1;
+            pull_up_attr = true;
+        } else
+            sbio->params[id_PIN_TYPE] = 25;
         nxio->movePortTo(id_I, sbio, id_D_OUT_0);
     } else if (nxio->type == ctx->id("$nextpnr_iobuf")) {
         // N.B. tristate will be dealt with below

--- a/ice40/cells.cc
+++ b/ice40/cells.cc
@@ -404,25 +404,23 @@ void dff_to_lc(const Context *ctx, CellInfo *dff, CellInfo *lc, bool pass_thru_l
 
 void nxio_to_sb(Context *ctx, CellInfo *nxio, CellInfo *sbio, pool<IdString> &todelete_cells)
 {
+    bool pull_up_attr = false;
+
     if (nxio->type == ctx->id("$nextpnr_ibuf")) {
         sbio->params[id_PIN_TYPE] = 1;
-        auto pu_attr = nxio->attrs.find(id_PULLUP);
-        if (pu_attr != nxio->attrs.end())
-            sbio->params[id_PULLUP] = pu_attr->second;
         nxio->movePortTo(id_O, sbio, id_D_IN_0);
+        pull_up_attr = true;
     } else if (nxio->type == ctx->id("$nextpnr_obuf")) {
         sbio->params[id_PIN_TYPE] = 25;
         nxio->movePortTo(id_I, sbio, id_D_OUT_0);
     } else if (nxio->type == ctx->id("$nextpnr_iobuf")) {
         // N.B. tristate will be dealt with below
         NetInfo *i = nxio->getPort(id_I);
-        if (i == nullptr || i->driver.cell == nullptr)
+        if (i == nullptr || i->driver.cell == nullptr) {
             sbio->params[id_PIN_TYPE] = 1;
-        else
+            pull_up_attr = true;
+        } else
             sbio->params[id_PIN_TYPE] = 25;
-        auto pu_attr = nxio->attrs.find(id_PULLUP);
-        if (pu_attr != nxio->attrs.end())
-            sbio->params[id_PULLUP] = pu_attr->second;
         nxio->movePortTo(id_I, sbio, id_D_OUT_0);
         nxio->movePortTo(id_O, sbio, id_D_IN_0);
     } else {
@@ -465,6 +463,7 @@ void nxio_to_sb(Context *ctx, CellInfo *nxio, CellInfo *sbio, pool<IdString> &to
         sbio->params[id_PIN_TYPE] = 41;
         tbuf->movePortTo(id_A, sbio, id_D_OUT_0);
         tbuf->movePortTo(id_E, sbio, id_OUTPUT_ENABLE);
+        pull_up_attr = true;
 
         if (donet->users.entries() > 1) {
             for (auto user : donet->users)
@@ -475,6 +474,13 @@ void nxio_to_sb(Context *ctx, CellInfo *nxio, CellInfo *sbio, pool<IdString> &to
         }
         ctx->nets.erase(donet->name);
         todelete_cells.insert(tbuf->name);
+    }
+
+    // Copy pull-up attribute if there's any chance output driver isn't active
+    if (pull_up_attr) {
+        auto pu_attr = nxio->attrs.find(id_PULLUP);
+        if (pu_attr != nxio->attrs.end())
+            sbio->params[id_PULLUP] = pu_attr->second;
     }
 }
 


### PR DESCRIPTION
Previously if a port was declared as `output`, there would be two issues :

 - In all cases, the pull up settings from the PCF wouldn't be applied, even if there was a `TBUF`
 - If the port was bound to a constant net `x` or `z`, this would end up as PIN_TYPE `0110_01` ( `PIN_OUTPUT` ) with `D_OUT_0` no connection, which would result in the pin being actively driven.  ( And AFAICT it could be driven to either 0 or 1 depending on its position in the IO tile ? Although I have yet to reconfirm this ).

This fixes both of theses.

I'm marking this as Draft because I don't have access to hardware ATM to double check everything ... will do during the week, but still open for code review if anyone has comments.