### PR TITLE
Fix abstract class implementation for fpga_interchange

### DIFF
--- a/fpga_interchange/arch.h
+++ b/fpga_interchange/arch.h
@@ -500,6 +500,8 @@ struct Arch : ArchAPI<ArchRanges>
 
     WireId getConflictingWireWire(WireId wire) const final { return wire; }
 
+    IdString getWireConstantValue(WireId wire) const final { return {}; }
+
     NetInfo *getConflictingWireNet(WireId wire) const final
     {
         NPNR_ASSERT(wire != WireId());


### PR DESCRIPTION
Hi folks,

This fixes a missing declaration for the fpga_interchange submodule.

The error was introduced in #1228 :
```
nextpnr/common/kernel/pybindings.cc: In function ‘nextpnr_fpga_interchange::Context* nextpnr_fpga_interchange::load_design_shim(std::string, ArchArgs)’:
BUILD/nextpnr/common/kernel/pybindings.cc:61:34: error: invalid new-expression of abstract class type ‘nextpnr_fpga_interchange::Context’
   61 |     Context *d = new Context(args);
      |                                  ^
In file included from BUILD/nextpnr/common/kernel/nextpnr.h:24,
                 from BUILD/nextpnr/common/kernel/pycontainers.h:29,
                 from BUILD/nextpnr/common/kernel/pybindings.h:30,
                 from BUILD/nextpnr/common/kernel/pybindings.cc:23:
BUILD/nextpnr/common/kernel/context.h:31:8: note:   because the following virtual functions are pure within ‘nextpnr_fpga_interchange::Context’:
   31 | struct Context : Arch, DeterministicRNG
      |        ^~~~~~~
In file included from BUILD/nextpnr/common/kernel/base_arch.h:27,
                 from BUILD/nextpnr/common/kernel/nextpnr.h:23:
BUILD/nextpnr/common/kernel/arch_api.h:86:22: note:     ‘nextpnr_fpga_interchange::IdString nextpnr_fpga_interchange::ArchAPI<R>::getWireConstantValue(nextpnr_fpga_interchange::WireId) const [with R = nextpnr_fpga_interchange::ArchRanges]’
   86 |     virtual IdString getWireConstantValue(WireId wire) const = 0;

```