### PR TITLE
gowin: Himbaechel. Extend clock router

### DIFF
--- a/himbaechel/uarch/gowin/constids.inc
+++ b/himbaechel/uarch/gowin/constids.inc
@@ -1097,3 +1097,7 @@ X(HCLK_OUT1)
 X(HCLK_OUT2)
 X(HCLK_OUT3)
 
+// BUFG, clock buffers stuff
+X(BUFG)
+X(CLOCK)
+

--- a/himbaechel/uarch/gowin/cst.cc
+++ b/himbaechel/uarch/gowin/cst.cc
@@ -129,8 +129,16 @@ struct GowinCstReader
                         log_info("Can't use the long wires. The %s network will use normal routing.\n", net.c_str(ctx));
                         //}
                     } else {
-                        log_info("BUFG isn't supported\n");
-                        continue;
+                        auto ni = ctx->nets.find(net);
+                        if (ni == ctx->nets.end()) {
+                            log_info("Net %s not found\n", net.c_str(ctx));
+                            continue;
+                        }
+                        if (ctx->debug) {
+                            log_info("Mark net '%s' as CLOCK\n", net.c_str(ctx));
+                        }
+                        // XXX YES for now. May be put the number here
+                        ni->second->attrs[id_CLOCK] = Property(std::string("YES"));
                     }
                 } break;
                 case ioloc: { // IO_LOC name pin

--- a/himbaechel/uarch/gowin/gowin.h
+++ b/himbaechel/uarch/gowin/gowin.h
@@ -88,6 +88,8 @@ enum
     IDES16_Z = 72,
     OSER16_Z = 73,
 
+    BUFG_Z = 74, // : 81 reserve just in case
+
     OSC_Z = 274,
     PLL_Z = 275,
     GSR_Z = 276,

--- a/himbaechel/uarch/gowin/gowin_arch_gen.py
+++ b/himbaechel/uarch/gowin/gowin_arch_gen.py
@@ -32,6 +32,8 @@ IOLOGICA_Z = 70
 IDES16_Z   = 72
 OSER16_Z   = 73
 
+BUFG_Z  = 74 # : 81 reserve just in case
+
 OSC_Z   = 274
 PLL_Z   = 275
 GSR_Z   = 276
@@ -291,6 +293,18 @@ def create_extra_funcs(tt: TileType, db: chipdb, x: int, y: int):
                         tt.add_bel_pin(bel, port, wire, PinType.OUTPUT)
                     else:
                         tt.add_bel_pin(bel, port, wire, PinType.INPUT)
+        if func == 'buf':
+            for buf_type, wires in desc.items():
+                for i, wire in enumerate(wires):
+                    if not tt.has_wire(wire):
+                        tt.create_wire(wire, "TILE_CLK")
+                    wire_out = f'{buf_type}{i}_O'
+                    tt.create_wire(wire_out, "TILE_CLK")
+                    # XXX make Z from buf_type
+                    bel = tt.create_bel(f'{buf_type}{i}', buf_type, z = BUFG_Z + i)
+                    bel.flags = BEL_FLAG_GLOBAL
+                    tt.add_bel_pin(bel, "I", wire, PinType.INPUT)
+                    tt.add_bel_pin(bel, "O", wire_out, PinType.OUTPUT)
 
 def create_tiletype(create_func, chip: Chip, db: chipdb, x: int, y: int, ttyp: int):
     has_extra_func = (y, x) in db.extra_func

--- a/himbaechel/uarch/gowin/pack.cc
+++ b/himbaechel/uarch/gowin/pack.cc
@@ -1347,9 +1347,7 @@ struct GowinPacker
             ctx->createCell(buf_name, id_BUFG);
             CellInfo *buf_ci = ctx->cells.at(buf_name).get();
             buf_ci->addInput(id_I);
-            auto s_net = std::make_unique<NetInfo>(ctx->idf("$PACKER_BUF_%s", net.first.c_str(ctx)));
-            NetInfo *buf_ni = s_net.get();
-            ctx->nets[s_net->name] = std::move(s_net);
+            NetInfo *buf_ni = ctx->createNet(ctx->idf("$PACKER_BUF_%s", net.first.c_str(ctx)));
 
             if (ctx->verbose) {
                 log_info("Create buf '%s' with IN net '%s'\n", buf_name.c_str(ctx), buf_ni->name.c_str(ctx));


### PR DESCRIPTION
Now the clock router can place a buffer into the specified network, which divides the network into two parts: from the source to the buffer, routing occurs through any available PIPs, and after the buffer to the sink, only through a dedicated global clock network.

This is made specifically for the Tangnano20k where the external oscillator is soldered to a regular non-clock pin. But it can be used for other purposes, you just need to remember that the recipient must be a CLK input or output pin.

The port/network to set the buffer to is specified in the .CST file:

CLOCK_LOC "name" BUFG;