### PR TITLE
archapi: Add new API for global constant routing

### DIFF
--- a/common/kernel/arch_api.h
+++ b/common/kernel/arch_api.h
@@ -83,6 +83,7 @@ template <typename R> struct ArchAPI : BaseCtx
     virtual WireId getConflictingWireWire(WireId wire) const = 0;
     virtual NetInfo *getConflictingWireNet(WireId wire) const = 0;
     virtual DelayQuad getWireDelay(WireId wire) const = 0;
+    virtual IdString getWireConstantValue(WireId wire) const = 0;
     // Pip methods
     virtual typename R::AllPipsRangeT getPips() const = 0;
     virtual PipId getPipByName(IdStringList name) const = 0;

--- a/common/kernel/base_arch.h
+++ b/common/kernel/base_arch.h
@@ -237,6 +237,7 @@ template <typename R> struct BaseArch : ArchAPI<R>
     }
     virtual WireId getConflictingWireWire(WireId wire) const override { return wire; };
     virtual NetInfo *getConflictingWireNet(WireId wire) const override { return getBoundWireNet(wire); }
+    virtual IdString getWireConstantValue(WireId wire) const override { return {}; }
 
     // Pip methods
     virtual IdString getPipType(PipId pip) const override { return IdString(); }

--- a/common/kernel/nextpnr_types.h
+++ b/common/kernel/nextpnr_types.h
@@ -132,6 +132,10 @@ struct NetInfo : ArchNetInfo
     indexed_store<PortRef> users;
     dict<IdString, Property> attrs;
 
+    // If this is set to a non-empty ID, then the driver is ignored and it will be routed from any wire with a matching
+    // getWireConstantValue
+    IdString constant_value;
+
     // wire -> uphill_pip
     dict<WireId, PipMap> wires;
 

--- a/common/route/router2.cc
+++ b/common/route/router2.cc
@@ -346,7 +346,8 @@ struct Router2
             return;
         WireId src = nets.at(net->udata).src_wire;
         WireId cursor = ad.sink_wire;
