### PR TITLE
mistral: Don't allow route-through LUTs in carry-mode ALMs

### DIFF
--- a/mistral/arch.h
+++ b/mistral/arch.h
@@ -48,6 +48,7 @@ struct ALMInfo
     std::array<BelId, 4> ff_bels;
 
     bool l6_mode = false;
+    bool carry_mode = false;
 
     // Which CLK/ENA and ACLR is chosen for each half
     std::array<int, 2> clk_ena_idx, aclr_idx;


### PR DESCRIPTION
Carry mode is per-ALM rather than per-LUT. So when route-through LUTs were being added for FF access in ALMs in carry modes, those LUTs would actually function in adder mode rather than pure buffers, causing occasional failures with certain seeds of certain designs.

