### PR TITLE
TimingEngine: Fix argument order and slack histogram reporting

### DIFF
--- a/common/kernel/timing.cc
+++ b/common/kernel/timing.cc
@@ -45,11 +45,11 @@ void TimingAnalyser::setup(bool update_net_timings, bool update_histogram, bool 
     topo_sort();
     setup_port_domains();
     identify_related_domains();
-    run(update_net_timings, update_histogram, update_crit_paths, true);
+    run(true, update_net_timings, update_histogram, update_crit_paths);
 }
 
-void TimingAnalyser::run(bool update_net_timings, bool update_histogram, bool update_crit_paths,
-                         bool update_route_delays)
+void TimingAnalyser::run(bool update_route_delays, bool update_net_timings, bool update_histogram,
+                         bool update_crit_paths)
 {
     reset_times();
     if (update_route_delays)

--- a/common/kernel/timing.h
+++ b/common/kernel/timing.h
@@ -77,8 +77,8 @@ struct TimingAnalyser
     TimingAnalyser(Context *ctx);
 
     void setup(bool update_net_timings = false, bool update_histogram = false, bool update_crit_paths = false);
-    void run(bool update_net_timings = false, bool update_histogram = false, bool update_crit_paths = false,
-             bool update_route_delays = true);
+    void run(bool update_route_delays = true, bool update_net_timings = false, bool update_histogram = false,
+             bool update_crit_paths = false);
 
     // This is used when routers etc are not actually binding detailed routing (due to congestion or an abstracted
     // model), but want to re-run STA with their own calculated delays

--- a/common/kernel/timing_log.cc
+++ b/common/kernel/timing_log.cc
@@ -365,7 +365,7 @@ void Context::log_timing_results(TimingResult &result, bool print_histogram, boo
     if (print_fmax)
         log_fmax(this, result, warn_on_failure);
 
-    if (print_histogram && !timing_result.slack_histogram.empty())
+    if (print_histogram && !result.slack_histogram.empty())
         log_histogram(this, result);
 }
 


### PR DESCRIPTION
Fixes the bug @Ravenslofty reported in https://github.com/YosysHQ/nextpnr/pull/1183#issuecomment-1732692287

Also fixes missing slack histogram printing which I noticed while debugging this.

