### PR TITLE
heap: improved net weighting

### DIFF
--- a/common/place/placer_heap.cc
+++ b/common/place/placer_heap.cc
@@ -752,8 +752,7 @@ class HeAPPlacer
                                                                        std::abs(o_pos - this_pos)));
 
                     if (user_idx) {
-                        weight *= (1.0 + cfg.timingWeight * std::pow(tmg.get_criticality(CellPortKey(port)),
-                                                                     cfg.criticalityExponent));
+                        weight = tmg.get_criticality(CellPortKey(port)) * ni->users.entries() * double(std::abs(o_pos - this_pos));
                     }
 
                     // If cell 0 is not fixed, it will stamp +w on its equation and -w on the other end's equation,


### PR DESCRIPTION
This might be a little controversial.

While *doing research*, I found [Agashiwala, 2015](https://conservancy.umn.edu/handle/11299/175486), which describes a quadratic analytical placer. While the paper itself wasn't too interesting, I found Formula 3.8 on timing-driven net weighting, which intrigued me because the formula in nextpnr scales the weight down with users, and this one scales the weight up with users.

So, I compared it to the old formula on 100 runs each of dragonmux's [HeadphoneAmp](https://github.com/dragonmux/HeadphoneAmp), and got this:

![firefox_IzQan83c3B](https://github.com/YosysHQ/nextpnr/assets/1503707/d80e3e69-bbab-4715-8262-400bd02881ef)

and my SPRT calculator is happy to accept this as an improvement for this design.

My question is: given how heap is the default placer everywhere in nextpnr, what's the criteria for "seems sufficiently unlikely to regress people's designs"?