### PR TITLE
router2: Don't use estimates for constant nets

### DIFF
--- a/common/route/router2.cc
+++ b/common/route/router2.cc
@@ -782,7 +782,7 @@ struct Router2
                         next_score.delay = curr.score.delay + cfg.get_base_cost(ctx, next, uh, crit_weight);
                         next_score.cost = curr.score.cost + score_wire_for_arc(net, i, phys_pin, next, uh, crit_weight);
                         next_score.togo_cost =
-                                cfg.estimate_weight * get_togo_cost(net, i, next_idx, src_wire, true, crit_weight);
+                                const_mode ? 0 : cfg.estimate_weight * get_togo_cost(net, i, next_idx, src_wire, true, crit_weight);
                         if (was_visited_bwd(next_idx, next_score.delay)) {
                             // Don't expand the same node twice.
                             continue;


### PR DESCRIPTION
As constant nets could start from many possible locations (e.g. every interconnect tile), the backwards estimate to some arbitrary location is largely meaningless in this mode, so just set it to zero so it doesn't cause problems.

Fixes the router2 performance issue raised in #1235.