### PR TITLE
CMake: detect platform support for threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,26 +42,25 @@ endif()
 
 set(Boost_NO_BOOST_CMAKE ON)
 
-if(WASI)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lwasi-emulated-mman")
-    set(USE_THREADS OFF)
-    add_definitions(
-        -DBOOST_EXCEPTION_DISABLE
-        -DBOOST_NO_EXCEPTIONS
-        -DBOOST_SP_NO_ATOMIC_ACCESS
-        -DBOOST_AC_DISABLE_THREADS
-        -DBOOST_NO_CXX11_HDR_MUTEX
-    )
-else()
-    set(USE_THREADS ON)
+find_package(Threads)
+if (Threads_FOUND)
     find_package(TBB QUIET)
     if (TBB_FOUND)
         add_definitions(-DNEXTPNR_USE_TBB)
     endif()
+else()
+    add_definitions(-DNPNR_DISABLE_THREADS)
 endif()
 
-if (NOT USE_THREADS)
-    add_definitions(-DNPNR_DISABLE_THREADS)
+if(WASI)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lwasi-emulated-mman")
+    add_definitions(
+        -DBOOST_EXCEPTION_DISABLE
+        -DBOOST_NO_EXCEPTIONS
+    )
+    if (NOT Threads_FOUND)
+        add_definitions(-DBOOST_NO_CXX11_HDR_MUTEX)
+    endif()
 endif()
 
 set(link_param "")
@@ -160,7 +159,7 @@ find_package(Sanitizers)
 
 # List of Boost libraries to include
 set(boost_libs filesystem program_options iostreams system)
-if (USE_THREADS)
+if (Threads_FOUND)
     list(APPEND boost_libs thread)
 endif()
 


### PR DESCRIPTION
Together with https://github.com/YosysHQ/nextpnr/pull/1111 this change makes it possible to build nextpnr with or without parallel refinement support depending on whether the platform has threads available (in case of WASI, you can have WASI with or without threads).