### PR TITLE
gowin: implement differential IO primitives

### DIFF
--- a/gowin/constids.inc
+++ b/gowin/constids.inc
@@ -638,6 +638,7 @@ X(O)
 X(IO)
 X(OE)
 X(OB)
+X(IB)
 
 // bels
 X(DFF0)
@@ -888,6 +889,13 @@ X(OBUF)
 X(IOBUF)
 X(TBUF)
 X(TLVDS_OBUF)
+X(TLVDS_TBUF)
+X(TLVDS_IBUF)
+X(TLVDS_IOBUF)
+X(ELVDS_OBUF)
+X(ELVDS_TBUF)
+X(ELVDS_IBUF)
+X(ELVDS_IOBUF)
 
 // global set/reset
 X(GSR)
@@ -918,6 +926,7 @@ X(BEL)
 X(DIFF)
 X(DIFF_TYPE)
 X(DEVICE)
+X(IOLOGIC_IOB)
 
 // ports
 X(EN)

--- a/gowin/pack.cc
+++ b/gowin/pack.cc
@@ -936,7 +936,7 @@ static void get_next_oser16_loc(std::string device, Loc &loc)
 // create IOB connections for gowin_pack
 static void make_iob_nets(Context *ctx, CellInfo *iob)
 {
-    for (const auto port : iob->ports) {
+    for (const auto &port : iob->ports) {
         const NetInfo *net = iob->getPort(port.first);
         std::string connected_net = "NET";
         if (net != nullptr) {


### PR DESCRIPTION
Adds missing TLVDS_IBUF/IOBUF/TBUF primitives, as well as all kinds of LVDS emulation primitives.