### PR TITLE
himbaechel: Initial timing support

### DIFF
--- a/generic/viaduct/example/synth_viaduct_example.tcl
+++ b/generic/viaduct/example/synth_viaduct_example.tcl
@@ -2,7 +2,7 @@
 # tcl synth_viaduct_example.tcl {out.json}
 
 yosys read_verilog -lib [file dirname [file normalize $argv0]]/example_prims.v
-yosys hierarchy -check
+yosys hierarchy -check -top top
 yosys proc
 yosys flatten
 yosys tribuf -logic

--- a/himbaechel/archdefs.h
+++ b/himbaechel/archdefs.h
@@ -98,6 +98,7 @@ struct ArchNetInfo
 struct ArchCellInfo : BaseClusterInfo
 {
     int flat_index;
+    int timing_index = -1;
     dict<IdString, std::vector<IdString>> cell_bel_pins;
 };
 

--- a/himbaechel/chipdb.h
+++ b/himbaechel/chipdb.h
@@ -62,7 +62,8 @@ NPNR_PACKED_STRUCT(struct BelPinRefPOD {
 NPNR_PACKED_STRUCT(struct TileWireDataPOD {
     int32_t name;
     int32_t wire_type;
-    int32_t flags; // 32 bits of arbitrary data
+    int32_t flags;      // 32 bits of arbitrary data
+    int32_t timing_idx; // used only when the wire is not part of a node, otherwise node idx applies
     RelSlice<int32_t> pips_uphill;
     RelSlice<int32_t> pips_downhill;
     RelSlice<BelPinRefPOD> bel_pins;
@@ -85,7 +86,7 @@ NPNR_PACKED_STRUCT(struct RelTileWireRefPOD {
 
 NPNR_PACKED_STRUCT(struct NodeShapePOD {
     RelSlice<RelTileWireRefPOD> tile_wires;
-    int32_t timing_index;
+    int32_t timing_idx;
 });
 
 NPNR_PACKED_STRUCT(struct TileTypePOD {
@@ -151,12 +152,6 @@ NPNR_PACKED_STRUCT(struct TimingValue {
     int32_t slow_max;
 });
 
-NPNR_PACKED_STRUCT(struct BelPinTimingPOD {
-    TimingValue in_cap;
-    TimingValue drive_res;
-    TimingValue delay;
-});
-
 NPNR_PACKED_STRUCT(struct PipTimingPOD {
     TimingValue int_delay;
     TimingValue in_cap;
@@ -186,19 +181,19 @@ NPNR_PACKED_STRUCT(struct CellPinCombArcPOD {
 
 NPNR_PACKED_STRUCT(struct CellPinTimingPOD {
     int32_t pin;
+    int32_t flags;
     RelSlice<CellPinCombArcPOD> comb_arcs;
     RelSlice<CellPinRegArcPOD> reg_arcs;
+    static constexpr int32_t FLAG_CLK = 1;
 });
 
 NPNR_PACKED_STRUCT(struct CellTimingPOD {
-    int32_t type;
-    int32_t variant;
+    int32_t type_variant;
     RelSlice<CellPinTimingPOD> pins;
 });
 
 NPNR_PACKED_STRUCT(struct SpeedGradePOD {
     int32_t name;
-    RelSlice<BelPinTimingPOD> bel_pin_classes;
     RelSlice<PipTimingPOD> pip_classes;
     RelSlice<NodeTimingPOD> node_classes;
     RelSlice<CellTimingPOD> cell_types;

--- a/himbaechel/himbaechel_dbgen/bba.py
+++ b/himbaechel/himbaechel_dbgen/bba.py
@@ -17,10 +17,13 @@ class BBAWriter:
 	def label(self, s):
 		print(f"label {s}", file=self.f)
 	def u8(self, n, comment=""):
+		assert isinstance(n, int), n
 		print(f"u8 {n} {comment}", file=self.f)
 	def u16(self, n, comment=""):
+		assert isinstance(n, int), n
 		print(f"u16 {n} {comment}", file=self.f)
 	def u32(self, n, comment=""):
+		assert isinstance(n, int), n
 		print(f"u32 {n} {comment}", file=self.f)
 	def pop(self):
 		print("pop", file=self.f)

--- a/himbaechel/himbaechel_dbgen/chip.py
+++ b/himbaechel/himbaechel_dbgen/chip.py
@@ -25,7 +25,7 @@ class BBAStruct(abc.ABC):
     def serialise(self, context: str, bba: BBAWriter):
         pass
 
-@dataclass(eq=True, frozen=True)
+@dataclass(eq=True, order=True, frozen=True)
 class IdString:
     index: int = 0
 
@@ -144,6 +144,7 @@ class TileWireData:
     name: IdString
     wire_type: IdString
     flags: int = 0
+    timing_idx: int = -1
 
     # not serialised, but used to build the global constant networks
     const_val: int = -1
@@ -167,6 +168,7 @@ class TileWireData:
         bba.u32(self.name.index)
         bba.u32(self.wire_type.index)
         bba.u32(self.flags)
+        bba.u32(self.timing_idx)
         bba.slice(f"{context}_pips_uh", len(self.pips_uphill))
         bba.slice(f"{context}_pips_dh", len(self.pips_downhill))
         bba.slice(f"{context}_bel_pins", len(self.bel_pins))
@@ -191,6 +193,7 @@ class PipData(BBAStruct):
 @dataclass
 class TileType(BBAStruct):
     strs: StringPool
+    tmg: "TimingPool"
     type_name: IdString
     bels: list[BelData] = field(default_factory=list)
     pips: list[PipData] = field(default_factory=list)
@@ -223,11 +226,12 @@ class TileType(BBAStruct):
         self._wire2idx[wire.name] = wire.index
         self.wires.append(wire)
         return wire
-    def create_pip(self, src: str, dst: str):
+    def create_pip(self, src: str, dst: str, timing_class: str=""):
         # Create a pip between two tile wires in the tile type. Both wires should exist already.
         src_idx = self._wire2idx[self.strs.id(src)]
         dst_idx = self._wire2idx[self.strs.id(dst)]
-        pip = PipData(index=len(self.pips), src_wire=src_idx, dst_wire=dst_idx)
+        pip = PipData(index=len(self.pips), src_wire=src_idx, dst_wire=dst_idx,
+            timing_idx=self.tmg.pip_class_idx(timing_class))
         self.wires[src_idx].pips_downhill.append(pip.index)
         self.wires[dst_idx].pips_uphill.append(pip.index)
         self.pips.append(pip)
@@ -294,6 +298,8 @@ class TileWireRef(BBAStruct):
 @dataclass
 class NodeShape(BBAStruct):
     wires: list[TileWireRef] = field(default_factory=list)
+    timing_index: int = -1
+
     def key(self):
         m = hashlib.sha1()
         for wire in self.wires:
@@ -310,7 +316,7 @@ class NodeShape(BBAStruct):
             bba.u16(0) # alignment
     def serialise(self, context: str, bba: BBAWriter):
         bba.slice(f"{context}_wires", len(self.wires))
-        bba.u32(-1) # timing index (not yet used)
+        bba.u32(self.timing_index) # timing index (not yet used)
 
 MODE_TILE_WIRE = 0x7000
 MODE_IS_ROOT = 0x7001
@@ -430,6 +436,247 @@ class PackageInfo(BBAStruct):
         bba.u32(self.name.index)
         bba.slice(f"{context}_pads", len(self.pads))
 
+class TimingValue(BBAStruct):
+    def __init__(self, fast_min=0, fast_max=None, slow_min=None, slow_max=None):
+        self.fast_min = fast_min
+        self.fast_max = fast_max or fast_min
+        self.slow_min = slow_min or self.fast_min
+        self.slow_max = slow_max or self.fast_max
+
+    def serialise_lists(self, context: str, bba: BBAWriter):
+        pass
+    def serialise(self, context: str, bba: BBAWriter):
+            bba.u32(self.fast_min)
+            bba.u32(self.fast_max)
+            bba.u32(self.slow_min)
+            bba.u32(self.slow_max)
+
+@dataclass
+class PipTiming(BBAStruct):
+    int_delay: TimingValue = field(default_factory=TimingValue) # internal fixed delay in ps
+    in_cap: TimingValue = field(default_factory=TimingValue) # internal capacitance in notional femtofarads
+    out_res: TimingValue = field(default_factory=TimingValue) # drive/output resistance in notional milliohms
+    flags: int = 0 # is_buffered etc
+    def serialise_lists(self, context: str, bba: BBAWriter):
+        pass
+    def serialise(self, context: str, bba: BBAWriter):
+        self.int_delay.serialise(context, bba)
+        self.in_cap.serialise(context, bba)
+        self.out_res.serialise(context, bba)
+        bba.u32(self.flags)
+
+@dataclass
+class NodeTiming(BBAStruct):
+    res: TimingValue = field(default_factory=TimingValue) # wire resistance in notional milliohms
+    cap: TimingValue = field(default_factory=TimingValue) # wire capacitance in notional femtofarads
+    delay: TimingValue = field(default_factory=TimingValue) # fixed wire delay in ps
+    def serialise_lists(self, context: str, bba: BBAWriter):
+        pass
+    def serialise(self, context: str, bba: BBAWriter):
+        self.res.serialise(context, bba)
+        self.cap.serialise(context, bba)
+        self.delay.serialise(context, bba)
+
+@dataclass
+class ClockEdge(Enum):
+    RISING = 0
+    FALLING = 1
+
+@dataclass
+class CellPinRegArc(BBAStruct):
+    clock: int
+    edge: ClockEdge
+    setup: TimingValue = field(default_factory=TimingValue) # setup time in ps
+    hold: TimingValue = field(default_factory=TimingValue) # hold time in ps
+    clk_q: TimingValue = field(default_factory=TimingValue) # clock to output time in ps
+    def serialise_lists(self, context: str, bba: BBAWriter):
+        pass
+    def serialise(self, context: str, bba: BBAWriter):
+        bba.u32(self.clock.index)
+        bba.u32(self.edge.value)
+        self.setup.serialise(context, bba)
+        self.hold.serialise(context, bba)
+        self.clk_q.serialise(context, bba)
+
+@dataclass
+class CellPinCombArc(BBAStruct):
+    from_pin: int
+    delay: TimingValue = field(default_factory=TimingValue)
+    def serialise_lists(self, context: str, bba: BBAWriter):
+        pass
+    def serialise(self, context: str, bba: BBAWriter):
+        bba.u32(self.from_pin.index)
+        self.delay.serialise(context, bba)
+
+@dataclass
+class CellPinTiming(BBAStruct):
+    pin: int
+    flags: int = 0
+    comb_arcs: list[CellPinCombArc] = field(default_factory=list) # sorted by from_pin ID index
+    reg_arcs: list[CellPinRegArc] = field(default_factory=list) # sorted by clock ID index
+
+    def set_clock(self):
+        self.flags |= 1
+
+    def finalise(self):
+        self.comb_arcs.sort(key=lambda a: a.from_pin)
+        self.reg_arcs.sort(key=lambda a: a.clock)
+
+    def serialise_lists(self, context: str, bba: BBAWriter):
+        bba.label(f"{context}_comb")
+        for i, a in enumerate(self.comb_arcs):
+            a.serialise(f"{context}_comb{i}", bba)
+        bba.label(f"{context}_reg")
+        for i, a in enumerate(self.reg_arcs):
+            a.serialise(f"{context}_reg{i}", bba)
+    def serialise(self, context: str, bba: BBAWriter):
+        bba.u32(self.pin.index) # pin idstring
+        bba.u32(self.flags)
+        bba.slice(f"{context}_comb", len(self.comb_arcs))
+        bba.slice(f"{context}_reg", len(self.reg_arcs))
+
+class CellTiming(BBAStruct):
+    def __init__(self, strs: StringPool, type_variant: str):
+        self.strs = strs
+        self.type_variant = strs.id(type_variant)
+        self.pin_data = {}
+
+    # combinational timing through a cell (like a LUT delay)
+    def add_comb_arc(self, from_pin: str, to_pin: str, delay: TimingValue):
+        if to_pin not in self.pin_data:
+            self.pin_data[to_pin] = CellPinTiming(pin=self.strs.id(to_pin))
+        self.pin_data[to_pin].comb_arcs.append(CellPinCombArc(from_pin=self.strs.id(from_pin), delay=delay))
+
+    # register input style timing (like a DFF input)
+    def add_setup_hold(self, clock: str, input_pin: str, edge: ClockEdge, setup: TimingValue, hold: TimingValue):
+        if input_pin not in self.pin_data:
+            self.pin_data[input_pin] = CellPinTiming(pin=self.strs.id(input_pin))
+        if clock not in self.pin_data:
+            self.pin_data[clock] = CellPinTiming(pin=self.strs.id(clock))
+        self.pin_data[input_pin].reg_arcs.append(CellPinRegArc(clock=self.strs.id(clock), edge=edge, setup=setup, hold=hold))
+        self.pin_data[clock].set_clock()
+
+    # register output style timing (like a DFF output)
+    def add_clock_out(self, clock: str, output_pin: str, edge: ClockEdge, delay: TimingValue):
+        if output_pin not in self.pin_data:
+            self.pin_data[output_pin] = CellPinTiming(pin=self.strs.id(output_pin))
+        if clock not in self.pin_data:
+            self.pin_data[clock] = CellPinTiming(pin=self.strs.id(clock))
+        self.pin_data[output_pin].reg_arcs.append(CellPinRegArc(clock=self.strs.id(clock), edge=edge, clk_q=delay))
+        self.pin_data[clock].set_clock()
+
+    def finalise(self):
+        self.pins = list(self.pin_data.values())
+        self.pins.sort(key=lambda p: p.pin)
+        for pin in self.pins:
+            pin.finalise()
+
+    def serialise_lists(self, context: str, bba: BBAWriter):
+        for i, p in enumerate(self.pins):
+            p.serialise_lists(f"{context}_pin{i}", bba)
+        bba.label(f"{context}_pins")
+        for i, p in enumerate(self.pins):
+            p.serialise(f"{context}_pin{i}", bba)
+    def serialise(self, context: str, bba: BBAWriter):
+        bba.u32(self.type_variant.index) # type idstring
+        bba.slice(f"{context}_pins", len(self.pins))
+
+@dataclass
+class SpeedGrade(BBAStruct):
+    name: int
+    pip_classes: list[PipTiming|None] = field(default_factory=list)
+    node_classes: list[NodeTiming|None] = field(default_factory=list)
+    cell_types: list[CellTiming] = field(default_factory=list) # sorted by (cell_type, variant) ID tuple
+
+    def finalise(self):
+        self.cell_types.sort(key=lambda ty: ty.type_variant)
+        for ty in self.cell_types:
+            ty.finalise()
+
+    def serialise_lists(self, context: str, bba: BBAWriter):
+        for i, t in enumerate(self.cell_types):
+            t.serialise_lists(f"{context}_cellty{i}", bba)
+        bba.label(f"{context}_pip_classes")
+        for i, p in enumerate(self.pip_classes):
+            p.serialise(f"{context}_pipc{i}", bba)
+        bba.label(f"{context}_node_classes")
+        for i, n in enumerate(self.node_classes):
+            n.serialise(f"{context}_nodec{i}", bba)
+        bba.label(f"{context}_cell_types")
+        for i, t in enumerate(self.cell_types):
+            t.serialise(f"{context}_cellty{i}", bba)
+    def serialise(self, context: str, bba: BBAWriter):
+        bba.u32(self.name.index) # speed grade idstring
+        bba.slice(f"{context}_pip_classes", len(self.pip_classes))
+        bba.slice(f"{context}_node_classes", len(self.node_classes))
+        bba.slice(f"{context}_cell_types", len(self.cell_types))
+
+class TimingPool(BBAStruct):
+    def __init__(self, strs: StringPool):
+        self.strs = strs
+        self.speed_grades = []
+        self.speed_grade_idx = {}
+        self.pip_classes = {}
+        self.node_classes = {}
+
+    def set_speed_grades(self, speed_grades: list):
+        assert len(self.speed_grades) == 0
+        self.speed_grades = [SpeedGrade(name=self.strs.id(g)) for g in speed_grades]
+        self.speed_grade_idx = {g: i for i, g in enumerate(speed_grades)}
+
+    def pip_class_idx(self, name: str):
+        if name == "":
+            return -1
+        elif name in self.pip_classes:
+            return self.pip_classes[name]
+        else:
+            idx = len(self.pip_classes)
+            self.pip_classes[name] = idx
+            return idx
+
+    def node_class_idx(self, name: str):
+        if name == "":
+            return -1
+        elif name in self.node_classes:
+            return self.node_classes[name]
+        else:
+            idx = len(self.node_classes)
+            self.node_classes[name] = idx
+            return idx
+
+    def set_pip_class(self, grade: str, name: str, delay: TimingValue,
+            in_cap: Optional[TimingValue]=None, out_res: Optional[TimingValue]=None,
+            is_buffered=True):
+        idx = self.pip_class_idx(name)
+        sg = self.speed_grades[self.speed_grade_idx[grade]]
+        if idx >= len(sg.pip_classes):
+            sg.pip_classes += [None for i in range(1 + idx - len(sg.pip_classes))]
+        assert sg.pip_classes[idx] is None, f"attempting to set pip class {name} in speed grade {grade} twice"
+        sg.pip_classes[idx] = PipTiming(int_delay=delay, in_cap=in_cap, out_res=out_res, flags=(1 if is_buffered else 0))
+
+    def set_bel_pin_class(self, grade: str, name: str, delay: TimingValue,
+            in_cap: Optional[TimingValue]=None, out_res: Optional[TimingValue]=None):
+        # bel pin classes are shared with pip classes, but this alias adds a bit of extra clarity
+        set_pip_class(self, grade, name, delay, in_cap, out_res, is_buffered=True)
+
+    def set_node_class(self, grade: str, name: str,  delay: TimingValue,
+            res: Optional[TimingValue]=None, cap: Optional[TimingValue]=None):
+        idx = self.node_class_idx(name)
+        sg = self.speed_grades[self.speed_grade_idx[grade]]
+        if idx >= len(sg.node_classes):
+            sg.node_classes += [None for i in range(1 + idx - len(sg.node_classes))]
+        assert sg.node_classes[idx] is None, f"attempting to set node class {name} in speed grade {grade} twice"
+        sg.node_classes[idx] = NodeTiming(delay=delay, res=res, cap=cap)
+
+    def add_cell_variant(self, speed_grade: str, name: str):
+        cell = CellTiming(self.strs, name)
+        self.speed_grades[self.speed_grade_idx[speed_grade]].cell_types.append(cell)
+        return cell
+
+    def finalise(self):
+        for sg in self.speed_grades:
+            sg.finalise()
+
 class Chip:
     def __init__(self, uarch: str, name: str, width: int, height: int):
         self.strs = StringPool()
@@ -446,8 +693,9 @@ class Chip:
         self.tile_shapes_idx = dict()
         self.packages = []
         self.extra_data = None
+        self.timing = TimingPool(self.strs)
     def create_tile_type(self, name: str):
-        tt = TileType(self.strs, self.strs.id(name))
+        tt = TileType(self.strs, self.timing, self.strs.id(name))
         self.tile_type_idx[name] = len(self.tile_types)
         self.tile_types.append(tt)
         return tt
@@ -456,6 +704,9 @@ class Chip:
     def tile_type_at(self, x: int, y: int):
         assert self.tiles[y][x].type_idx is not None, f"tile type at ({x}, {y}) must be set"
         return self.tile_types[self.tiles[y][x].type_idx]
+    def set_speed_grades(self, speed_grades: list):
+        self.timing.set_speed_grades(speed_grades)
+        return self.timing
     def add_node(self, wires: list[NodeWire]):
         # add a node - joining between multiple tile wires into a single connection (from nextpnr's point of view)
         # all the tile wires must exist, and the tile types must be set, first
@@ -529,7 +780,8 @@ class Chip:
         for y, row in enumerate(self.tiles):
             for x, tinst in enumerate(row):
                 tinst.serialise_lists(f"tinst_{x}_{y}", bba)
-
+        for i, sg in enumerate(self.timing.speed_grades):
+            sg.serialise_lists(f"sg{i}", bba)
         self.strs.serialise_lists(f"constids", bba)
         if self.extra_data is not None:
             self.extra_data.serialise_lists("extra_data", bba)
@@ -552,7 +804,9 @@ class Chip:
         for y, row in enumerate(self.tiles):
             for x, tinst in enumerate(row):
                 tinst.serialise(f"tinst_{x}_{y}", bba)
-
+        bba.label(f"speed_grades")
+        for i, sg in enumerate(self.timing.speed_grades):
+            sg.serialise(f"sg{i}", bba)
         bba.label(f"constids")
         self.strs.serialise(f"constids", bba)
 
@@ -573,8 +827,7 @@ class Chip:
         # packages
         bba.slice("packages", len(self.packages))
         # speed grades: not yet used
-        bba.u32(0)
-        bba.u32(0)
+        bba.slice("speed_grades", len(self.timing.speed_grades))
         # db-defined constids
         bba.ref("constids")
         # extra data
@@ -584,6 +837,7 @@ class Chip:
             bba.u32(0)
 
     def write_bba(self, filename):
+        self.timing.finalise()
         with open(filename, "w") as f:
             bba = BBAWriter(f)
             bba.pre('#include \"nextpnr.h\"')

--- a/himbaechel/main.cc
+++ b/himbaechel/main.cc
@@ -49,6 +49,7 @@ po::options_description HimbaechelCommandHandler::getArchOptions()
     po::options_description specific("Architecture specific options");
     specific.add_options()("uarch", po::value<std::string>(), uarch_help.c_str());
     specific.add_options()("chipdb", po::value<std::string>(), "path to chip database file");
+    specific.add_options()("speed", po::value<std::string>(), "device speed grade");
     specific.add_options()("vopt,o", po::value<std::vector<std::string>>(), "options to pass to the himbächel uarch");
 
     return specific;
@@ -70,6 +71,8 @@ std::unique_ptr<Context> HimbaechelCommandHandler::createContext(dict<std::strin
         log_error("chip database path must be specified.\n");
     chipArgs.uarch = vm["uarch"].as<std::string>();
     chipArgs.chipdb = vm["chipdb"].as<std::string>();
+    if (vm.count("speed"))
+        chipArgs.speed = vm["speed"].as<std::string>();
     if (vm.count("vopt")) {
         std::vector<std::string> options = vm["vopt"].as<std::vector<std::string>>();
         for (const auto &opt : options) {


### PR DESCRIPTION
This currently WIP and will probably end up landing after #1184.

Remaining issues are adding support for setting node/wire timings in the Python API as well as pip timings; and adding more examples of how this structure could be used to implement different timing models - like configurable cell types, and the spectrum from simple fixed pip delays to fanout-dependent delays (without RC data) to a full RC model.

The RC model implementation is also currently incomplete, but should be good enough for a context where most of the delays are on the pips and it's used to implement a small fanout penalty.