-        while (cursor != src) {
+        while (cursor != src &&
+               (net->constant_value == IdString() || ctx->getWireConstantValue(cursor) == net->constant_value)) {
             PipId pip = nd.wires.at(cursor).first;
             unbind_pip_internal(nd, user, cursor);
             cursor = ctx->getPipSrcWire(pip);
@@ -533,18 +534,11 @@ struct Router2
 
     // These nets have very-high-fanout pips and special rules must be followed (only working backwards) to avoid
     // crippling perf
-    bool is_pseudo_const_net(const NetInfo *net)
-    {
-#ifdef ARCH_NEXUS
-        if (net->driver.cell != nullptr && net->driver.cell->type == id_VCC_DRV)
-            return true;
-#endif
-        return false;
-    }
+    bool is_dedi_const_net(const NetInfo *net) { return net->constant_value != IdString(); }
 
     void update_wire_by_loc(ThreadContext &t, NetInfo *net, store_index<PortRef> i, size_t phys_pin, bool is_mt)
     {
-        if (is_pseudo_const_net(net))
+        if (is_dedi_const_net(net))
             return;
         auto &nd = nets.at(net->udata);
         auto &ad = nd.arcs.at(i.idx()).at(phys_pin);
@@ -613,16 +607,17 @@ struct Router2
         auto &nd = nets[net->udata];
         auto &ad = nd.arcs.at(i.idx()).at(phys_pin);
         auto &usr = net->users.at(i);
+        bool const_mode = is_dedi_const_net(net);
         ROUTE_LOG_DBG("Routing arc %d of net '%s' (%d, %d) -> (%d, %d)\n", i.idx(), ctx->nameOf(net), ad.bb.x0,
                       ad.bb.y0, ad.bb.x1, ad.bb.y1);
         WireId src_wire = ctx->getNetinfoSourceWire(net), dst_wire = ctx->getNetinfoSinkWire(net, usr, phys_pin);
-        if (src_wire == WireId())
+        if (src_wire == WireId() && !const_mode)
             ARC_LOG_ERR("No wire found for port %s on source cell %s.\n", ctx->nameOf(net->driver.port),
                         ctx->nameOf(net->driver.cell));
         if (dst_wire == WireId())
             ARC_LOG_ERR("No wire found for port %s on destination cell %s.\n", ctx->nameOf(usr.port),
                         ctx->nameOf(usr.cell));
-        int src_wire_idx = wire_to_idx.at(src_wire);
+        int src_wire_idx = const_mode ? -1 : wire_to_idx.at(src_wire);
         int dst_wire_idx = wire_to_idx.at(dst_wire);
         // Calculate a timing weight based on criticality
         float crit = get_arc_crit(net, i);
@@ -683,12 +678,13 @@ struct Router2
 
             if (mode == 0 && t.fwd_queue.size() < 4)
                 continue;
-
-            if (mode == 1 && !is_pseudo_const_net(net)) {
-                // Seed forwards with the source wire, if less than 8 existing wires added
-                seed_queue_fwd(src_wire);
-            } else {
-                set_visited_fwd(t, src_wire_idx, PipId(), 0.0);
+            if (!const_mode) {
+                if (mode == 1) {
+                    // Seed forwards with the source wire, if less than 8 existing wires added
+                    seed_queue_fwd(src_wire);
+                } else {
+                    set_visited_fwd(t, src_wire_idx, PipId(), 0.0);
+                }
             }
             auto seed_queue_bwd = [&](WireId wire) {
                 WireScore base_score;
@@ -711,7 +707,7 @@ struct Router2
                                 : (!t.fwd_queue.empty() || !t.bwd_queue.empty())) &&
                    (!is_bb || iter < toexplore)) {
                 ++iter;
-                if (!t.fwd_queue.empty()) {
+                if (!t.fwd_queue.empty() && !const_mode) {
                     // Explore forwards
                     auto curr = t.fwd_queue.top();
                     t.fwd_queue.pop();
@@ -760,12 +756,13 @@ struct Router2
                     auto curr = t.bwd_queue.top();
                     t.bwd_queue.pop();
                     ++explored;
-                    if (was_visited_fwd(curr.wire, std::numeric_limits<float>::max())) {
+                    auto &curr_data = flat_wires.at(curr.wire);
+                    if (was_visited_fwd(curr.wire, std::numeric_limits<float>::max()) ||
+                        (const_mode && ctx->getWireConstantValue(curr_data.w) == net->constant_value)) {
                         // Meet in the middle; done
                         midpoint_wire = curr.wire;
                         break;
                     }
-                    auto &curr_data = flat_wires.at(curr.wire);
                     // Don't allow the same wire to be bound to the same net with a different driving pip
                     PipId bound_pip;
                     auto fnd_wire = nd.wires.find(curr_data.w);
@@ -809,44 +806,48 @@ struct Router2
         ArcRouteResult result = ARC_SUCCESS;
         if (midpoint_wire != -1) {
             ROUTE_LOG_DBG("   Routed (explored %d wires): ", explored);
-            int cursor_bwd = midpoint_wire;
-            while (was_visited_fwd(cursor_bwd, std::numeric_limits<float>::max())) {
-                PipId pip = flat_wires.at(cursor_bwd).pip_fwd;
-                if (pip == PipId() && cursor_bwd != src_wire_idx)
-                    break;
-                bind_pip_internal(nd, i, cursor_bwd, pip);
-                if (ctx->debug && !is_mt) {
-                    auto &wd = flat_wires.at(cursor_bwd);
-                    ROUTE_LOG_DBG("      fwd wire: %s (curr %d hist %f share %d)\n", ctx->nameOfWire(wd.w),
-                                  wd.curr_cong - 1, wd.hist_cong_cost, nd.wires.at(wd.w).second);
+            if (const_mode) {
+                bind_pip_internal(nd, i, midpoint_wire, PipId());
+            } else {
+                int cursor_bwd = midpoint_wire;
+                while (was_visited_fwd(cursor_bwd, std::numeric_limits<float>::max())) {
+                    PipId pip = flat_wires.at(cursor_bwd).pip_fwd;
+                    if (pip == PipId() && cursor_bwd != src_wire_idx)
+                        break;
+                    bind_pip_internal(nd, i, cursor_bwd, pip);
+                    if (ctx->debug && !is_mt) {
+                        auto &wd = flat_wires.at(cursor_bwd);
+                        ROUTE_LOG_DBG("      fwd wire: %s (curr %d hist %f share %d)\n", ctx->nameOfWire(wd.w),
+                                      wd.curr_cong - 1, wd.hist_cong_cost, nd.wires.at(wd.w).second);
+                    }
+                    if (pip == PipId()) {
+                        break;
+                    }
+                    ROUTE_LOG_DBG("         fwd pip: %s (%d, %d)\n", ctx->nameOfPip(pip), ctx->getPipLocation(pip).x,
+                                  ctx->getPipLocation(pip).y);
+                    cursor_bwd = wire_to_idx.at(ctx->getPipSrcWire(pip));
                 }
-                if (pip == PipId()) {
-                    break;
-                }
-                ROUTE_LOG_DBG("         fwd pip: %s (%d, %d)\n", ctx->nameOfPip(pip), ctx->getPipLocation(pip).x,
-                              ctx->getPipLocation(pip).y);
-                cursor_bwd = wire_to_idx.at(ctx->getPipSrcWire(pip));
-            }
 
-            while (cursor_bwd != src_wire_idx) {
-                // Tack onto existing routing
-                WireId bwd_w = flat_wires.at(cursor_bwd).w;
-                if (!nd.wires.count(bwd_w))
-                    break;
-                auto &bound = nd.wires.at(bwd_w);
-                PipId pip = bound.first;
-                if (ctx->debug && !is_mt) {
-                    auto &wd = flat_wires.at(cursor_bwd);
-                    ROUTE_LOG_DBG("      ext wire: %s (curr %d hist %f share %d)\n", ctx->nameOfWire(wd.w),
-                                  wd.curr_cong - 1, wd.hist_cong_cost, bound.second);
+                while (cursor_bwd != src_wire_idx) {
+                    // Tack onto existing routing
+                    WireId bwd_w = flat_wires.at(cursor_bwd).w;
+                    if (!nd.wires.count(bwd_w))
+                        break;
+                    auto &bound = nd.wires.at(bwd_w);
+                    PipId pip = bound.first;
+                    if (ctx->debug && !is_mt) {
+                        auto &wd = flat_wires.at(cursor_bwd);
+                        ROUTE_LOG_DBG("      ext wire: %s (curr %d hist %f share %d)\n", ctx->nameOfWire(wd.w),
+                                      wd.curr_cong - 1, wd.hist_cong_cost, bound.second);
+                    }
+                    bind_pip_internal(nd, i, cursor_bwd, pip);
+                    if (pip == PipId())
+                        break;
+                    cursor_bwd = wire_to_idx.at(ctx->getPipSrcWire(pip));
                 }
-                bind_pip_internal(nd, i, cursor_bwd, pip);
-                if (pip == PipId())
-                    break;
-                cursor_bwd = wire_to_idx.at(ctx->getPipSrcWire(pip));
-            }
 
-            NPNR_ASSERT(cursor_bwd == src_wire_idx);
+                NPNR_ASSERT(cursor_bwd == src_wire_idx);
+            }
 
             int cursor_fwd = midpoint_wire;
             while (was_visited_bwd(cursor_fwd, std::numeric_limits<float>::max())) {
@@ -1029,7 +1030,7 @@ struct Router2
         auto &usr = net->users.at(usr_idx);
         WireId src = ctx->getNetinfoSourceWire(net);
         // Skip routes with no source
-        if (src == WireId())
+        if (src == WireId() && net->constant_value == IdString())
             return true;
         WireId dst = ctx->getNetinfoSinkWire(net, usr, phys_pin);
         if (dst == WireId())
@@ -1086,6 +1087,10 @@ struct Router2
                 break;
             }
             cursor = ctx->getPipSrcWire(p);
+            if (net->constant_value != IdString() && ctx->getWireConstantValue(cursor) == net->constant_value) {
+                src = cursor;
+                break;
+            }
         }
 
         if (success) {
@@ -1343,6 +1348,8 @@ struct Router2
     delay_t get_route_delay(int net, store_index<PortRef> usr_idx, int phys_idx)
     {
         auto &nd = nets.at(net);
+        if (nets_by_udata.at(net)->constant_value != IdString())
+            return 0;
         auto &ad = nd.arcs.at(usr_idx.idx()).at(phys_idx);
         WireId cursor = ad.sink_wire;
         if (cursor == WireId() || nd.src_wire == WireId())

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -340,6 +340,14 @@ chip. There may be significant performance impacts if routing regularly
 exceeds these bounds by more than a small margin; so an over-estimate
 of the bounds is almost always better than an under-estimate.
 
+### IdString getWireConstantValue() const
+
+If not an empty string, indicate this wire can be used to source nets
+with their `constant_value` equal to its return value.
+
+*BaseArch default: returns `IdString()`*
+
+
 Pip Methods
 -----------
 

--- a/himbaechel/arch.cc
+++ b/himbaechel/arch.cc
@@ -32,7 +32,7 @@
 
 NEXTPNR_NAMESPACE_BEGIN
 
-static constexpr int database_version = 2;
+static constexpr int database_version = 3;
 
 static const ChipInfoPOD *get_chip_info(const RelPtr<ChipInfoPOD> *ptr) { return ptr->get(); }
 

--- a/himbaechel/arch.h
+++ b/himbaechel/arch.h
@@ -488,6 +488,10 @@ struct Arch : BaseArch<ArchRanges>
     IdString getWireType(WireId wire) const override { return IdString(chip_wire_info(chip_info, wire).wire_type); }
     DelayQuad getWireDelay(WireId wire) const override { return DelayQuad(0); } // TODO
     BelPinRange getWireBelPins(WireId wire) const override { return BelPinRange(chip_info, get_tile_wire_range(wire)); }
+    IdString getWireConstantValue(WireId wire) const override
+    {
+        return IdString(chip_wire_info(chip_info, wire).const_value);
+    }
     WireRange getWires() const override { return WireRange(chip_info); }
     bool checkWireAvail(WireId wire) const override
     {

--- a/himbaechel/chipdb.h
+++ b/himbaechel/chipdb.h
@@ -62,6 +62,7 @@ NPNR_PACKED_STRUCT(struct BelPinRefPOD {
 NPNR_PACKED_STRUCT(struct TileWireDataPOD {
     int32_t name;
     int32_t wire_type;
+    int32_t const_value;
     int32_t flags;      // 32 bits of arbitrary data
     int32_t timing_idx; // used only when the wire is not part of a node, otherwise node idx applies
     RelSlice<int32_t> pips_uphill;

--- a/himbaechel/himbaechel_helpers.cc
+++ b/himbaechel/himbaechel_helpers.cc
@@ -98,7 +98,8 @@ int HimbaechelHelpers::constrain_cell_pairs(const pool<CellTypePort> &src_ports,
 
 void HimbaechelHelpers::replace_constants(CellTypePort vcc_driver, CellTypePort gnd_driver,
                                           const dict<IdString, Property> &vcc_params,
-                                          const dict<IdString, Property> &gnd_params)
+                                          const dict<IdString, Property> &gnd_params, IdString vcc_const_val,
+                                          IdString gnd_const_val)
 {
     CellInfo *vcc_drv = ctx->createCell(ctx->id("$PACKER_VCC_DRV"), vcc_driver.cell_type);
     vcc_drv->addOutput(vcc_driver.port);
@@ -112,6 +113,9 @@ void HimbaechelHelpers::replace_constants(CellTypePort vcc_driver, CellTypePort 
 
     NetInfo *vcc_net = ctx->createNet(ctx->id("$PACKER_VCC"));
     NetInfo *gnd_net = ctx->createNet(ctx->id("$PACKER_GND"));
+
+    vcc_net->constant_value = vcc_const_val;
+    gnd_net->constant_value = gnd_const_val;
 
     vcc_drv->connectPort(vcc_driver.port, vcc_net);
     gnd_drv->connectPort(gnd_driver.port, gnd_net);

--- a/himbaechel/himbaechel_helpers.h
+++ b/himbaechel/himbaechel_helpers.h
@@ -67,7 +67,8 @@ struct HimbaechelHelpers
     // Replace constants with given driving cells
     void replace_constants(CellTypePort vcc_driver, CellTypePort gnd_driver,
                            const dict<IdString, Property> &vcc_params = {},
-                           const dict<IdString, Property> &gnd_params = {});
+                           const dict<IdString, Property> &gnd_params = {}, IdString vcc_const_val = IdString(),
+                           IdString gnd_const_val = IdString());
 };
 
 NEXTPNR_NAMESPACE_END

--- a/himbaechel/uarch/example/blinky.v
+++ b/himbaechel/uarch/example/blinky.v
@@ -11,6 +11,6 @@ always @(posedge clk)
 	else
 		ctr <= ctr + 1'b1;
 
-assign leds = ctr;
+assign leds = {4'b1010, ctr[7:4]};
 
 endmodule

--- a/himbaechel/uarch/example/constids.inc
+++ b/himbaechel/uarch/example/constids.inc
@@ -12,3 +12,8 @@ X(O)
 X(IOB)
 X(PAD)
 X(INIT)
+
+X(GND)
+X(GND_DRV)
+X(VCC)
+X(VCC_DRV)

--- a/himbaechel/uarch/example/example.cc
+++ b/himbaechel/uarch/example/example.cc
@@ -63,7 +63,7 @@ struct ExampleImpl : HimbaechelAPI
         // Replace constants with LUTs
         const dict<IdString, Property> vcc_params = {{id_INIT, Property(0xFFFF, 16)}};
         const dict<IdString, Property> gnd_params = {{id_INIT, Property(0x0000, 16)}};
-        h.replace_constants(CellTypePort(id_LUT4, id_F), CellTypePort(id_LUT4, id_F), vcc_params, gnd_params);
+        h.replace_constants(CellTypePort(id_VCC_DRV, id_VCC), CellTypePort(id_GND_DRV, id_GND), {}, {}, id_VCC, id_GND);
         // Constrain directly connected LUTs and FFs together to use dedicated resources
         int lutffs = h.constrain_cell_pairs(pool<CellTypePort>{{id_LUT4, id_F}}, pool<CellTypePort>{{id_DFF, id_D}}, 1);
         log_info("Constrained %d LUTFF pairs.\n", lutffs);

--- a/himbaechel/uarch/example/example_arch_gen.py
+++ b/himbaechel/uarch/example/example_arch_gen.py
@@ -30,6 +30,9 @@ dirs = [ # name, dx, dy
 
 def create_switch_matrix(tt: TileType, inputs: list[str], outputs: list[str]):
     # FIXME: terrible routing matrix, just for a toy example...
+    # constant wires
+    tt.create_wire("GND", "GND", const_value="GND")
+    tt.create_wire("VCC", "VCC", const_value="VCC")
     # switch wires
     for i in range(Wl):
         tt.create_wire(f"SWITCH{i}", "SWITCH")
@@ -45,6 +48,10 @@ def create_switch_matrix(tt: TileType, inputs: list[str], outputs: list[str]):
     for i, w in enumerate(outputs):
         for j in range((i % Sq), Wl, Sq):
             tt.create_pip(w, f"SWITCH{j}", timing_class="SWINPUT")
+    # constant pips
+    for i in range(Wl):
+        tt.create_pip("GND", f"SWITCH{i}")
+        tt.create_pip("VCC", f"SWITCH{i}")
     # neighbour local pips
     for i in range(Wl):
         for j, (d, dx, dy) in enumerate(dirs):
@@ -147,6 +154,15 @@ def create_corner_tiletype(ch):
     tt.create_wire(f"CLK", "TILE_CLK")
     tt.create_wire(f"CLK_PREV", "CLK_ROUTE")
     tt.create_pip(f"CLK_PREV", f"CLK")
+
+    tt.create_wire(f"GND", "GND", const_value="GND")
+    tt.create_wire(f"VCC", "VCC", const_value="VCC")
+
+    gnd = tt.create_bel(f"GND_DRV", f"GND_DRV", z=0)
+    tt.add_bel_pin(gnd, "GND", "GND", PinType.OUTPUT)
+    vcc = tt.create_bel(f"VCC_DRV", f"VCC_DRV", z=1)
+    tt.add_bel_pin(vcc, "VCC", "VCC", PinType.OUTPUT)
+
     return tt
 
 def is_corner(x, y):

--- a/nexus/arch.h
+++ b/nexus/arch.h
@@ -1170,6 +1170,13 @@ struct Arch : BaseArch<ArchRanges>
     virtual bool checkWireAvail(WireId wire) const override { return getBoundWireNet(wire) == nullptr; }
     NetInfo *getBoundWireNet(WireId wire) const override { return tileStatus.at(wire.tile).boundwires.at(wire.index); }
 
+    IdString getWireConstantValue(WireId wire) const override
+    {
+        if (chip_wire_data(db, chip_info, wire).name == ID_LOCAL_VCC)
+            return id_VCC_DRV;
+        else
+            return {};
+    }
     // -------------------------------------------------
 
     PipId getPipByName(IdStringList name) const override;

--- a/nexus/pack.cc
+++ b/nexus/pack.cc
@@ -325,6 +325,8 @@ struct NexusPacker
         CellInfo *new_cell = ctx->createCell(ctx->idf("$CONST_%s_DRV_", type.c_str(ctx)), type);
         new_cell->addOutput(id_Z);
         new_cell->connectPort(id_Z, new_net);
+        if (type == id_VCC_DRV)
+            new_net->constant_value = id_VCC_DRV;
         return new_net;
     }
 


### PR DESCRIPTION
High-fanout dedicated global constant routing has been a weak spot in nextpnr, and a previous complexity in e.g. Xilinx support, where it necessitated complex virtual routing structures so the general routers could route them efficiently.

This removes all the arch complexity by allowing wires to be tagged as having a constant value, and therefore creates a simplified backwards routing problem for constants, allowing such wires to have multiple sources.

This should also solve some of the performance problems with router1 for nextpnr-nexus.