### PR TITLE
Include <cstdint> in common/kernel/hashlib.h

### DIFF
--- a/common/kernel/hashlib.h
+++ b/common/kernel/hashlib.h
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <vector>


### PR DESCRIPTION
The definitions for uint32_t, uint64_t report as undefined when compiling under GCC13. They were previously found by transitive includes, but this is not guaranteed to work, and GCC13 forced the issue.