### PR TITLE
machxo2: Fix Python bindings for pip iterators

### DIFF
--- a/machxo2/arch_pybindings.cc
+++ b/machxo2/arch_pybindings.cc
@@ -54,8 +54,8 @@ void arch_wrap_python(py::module &m)
     readonly_wrapper<BelPin, decltype(&BelPin::bel), &BelPin::bel, conv_to_str<BelId>>::def_wrap(belpin_cls, "bel");
     readonly_wrapper<BelPin, decltype(&BelPin::pin), &BelPin::pin, conv_to_str<IdString>>::def_wrap(belpin_cls, "pin");
 
-    typedef const PipRange UphillPipRange;
-    typedef const PipRange DownhillPipRange;
+    typedef PipRange UphillPipRange;
+    typedef PipRange DownhillPipRange;
 
     typedef const std::vector<BelBucketId> &BelBucketRange;
     typedef const std::vector<BelId> &BelRangeForBelBucket;


### PR DESCRIPTION
This is basically just a #1053 port for machxo2.