### PR TITLE
himbaechel: Add discovery of uarch and chipdb

### DIFF
--- a/.github/ci/build_himbaechel.sh
+++ b/.github/ci/build_himbaechel.sh
@@ -12,7 +12,8 @@ function build_nextpnr {
     # We'd ideally use pypy3 for speed (as works locally), but the version
     # our CI Ubuntu provides doesn't like some of the typing stuff
     python3 ../himbaechel/uarch/example/example_arch_gen.py ./example.bba
-    ./bba/bbasm --l ./example.bba ./example.bin
+    mkdir -p share/himbaechel/example
+    ./bba/bbasm --l ./example.bba share/himbaechel/example/example.bin
     popd
 }
 
@@ -22,6 +23,6 @@ function run_tests {
 
 function run_archcheck {
     pushd build
-    ./nextpnr-himbaechel --uarch example --chipdb ./example.bin --test
+    ./nextpnr-himbaechel --device EXAMPLE --test
     popd
 }

--- a/common/kernel/command.h
+++ b/common/kernel/command.h
@@ -69,6 +69,12 @@ class CommandHandler
     std::ofstream logfile;
 };
 
+// Relative directory functions from Yosys
+bool check_file_exists(std::string filename, bool is_exec);
+void init_share_dirname();
+std::string proc_self_dirname();
+std::string proc_share_dirname();
+
 NEXTPNR_NAMESPACE_END
 
 #endif // COMMAND_H

--- a/himbaechel/arch.h
+++ b/himbaechel/arch.h
@@ -386,9 +386,8 @@ struct BelPinRange
 struct ArchArgs
 {
     std::string uarch;
-    std::string chipdb;
+    std::string chipdb_override;
     std::string device;
-    std::string speed;
     dict<std::string, std::string> options;
 };
 
@@ -420,6 +419,9 @@ struct Arch : BaseArch<ArchRanges>
     ArchArgs args;
     Arch(ArchArgs args);
     ~Arch(){};
+
+    void load_chipdb(const std::string &path);
+    void set_speed_grade(const std::string &speed);
 
     void late_init();
 

--- a/himbaechel/arch_pybindings.cc
+++ b/himbaechel/arch_pybindings.cc
@@ -28,7 +28,7 @@ NEXTPNR_NAMESPACE_BEGIN
 void arch_wrap_python(py::module &m)
 {
     using namespace PythonConversion;
-    py::class_<ArchArgs>(m, "ArchArgs").def_readwrite("chipdb", &ArchArgs::chipdb);
+    py::class_<ArchArgs>(m, "ArchArgs").def_readwrite("device", &ArchArgs::device);
 
     py::class_<BelId>(m, "BelId").def_readwrite("index", &BelId::index);
 

--- a/himbaechel/himbaechel_api.cc
+++ b/himbaechel/himbaechel_api.cc
@@ -25,8 +25,6 @@ NEXTPNR_NAMESPACE_BEGIN
 
 void HimbaechelAPI::init(Context *ctx) { this->ctx = ctx; }
 
-void HimbaechelAPI::init_constids(Arch *arch) {}
-
 std::vector<IdString> HimbaechelAPI::getCellTypes() const
 {
     std::vector<IdString> result;
@@ -89,17 +87,17 @@ std::string HimbaechelArch::list()
     }
     return result;
 }
