### PR TITLE
kernel/timing: use std::numeric_limits::lowest() instead of min()

### DIFF
--- a/common/kernel/timing.cc
+++ b/common/kernel/timing.cc
@@ -770,7 +770,7 @@ void TimingAnalyser::build_detailed_net_timing_report()
 std::vector<CellPortKey> TimingAnalyser::get_worst_eps(domain_id_t domain_pair, int count)
 {
     std::vector<CellPortKey> worst_eps;
-    delay_t last_slack = std::numeric_limits<delay_t>::min();
+    delay_t last_slack = std::numeric_limits<delay_t>::lowest();
     auto &dp = domain_pairs.at(domain_pair);
     auto &cap_d = domains.at(dp.key.capture);
     while (int(worst_eps.size()) < count) {

--- a/common/route/router1.cc
+++ b/common/route/router1.cc
@@ -811,7 +811,7 @@ struct Router1
             for (auto &usr : ni->users) {
                 ++arc_count;
                 delay_t slack = tmg.get_setup_slack(CellPortKey(usr));
-                if (slack == std::numeric_limits<delay_t>::min())
+                if (slack == std::numeric_limits<delay_t>::lowest())
                     continue;
                 if (slack < default_thresh)
                     ++failed_count;
@@ -829,7 +829,7 @@ struct Router1
                 continue;
             for (auto &usr : ni->users) {
                 delay_t slack = tmg.get_setup_slack(CellPortKey(usr));
-                if (slack == std::numeric_limits<delay_t>::min())
+                if (slack == std::numeric_limits<delay_t>::lowest())
                     continue;
                 slacks.push_back(slack);
             }
@@ -941,7 +941,7 @@ bool router1(Context *ctx, const Router1Cfg &cfg)
                         continue;
                     for (auto &usr : ni->users) {
                         delay_t slack = router.tmg.get_setup_slack(CellPortKey(usr));
-                        if (slack == std::numeric_limits<delay_t>::min())
+                        if (slack == std::numeric_limits<delay_t>::lowest())
                             continue;
                         if (slack < 0) {
                             wns = std::min(wns, slack);

--- a/fpga_interchange/cost_map.cc
+++ b/fpga_interchange/cost_map.cc
@@ -318,7 +318,7 @@ void CostMap::fill_holes(const Context *ctx, const TypeWirePair &type_pair, boos
 delay_t CostMap::get_penalty(const boost::multi_array<delay_t, 2> &matrix) const
 {
     delay_t min_delay = std::numeric_limits<delay_t>::max();
-    delay_t max_delay = std::numeric_limits<delay_t>::min();
+    delay_t max_delay = std::numeric_limits<delay_t>::lowest();
 
     std::pair<int32_t, int32_t> min_location(0, 0), max_location(0, 0);
     for (unsigned ix = 0; ix < matrix.shape()[0]; ix++) {


### PR DESCRIPTION
`std::numeric_limits<delay_t>::min()` returns the smallest number larger then 0 for `float` which broke the worst endpoint search for timing reporting for any arch that uses `delay_t = float` or ``delay_t = double`` 

I have found some other suspect spots in the code. @gatecat please go over them whether they are correct. (I'm commenting these in a new comment)
