### PR TITLE
Allow gowin family aliases to be specified

### DIFF
--- a/gowin/family_aliases.h
+++ b/gowin/family_aliases.h
@@ -1,0 +1,20 @@
+#ifndef FAMILY_ALIASES_H
+#define FAMILY_ALIASES_H
+
+#include <map>
+#include <string>
+
+const std::map<const std::string, const std::string> gowin_family_aliases = {
+        {"GW1N-1", "GW1N-1"},      {"GW1N-1S", "GW1N-1S"},     {"GW1N-1P5", "GW1N-2"},   {"GW1N-1P5B", "GW1N-2"},
+        {"GW1N-2", "GW1N-2"},      {"GW1N-2B", "GW1N-2"},      {"GW1N-4B", "GW1N-4"},    {"GW1N-4", "GW1N-4"},
+        {"GW1N-4D", "GW1N-4"},     {"GW1N-9", "GW1N-9"},       {"GW1N-9C", "GW1N-9C"},   {"GW1NZ-1", "GW1NZ-1"},
+        {"GW1NZ-1C", "GW1NZ-1"},   {"GW1NR-2", "GW1N-2"},      {"GW1NR-2B", "GW1N-2"},   {"GW1NS-2", "GW1NS-2"},
+        {"GW1NS-2C", "GW1NS-2"},   {"GW1NS-4", "GW1NS-4"},     {"GW1NSR-2", "GW1NS-2"},  {"GW1NSR-2C", "GW1NS-2"},
+        {"GW1NSE-2C", "GW1NS-2"},  {"GW1NSR-4", "GW1NS-4"},    {"GW1NSR-4C", "GW1NS-4"}, {"GW1NR-1", "GW1N-1"},
+        {"GW1NR-4B", "GW1N-4"},    {"GW1NR-4", "GW1N-4"},      {"GW1NR-4D", "GW1N-4"},   {"GW1NR-9", "GW1N-9"},
+        {"GW1NR-9C", "GW1N-9C"},   {"GW1NRF-4B", "GW1N-4"},    {"GW2A-55", "GW2A-55"},   {"GW2A-18", "GW2A-18"},
+        {"GW2AR-18", "GW2A-18"},   {"GW2A-55C", "GW2A-55"},    {"GW2A-18C", "GW2A-18C"}, {"GW2AR-18C", "GW2A-18C"},
+        {"GW1NSER-4C", "GW1NS-4"}, {"GW1NS-4C", "GW1NS-4"},    {"GW2AN-9X", "GW2AN-4X"}, {"GW2AN-18X", "GW2AN-4X"},
+        {"GW2AN-55C", "GW2A-55"},  {"GW2ANR-18C", "GW2A-18C"}, {"GW1NZR-2", "GW1N-2"},   {"GW2AN-4X", "GW2AN-4X"}};
+
+#endif

--- a/gowin/main.cc
+++ b/gowin/main.cc
@@ -25,6 +25,7 @@
 #include <regex>
 #include "command.h"
 #include "design_utils.h"
+#include "family_aliases.h"
 #include "log.h"
 #include "timing.h"
 
@@ -87,6 +88,10 @@ std::unique_ptr<Context> GowinCommandHandler::createContext(dict<std::string, Pr
             chipArgs.family = "GW2A-18";
         }
     }
+    if (gowin_family_aliases.count(chipArgs.family)) {
+        chipArgs.family = gowin_family_aliases.at(chipArgs.family);
+    }
+
     if (!GW2) {
         chipArgs.partnumber = match[0];
     } else {

--- a/himbaechel/uarch/gowin/family_aliases.h
+++ b/himbaechel/uarch/gowin/family_aliases.h
@@ -1,0 +1,20 @@
+#ifndef FAMILY_ALIASES_H
+#define FAMILY_ALIASES_H
+
+#include <map>
+#include <string>
+
+const std::map<const std::string, const std::string> gowin_family_aliases = {
+        {"GW1N-1", "GW1N-1"},      {"GW1N-1S", "GW1N-1S"},     {"GW1N-1P5", "GW1N-2"},   {"GW1N-1P5B", "GW1N-2"},
+        {"GW1N-2", "GW1N-2"},      {"GW1N-2B", "GW1N-2"},      {"GW1N-4B", "GW1N-4"},    {"GW1N-4", "GW1N-4"},
+        {"GW1N-4D", "GW1N-4"},     {"GW1N-9", "GW1N-9"},       {"GW1N-9C", "GW1N-9C"},   {"GW1NZ-1", "GW1NZ-1"},
+        {"GW1NZ-1C", "GW1NZ-1"},   {"GW1NR-2", "GW1N-2"},      {"GW1NR-2B", "GW1N-2"},   {"GW1NS-2", "GW1NS-2"},
+        {"GW1NS-2C", "GW1NS-2"},   {"GW1NS-4", "GW1NS-4"},     {"GW1NSR-2", "GW1NS-2"},  {"GW1NSR-2C", "GW1NS-2"},
+        {"GW1NSE-2C", "GW1NS-2"},  {"GW1NSR-4", "GW1NS-4"},    {"GW1NSR-4C", "GW1NS-4"}, {"GW1NR-1", "GW1N-1"},
+        {"GW1NR-4B", "GW1N-4"},    {"GW1NR-4", "GW1N-4"},      {"GW1NR-4D", "GW1N-4"},   {"GW1NR-9", "GW1N-9"},
+        {"GW1NR-9C", "GW1N-9C"},   {"GW1NRF-4B", "GW1N-4"},    {"GW2A-55", "GW2A-55"},   {"GW2A-18", "GW2A-18"},
+        {"GW2AR-18", "GW2A-18"},   {"GW2A-55C", "GW2A-55"},    {"GW2A-18C", "GW2A-18C"}, {"GW2AR-18C", "GW2A-18C"},
+        {"GW1NSER-4C", "GW1NS-4"}, {"GW1NS-4C", "GW1NS-4"},    {"GW2AN-9X", "GW2AN-4X"}, {"GW2AN-18X", "GW2AN-4X"},
+        {"GW2AN-55C", "GW2A-55"},  {"GW2ANR-18C", "GW2A-18C"}, {"GW1NZR-2", "GW1N-2"},   {"GW2AN-4X", "GW2AN-4X"}};
+
+#endif

--- a/himbaechel/uarch/gowin/gowin.cc
+++ b/himbaechel/uarch/gowin/gowin.cc
@@ -14,6 +14,7 @@
 #include "gowin.h"
 #include "gowin_utils.h"
 #include "pack.h"
+#include "family_aliases.h"
 
 NEXTPNR_NAMESPACE_BEGIN
 
@@ -97,6 +98,9 @@ void GowinImpl::init_database(Arch *arch)
         }
     }
 
+    if (gowin_family_aliases.count(family)) {
+        family = gowin_family_aliases.at(family);
+    }
     arch->load_chipdb(stringf("gowin/chipdb-%s.bin", family.c_str()));
 
     // These fields go in the header of the output JSON file and can help


### PR DESCRIPTION
This allows Gowin family aliases to be specified. I updated both the gowin and himbaechel areas. Note that if you do specify these aliases, it will only work fully once this PR is merged: https://github.com/YosysHQ/apicula/pull/210

Fixes https://github.com/YosysHQ/nextpnr/issues/1243