-std::unique_ptr<HimbaechelAPI> HimbaechelArch::create(const std::string &name,
-                                                      const dict<std::string, std::string> &args)
+
+HimbaechelArch *HimbaechelArch::find_match(const std::string &device)
 {
     HimbaechelArch *cursor = HimbaechelArch::list_head;
     while (cursor) {
-        if (cursor->name != name) {
+        if (!cursor->match_device(device)) {
             cursor = cursor->list_next;
             continue;
         }
-        return cursor->create(args);
+        return cursor;
     }
-    return {};
+    return nullptr;
 }
 NEXTPNR_NAMESPACE_END

--- a/himbaechel/himbaechel_api.h
+++ b/himbaechel/himbaechel_api.h
@@ -58,8 +58,9 @@ struct PlacerHeapCfg;
 struct HimbaechelAPI
 {
     virtual void init(Context *ctx);
-    // If constids are being used, this is used to set them up early before loading the db blob
-    virtual void init_constids(Arch *arch);
+    // If constids are being used, this is used to set them up early
+    // then it is responsible for loading the db blob with arch->load_chipdb()
+    virtual void init_database(Arch *arch) = 0;
     Context *ctx;
     bool with_gui = false;
 
@@ -116,10 +117,12 @@ struct HimbaechelArch
     std::string name;
     HimbaechelArch(const std::string &name);
     ~HimbaechelArch(){};
-    virtual std::unique_ptr<HimbaechelAPI> create(const dict<std::string, std::string> &args) = 0;
+    virtual bool match_device(const std::string &device) = 0;
+    virtual std::unique_ptr<HimbaechelAPI> create(const std::string &device,
+                                                  const dict<std::string, std::string> &args) = 0;
 
     static std::string list();
-    static std::unique_ptr<HimbaechelAPI> create(const std::string &name, const dict<std::string, std::string> &args);
+    static HimbaechelArch *find_match(const std::string &device);
 };
 
 NEXTPNR_NAMESPACE_END

--- a/himbaechel/uarch/example/example.cc
+++ b/himbaechel/uarch/example/example.cc
@@ -37,7 +37,13 @@ struct ExampleImpl : HimbaechelAPI
     static constexpr int K = 4;
 
     ~ExampleImpl(){};
-    void init_constids(Arch *arch) override { init_uarch_constids(arch); }
+    void init_database(Arch *arch) override
+    {
+        init_uarch_constids(arch);
+        arch->load_chipdb("example/example.bin");
+        arch->set_speed_grade("DEFAULT");
+    }
+
     void init(Context *ctx) override
     {
         h.init(ctx);
@@ -134,7 +140,8 @@ struct ExampleImpl : HimbaechelAPI
 struct ExampleArch : HimbaechelArch
 {
     ExampleArch() : HimbaechelArch("example"){};
-    std::unique_ptr<HimbaechelAPI> create(const dict<std::string, std::string> &args)
+    bool match_device(const std::string &device) override { return device == "EXAMPLE"; }
+    std::unique_ptr<HimbaechelAPI> create(const std::string &device, const dict<std::string, std::string> &args)
     {
         return std::make_unique<ExampleImpl>();
     }

--- a/himbaechel/uarch/gowin/CMakeLists.txt
+++ b/himbaechel/uarch/gowin/CMakeLists.txt
@@ -25,14 +25,14 @@ else()
 endif()
 
 set(chipdb_binaries)
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/chipdb)
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/share/himbaechel/gowin)
 foreach(device ${HIMBAECHEL_GOWIN_DEVICES})
     if(NOT device IN_LIST ALL_HIMBAECHEL_GOWIN_DEVICES)
 		message(FATAL_ERROR "Device ${device} is not a supported Gowin device")
     endif()
 
-	set(device_bba chipdb/chipdb-${device}.bba)
-	set(device_bin chipdb/chipdb-${device}.bin)
+	set(device_bba ${CMAKE_BINARY_DIR}/share/himbaechel/gowin/chipdb-${device}.bba)
+	set(device_bin ${CMAKE_BINARY_DIR}/share/himbaechel/gowin/chipdb-${device}.bin)
 	add_custom_command(
 		OUTPUT ${device_bin}
 		COMMAND ${apycula_Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gowin_arch_gen.py -d ${device} -o ${device_bba}
@@ -48,5 +48,5 @@ foreach(device ${HIMBAECHEL_GOWIN_DEVICES})
 endforeach()
 
 add_custom_target(chipdb-himbaechel-gowin ALL DEPENDS ${chipdb_binaries})
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/chipdb/ DESTINATION share/nextpnr/himbaechel/gowin
+install(DIRECTORY ${CMAKE_BINARY_DIR}/share/himbaechel/gowin DESTINATION share/nextpnr/himbaechel/gowin
 	    PATTERN "*.bba" EXCLUDE)


### PR DESCRIPTION
This is a step to improve the user experience of himbächel by automatically determining the device and chipdb.

chipdb discovery uses the same binary-relative share directory finding code as Yosys, so should hopefully be pretty robust.

uarches must now provide a function to claim a device name, if they claim it they will be used for a given device. They must then call a function during initialisation to specify the chipdb path (although this can be overridden for debugging), how they determine chipdb name from device name and other arguments (e.g. family for gowin) is up to the uarch.

@yrabbit, I'd really appreciate any feedback and comments on how the Gowin side is looking, the code was mostly taken from the old Gowin arch but do say if you have feedback or suggestions for changing this mechanism.

Not included in this PR but still planned (and potentially a user-facing breaking change) is removing the existing "--vopt" mechanism and allowing arch-specific options to be specified more naturally as direct command line arguments.