### PR TITLE
ecp5: Don't segfault when DI port of TRELLIS_FF unconnected

### DIFF
--- a/ecp5/pack.cc
+++ b/ecp5/pack.cc
@@ -240,7 +240,7 @@ class Ecp5Packer
                     ci->disconnectPort(id_M);
                     ci->ports.erase(id_M);
                 }
-                if (di->driver.cell != nullptr && di->driver.cell->type == id_TRELLIS_COMB && di->driver.port == id_F) {
+                if (di && di->driver.cell != nullptr && di->driver.cell->type == id_TRELLIS_COMB && di->driver.port == id_F) {
                     CellInfo *comb = di->driver.cell;
                     if (comb->cluster != ClusterId()) {
                         // Special procedure where the comb cell is part of an existing macro


### PR DESCRIPTION
Currently a segfault happens while packing FFs when the DI port is not specified. Leaving it unconnected is probably incorrect, but it shouldn't crash the placer. This can only happen when doing direct instantiation. Fix by adding a check.