### PR TITLE
router2 alternative weights

### DIFF
--- a/common/kernel/command.cc
+++ b/common/kernel/command.cc
@@ -211,6 +211,8 @@ po::options_description CommandHandler::getGeneralOptions()
     general.add_options()("router2-tmg-ripup",
                           "enable experimental timing-driven ripup in router (deprecated; use --tmg-ripup instead)");
 
+    general.add_options()("router2-alt-weights", "use alternate router2 weights");
+
     general.add_options()("report", po::value<std::string>(),
                           "write timing and utilization report in JSON format to file");
     general.add_options()("detailed-timing-report", "Append detailed net timing data to the JSON report");
@@ -351,6 +353,9 @@ void CommandHandler::setupContext(Context *ctx)
         ctx->settings[ctx->id("router2/heatmap")] = vm["router2-heatmap"].as<std::string>();
     if (vm.count("tmg-ripup") || vm.count("router2-tmg-ripup"))
         ctx->settings[ctx->id("router/tmg_ripup")] = true;
+
+    if (vm.count("router2-alt-weights"))
+        ctx->settings[ctx->id("router2/alt-weights")] = true;
 
     // Setting default values
     if (ctx->settings.find(ctx->id("target_freq")) == ctx->settings.end())

--- a/common/route/router2.cc
+++ b/common/route/router2.cc
@@ -1423,7 +1423,7 @@ struct Router2
             int tmgfail = 0;
             if (timing_driven)
                 tmg.run(false);
-            if (timing_driven_ripup && iter < 500) {
+            if (timing_driven_ripup && iter < 1500) {
                 for (size_t i = 0; i < nets_by_udata.size(); i++) {
                     NetInfo *ni = nets_by_udata.at(i);
                     for (auto usr : ni->users.enumerate()) {
@@ -1492,10 +1492,17 @@ Router2Cfg::Router2Cfg(Context *ctx)
     bb_margin_y = ctx->setting<int>("router2/bbMargin/y", 3);
     ipin_cost_adder = ctx->setting<float>("router2/ipinCostAdder", 0.0f);
     bias_cost_factor = ctx->setting<float>("router2/biasCostFactor", 0.25f);
-    init_curr_cong_weight = ctx->setting<float>("router2/initCurrCongWeight", 0.5f);
-    hist_cong_weight = ctx->setting<float>("router2/histCongWeight", 1.0f);
-    curr_cong_mult = ctx->setting<float>("router2/currCongWeightMult", 2.0f);
-    estimate_weight = ctx->setting<float>("router2/estimateWeight", 1.25f);
+    if (ctx->settings.count(ctx->id("router2/alt-weights"))) {
+        init_curr_cong_weight = ctx->setting<float>("router2/initCurrCongWeight", 5.0f);
+        hist_cong_weight = ctx->setting<float>("router2/histCongWeight", 0.5f);
+        curr_cong_mult = ctx->setting<float>("router2/currCongWeightMult", 0.0f);
+        estimate_weight = ctx->setting<float>("router2/estimateWeight", 1.0f);
+    } else {
+        init_curr_cong_weight = ctx->setting<float>("router2/initCurrCongWeight", 0.5f);
+        hist_cong_weight = ctx->setting<float>("router2/histCongWeight", 1.0f);
+        curr_cong_mult = ctx->setting<float>("router2/currCongWeightMult", 2.0f);
+        estimate_weight = ctx->setting<float>("router2/estimateWeight", 1.25f);
+    }
     perf_profile = ctx->setting<bool>("router2/perfProfile", false);
     if (ctx->settings.count(ctx->id("router2/heatmap")))
         heatmap = ctx->settings.at(ctx->id("router2/heatmap")).as_string();


### PR DESCRIPTION
I've been tinkering with r2 over the past few days, and I think I have a set of weights that reaches a much higher maximum frequency than the defaults, using `mistral`, anyway.

The idea is to have more, smaller-step iterations, in the hopes of better negotiation between wires, and at least empirically, this seems to work out.