### PR TITLE
mistral: improve ALM packing in LABs

### DIFF
--- a/mistral/lab.cc
+++ b/mistral/lab.cc
@@ -690,12 +690,18 @@ bool Arch::is_lab_ctrlset_legal(uint32_t lab) const
 void Arch::lab_pre_route()
 {
     log_info("Preparing LABs for routing...\n");
+    int labs_used = 0;
     for (uint32_t lab = 0; lab < labs.size(); lab++) {
+        bool lab_used = false;
         assign_control_sets(lab);
         for (uint8_t alm = 0; alm < 10; alm++) {
             reassign_alm_inputs(lab, alm);
+            lab_used |= labs.at(lab).alms.at(alm).unique_input_count > 0;
         }
+        if (lab_used)
+            labs_used++;
     }
+    log_info("  %d LABs used\n", labs_used);
 }
 
 void Arch::assign_control_sets(uint32_t lab)


### PR DESCRIPTION
The current ALM packing code overestimates LAB TD congestion due to not accounting for sharing across ALMs. 

Recently, I tried to resolve this by hashing the signal names, but this actually underestimated LAB TD congestion, because the TD-to-GOUT (ALM input) crossbar is not fully populated. The solution to this is to hash signal-and-ALM-input pairs, which still results in a distinct reduction in LAB use for attosoc, from 133 to 123 LABs.

I am a bit concerned about the impact on performance here; while it's still "fine" for small designs, perhaps @gatecat might have an alternative implementation based on the existing `unique_input_count` code minus some incrementally-updated factor for signal sharing.

This code also does not take into account LD usage, which would need some further thinking.