### PR TITLE
gowin: Add support for GW2A series chips

### DIFF
--- a/gowin/CMakeLists.txt
+++ b/gowin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(chipdb-gowin NONE)
 
-set(ALL_GOWIN_DEVICES GW1N-1 GW1NZ-1 GW1N-4 GW1N-9 GW1N-9C GW1NS-2 GW1NS-4)
+set(ALL_GOWIN_DEVICES GW1N-1 GW1NZ-1 GW1N-4 GW1N-9 GW1N-9C GW1NS-2 GW1NS-4 GW2A-18)
 set(GOWIN_DEVICES ${ALL_GOWIN_DEVICES} CACHE STRING
     "Include support for these Gowin devices (available: ${ALL_GOWIN_DEVICES})")
 message(STATUS "Enabled Gowin devices: ${GOWIN_DEVICES}")


### PR DESCRIPTION
* Limited to Tangprimer 20k or GW2A-LV18PG256C8/I7 chip.
* Clock lines are disabled.