### PR TITLE
ecp5: Propagate clock constraints through DCSC

### DIFF
--- a/ecp5/pack.cc
+++ b/ecp5/pack.cc
@@ -38,10 +38,12 @@ static bool is_nextpnr_iob(Context *ctx, CellInfo *cell)
 
 static bool net_is_constant(const Context *ctx, NetInfo *net, bool &value)
 {
+    auto gnd = ctx->id("$PACKER_GND_NET");
+    auto vcc = ctx->id("$PACKER_VCC_NET");
     if (net == nullptr)
         return false;
-    if (net->name == ctx->id("$PACKER_GND_NET") || net->name == ctx->id("$PACKER_VCC_NET")) {
-        value = (net->name == ctx->id("$PACKER_VCC_NET"));
+    if (net->name.in(gnd, vcc)) {
+        value = (net->name == vcc);
         return true;
     } else {
         return false;

--- a/ice40/pack.cc
+++ b/ice40/pack.cc
@@ -132,10 +132,12 @@ static void pack_nonlut_ffs(Context *ctx)
 
 static bool net_is_constant(const Context *ctx, NetInfo *net, bool &value)
 {
+    auto gnd = ctx->id("$PACKER_GND_NET");
+    auto vcc = ctx->id("$PACKER_VCC_NET");
     if (net == nullptr)
         return false;
-    if (net->name == ctx->id("$PACKER_GND_NET") || net->name == ctx->id("$PACKER_VCC_NET")) {
-        value = (net->name == ctx->id("$PACKER_VCC_NET"));
+    if (net->name.in(gnd, vcc)) {
+        value = (net->name == vcc);
         return true;
     } else {
         return false;


### PR DESCRIPTION
I added a TODO. If `modesel` is tied to `0` and certain modes are selected we can push through either of the clock constraints directly. I couldn't quickly see how I can do this by grepping the codebase.  

 
Fixes https://github.com/YosysHQ/nextpnr/issues/804