### PR TITLE
mistral: improve timing calculation

### DIFF
--- a/mistral/arch.cc
+++ b/mistral/arch.cc
@@ -462,6 +462,10 @@ bool Arch::place()
         cfg.cellGroups.back().insert({id_MISTRAL_COMB});
         cfg.cellGroups.back().insert({id_MISTRAL_FF});
 
+        // The Cyclone V is asymmetrical enough that it's somewhat beneficial to prefer connecting things horizontally.
+        cfg.hpwl_scale_x = 1;
+        cfg.hpwl_scale_y = 2;
+
         cfg.beta = 0.5; // TODO: find a good value of beta for sensible ALM spreading
         cfg.criticalityExponent = 7;
         if (!placer_heap(getCtx(), cfg))

--- a/mistral/arch.h
+++ b/mistral/arch.h
@@ -289,6 +289,9 @@ struct Arch : BaseArch<ArchRanges>
     ArchArgs args;
     mistral::CycloneV *cyclonev;
 
+    // Mistral needs the bitstream configuring before it can use the simulator.
+    bool bitstream_configured = false;
+
     Arch(ArchArgs args);
     ArchArgs archArgs() const override { return args; }
 
@@ -434,6 +437,7 @@ struct Arch : BaseArch<ArchRanges>
     bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort,
                       DelayQuad &delay) const override; // delay.cc
     DelayQuad getPipDelay(PipId pip) const override;    // delay.cc
+    bool getArcDelayOverride(const NetInfo *net_info, const PortRef &sink, DelayQuad &delay) const override; // delay.cc
 
     // -------------------------------------------------
 

--- a/mistral/bitstream.cc
+++ b/mistral/bitstream.cc
@@ -20,6 +20,7 @@
 #include "log.h"
 #include "nextpnr.h"
 #include "util.h"
+#include "timing.h"
 
 NEXTPNR_NAMESPACE_BEGIN
 namespace {
@@ -379,6 +380,7 @@ struct MistralBitgen
         write_routing();
         write_cells();
         write_labs();
+        ctx->bitstream_configured = true;
     }
 };
 } // namespace
@@ -387,6 +389,16 @@ void Arch::build_bitstream()
 {
     MistralBitgen gen(getCtx());
     gen.run();
+
+    // This is a hack to run timing analysis yet again after the bitstream is
+    // configured in Mistral, because the analogue simulator won't work until
+    // it has a bitstream in the library.
+    //
+    // A better solution would be to move a lot of this bitstream code to
+    // {un,}bind{Bel, Pip} and friends, but we're not there yet.
+    log_info("Running signoff timing analysis...\n");
+
+    timing_analysis(getCtx(), true, true, true, true, true);
 }
 
 NEXTPNR_NAMESPACE_END


### PR DESCRIPTION
There are a number of timing-related goodies in here:
- the Mistral analogue simulator is now used for (admittedly-slow) timing signoff; it usually finds a few megahertz.
- routing timings have been redone; the old timings turned out to be about 11% more pessimistic than necessary.
- `predictDelay` and `estimateDelay` have been fitted to a sample design; this also helps Fmax a bit.
- HeAP has a parameter tweaked to account for the asymmetry of the Cyclone V.

Is this production-grade? Not quite, but I'd like to believe we're getting a bit closer.