### PR TITLE
static/ice40: bug fixes for ultraplus

### DIFF
--- a/common/place/placer_static.cc
+++ b/common/place/placer_static.cc
@@ -1267,7 +1267,7 @@ class StaticPlacer
                 penalty *= 1.025;
             if (!legalised_ip) {
                 float ip_overlap = 0;
-                for (int i = 2; i < int(groups.size()); i++)
+                for (int i = cfg.logic_groups; i < int(groups.size()); i++)
                     ip_overlap = std::max(ip_overlap, groups.at(i).overlap);
                 if (ip_overlap < 0.15) {
                     legalise_step(true);
@@ -1275,7 +1275,7 @@ class StaticPlacer
                 }
             } else {
                 float logic_overlap = 0;
-                for (int i = 0; i < 2; i++)
+                for (int i = 0; i < cfg.logic_groups; i++)
                     logic_overlap = std::max(logic_overlap, groups.at(i).overlap);
                 if (logic_overlap < 0.1) {
                     legalise_step(false);

--- a/common/place/placer_static.h
+++ b/common/place/placer_static.h
@@ -61,8 +61,9 @@ struct PlacerStaticCfg
     // estimate = c + mx*dx + my * dy
     delay_t timing_c = 100, timing_mx = 100, timing_my = 100;
     // groups of cells that should be placed together.
-    // group 0 must be LUTs and group 1 must be FFs, further groups for BRAM/DSP/misc
+    // groups < logic_groups are logic like LUTs and FFs, further groups for BRAM/DSP/misc
     std::vector<StaticCellGroupCfg> cell_groups;
+    int logic_groups = 2;
 };
 
 extern bool placer_static(Context *ctx, PlacerStaticCfg cfg);

--- a/ice40/arch.cc
+++ b/ice40/arch.cc
@@ -653,6 +653,7 @@ bool Arch::place()
             return false;
     } else if (placer == "static") {
         PlacerStaticCfg cfg(getCtx());
+        cfg.logic_groups = 1;
         {
             cfg.cell_groups.emplace_back();
             auto &comb = cfg.cell_groups.back();
@@ -673,6 +674,15 @@ bool Arch::place()
 
         {
             cfg.cell_groups.emplace_back();
+            auto& comb = cfg.cell_groups.back();
+            comb.name = getCtx()->id("DSP");
+            comb.cell_area[id_ICESTORM_DSP] = StaticRect(0.9f, 5.0f);
+            comb.bel_area[id_ICESTORM_DSP] = StaticRect(0.9f, 5.0f);
+            comb.spacer_rect = StaticRect(0.9f, 5.0f);
+        }
+
+        {
+            cfg.cell_groups.emplace_back();
             auto &comb = cfg.cell_groups.back();
             comb.name = getCtx()->id("GB");
             comb.cell_area[id_SB_GB] = StaticRect(0.5f, 0.5f);
@@ -684,9 +694,9 @@ bool Arch::place()
             cfg.cell_groups.emplace_back();
             auto &comb = cfg.cell_groups.back();
             comb.name = getCtx()->id("WARMBOOT");
-            comb.cell_area[id_SB_WARMBOOT] = StaticRect(1.0f, 1.0f);
-            comb.bel_area[id_SB_WARMBOOT] = StaticRect(1.0f, 1.0f);
-            comb.spacer_rect = StaticRect(1.0f, 1.0f);
+            comb.cell_area[id_SB_WARMBOOT] = StaticRect(0.5f, 1.0f);
+            comb.bel_area[id_SB_WARMBOOT] = StaticRect(0.5f, 1.0f);
+            comb.spacer_rect = StaticRect(0.5f, 1.0f);
         }
 
         {
@@ -695,7 +705,7 @@ bool Arch::place()
             comb.name = getCtx()->id("IO");
             comb.cell_area[id_SB_IO] = StaticRect(0.5f, 0.5f);
             comb.bel_area[id_SB_IO] = StaticRect(0.5f, 0.5f);
-            comb.spacer_rect = StaticRect(1.0f, 1.0f);
+            comb.spacer_rect = StaticRect(0.5f, 0.5f);
         }
         if (!placer_static(getCtx(), cfg))
             return false;


### PR DESCRIPTION
- for UP `static` throws an assert over `WARMBOOT` being too big, so it was shrunk a little.
- added DSP bel config (again, the width is set to be less than 1 due to it being too big otherwise).
- fix the IO spacer size to be the size of a cell.
- finally, the iCE40 has the LUT and FF packed together into an `ICESTORM_LC`, so the logic group offset needs to be changed.