### PR TITLE
machxo2: less pessimistic delay prediction

### DIFF
--- a/machxo2/arch.cc
+++ b/machxo2/arch.cc
@@ -476,7 +476,7 @@ delay_t Arch::predictDelay(BelId src_bel, IdString src_pin, BelId dst_bel, IdStr
 
     int dx = abs(driver_loc.x - sink_loc.x), dy = abs(driver_loc.y - sink_loc.y);
 
-    return (500 - 22 * device_speed) *
+    return (250 - 22 * device_speed) *
            (3 + std::max(dx - 5, 0) + std::max(dy - 5, 0) + 2 * (std::min(dx, 5) + std::min(dy, 5)));
 }
 


### PR DESCRIPTION
This puts the post-placement delay prediction in a band that matches the output Fmax a bit better. Though I only tuned this using one design, the figure only has to be roughly correct anyway. 