### PR TITLE
machxo2: ignore promoting to global when bel is not constrained

### DIFF
--- a/machxo2/pack.cc
+++ b/machxo2/pack.cc
@@ -1592,6 +1592,8 @@ class MachXO2Packer
         // Promote the N highest fanout clocks
         for (size_t i = 0; i < std::min<size_t>(clk_fanout.size(), available_globals); i++) {
             NetInfo *net = ctx->nets.at(clk_fanout.at(i).second).get();
+            if (!net->driver.cell->attrs.count(id_BEL))
+                continue;
             log_info("     promoting clock net '%s'\n", ctx->nameOf(net));
             insert_buffer(net, id_DCCA, "glb_clk", id_CLKI, id_CLKO,
                           [&](const PortRef &port) { return port.cell->type != id_DCCA; });


### PR DESCRIPTION
This fixes https://github.com/YosysHQ/nextpnr/issues/1236 by ignoring nets that are connected to non-constrained IO port.