### PR TITLE
common: disable parallel refinement only without threads

### DIFF
--- a/common/kernel/command.cc
+++ b/common/kernel/command.cc
@@ -200,7 +200,7 @@ po::options_description CommandHandler::getGeneralOptions()
                           "allow placer to attempt up to max(10000, total cells^2 / N) iterations to place a cell (int "
                           "N, default: 8, 0 for no timeout)");
 
-#if !defined(__wasm)
+#if !defined(NPNR_DISABLE_THREADS)
     general.add_options()("parallel-refine", "use new experimental parallelised engine for placement refinement");
 #endif
 

--- a/common/place/detail_place_core.cc
+++ b/common/place/detail_place_core.cc
@@ -219,7 +219,7 @@ bool DetailPlacerThreadState::bounds_check(BelId bel)
 
 bool DetailPlacerThreadState::bind_move()
 {
-#if !defined(__wasm)
+#if !defined(NPNR_DISABLE_THREADS)
     std::unique_lock<std::shared_timed_mutex> l(g.archapi_mutex);
 #endif
     for (auto &entry : moved_cells) {
@@ -240,7 +240,7 @@ bool DetailPlacerThreadState::bind_move()
 
 bool DetailPlacerThreadState::check_validity()
 {
-#if !defined(__wasm)
+#if !defined(NPNR_DISABLE_THREADS)
     std::shared_lock<std::shared_timed_mutex> l(g.archapi_mutex);
 #endif
     bool result = true;
@@ -263,7 +263,7 @@ void DetailPlacerThreadState::revert_move()
 {
     if (arch_state_dirty) {
         // If changes to the arch state were made, revert them by restoring original cell bindings
-#if !defined(__wasm)
+#if !defined(NPNR_DISABLE_THREADS)
         std::unique_lock<std::shared_timed_mutex> l(g.archapi_mutex);
 #endif
         for (auto &entry : moved_cells) {

--- a/common/place/detail_place_core.h
+++ b/common/place/detail_place_core.h
@@ -52,7 +52,7 @@ aborts the entire move transaction.
 
 #include <queue>
 
-#if !defined(__wasm)
+#if !defined(NPNR_DISABLE_THREADS)
 #include <shared_mutex>
 #endif
 
@@ -98,7 +98,7 @@ struct DetailPlacerState
     wirelen_t total_wirelen = 0;
     double total_timing_cost = 0;
 
-#if !defined(__wasm)
+#if !defined(NPNR_DISABLE_THREADS)
     std::shared_timed_mutex archapi_mutex;
 #endif
 

--- a/common/place/parallel_refine.cc
+++ b/common/place/parallel_refine.cc
@@ -20,7 +20,7 @@
 #include "parallel_refine.h"
 #include "log.h"
 
-#if !defined(__wasm)
+#if !defined(NPNR_DISABLE_THREADS)
 
 #include "detail_place_core.h"
 #include "scope_lock.h"
@@ -519,7 +519,7 @@ bool parallel_refine(Context *ctx, ParallelRefineCfg cfg)
 
 NEXTPNR_NAMESPACE_END
 
-#else /* !defined(__wasm) */
+#else /* !defined(NPNR_DISABLE_THREADS) */
 
 NEXTPNR_NAMESPACE_BEGIN
 

--- a/common/place/placer_heap.cc
+++ b/common/place/placer_heap.cc
@@ -355,7 +355,7 @@ class HeAPPlacer
         ctx->check();
         lock.unlock_early();
 
-#if !defined(__wasm)
+#if !defined(NPNR_DISABLE_THREADS)
         if (cfg.parallelRefine) {
             if (!parallel_refine(ctx, ParallelRefineCfg(ctx))) {
                 return false;


### PR DESCRIPTION
Previously it was always disabled on WebAssembly builds.

WASI [has threads now](https://bytecodealliance.org/articles/wasi-threads).