### PR TITLE
upgrade to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ foreach(item ${ARCH})
     endif()
 endforeach()
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 if (MSVC)
     set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "" FORCE)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /D_DEBUG /W4 /wd4100 /wd4244 /wd4125 /wd4800 /wd4456 /wd4458 /wd4305 /wd4459 /wd4121 /wd4996")

--- a/common/kernel/hashlib.h
+++ b/common/kernel/hashlib.h
@@ -380,8 +380,8 @@ template <typename K, typename T, typename OPS> class dict
         using iterator_category = std::forward_iterator_tag;
         using value_type = std::pair<K, T>;
         using difference_type = std::ptrdiff_t;
-        using pointer = std::pair<K, T>*;
-        using reference = std::pair<K, T>&;
+        using pointer = const std::pair<K, T>*;
+        using reference = const std::pair<K, T>&;
         const_iterator() {}
         const_iterator operator++()
         {
@@ -831,8 +831,8 @@ template <typename K, typename OPS> class pool
         using iterator_category = std::forward_iterator_tag;
         using value_type = K;
         using difference_type = std::ptrdiff_t;
-        using pointer = K*;
-        using reference = K&;
+        using pointer = const K*;
+        using reference = const K&;
         const_iterator() {}
         const_iterator operator++()
         {
@@ -1068,8 +1068,8 @@ template <typename K, int offset, typename OPS> class idict
         using iterator_category = std::forward_iterator_tag;
         using value_type = K;
         using difference_type = std::ptrdiff_t;
-        using pointer = K*;
-        using reference = K&;
+        using pointer = const K*;
+        using reference = const K&;
         const_iterator() {}
         const_iterator operator++()
         {

--- a/common/kernel/hashlib.h
+++ b/common/kernel/hashlib.h
@@ -367,7 +367,7 @@ template <typename K, typename T, typename OPS> class dict
     using mapped_type = T;
     using value_type = std::pair<K, T>;
 
-    class const_iterator : public std::iterator<std::forward_iterator_tag, std::pair<K, T>>
+    class const_iterator
     {
         friend class dict;
 
@@ -377,6 +377,11 @@ template <typename K, typename T, typename OPS> class dict
         const_iterator(const dict *ptr, int index) : ptr(ptr), index(index) {}
 
       public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = std::pair<K, T>;
+        using difference_type = std::ptrdiff_t;
+        using pointer = std::pair<K, T>*;
+        using reference = std::pair<K, T>&;
         const_iterator() {}
         const_iterator operator++()
         {
@@ -395,7 +400,7 @@ template <typename K, typename T, typename OPS> class dict
         const std::pair<K, T> *operator->() const { return &ptr->entries[index].udata; }
     };
 
-    class iterator : public std::iterator<std::forward_iterator_tag, std::pair<K, T>>
+    class iterator
     {
         friend class dict;
 
@@ -405,6 +410,11 @@ template <typename K, typename T, typename OPS> class dict
         iterator(dict *ptr, int index) : ptr(ptr), index(index) {}
 
       public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = std::pair<K, T>;
+        using difference_type = std::ptrdiff_t;
+        using pointer = std::pair<K, T>*;
+        using reference = std::pair<K, T>&;
         iterator() {}
         iterator operator++()
         {
@@ -808,7 +818,7 @@ template <typename K, typename OPS> class pool
     }
 
   public:
-    class const_iterator : public std::iterator<std::forward_iterator_tag, K>
+    class const_iterator
     {
         friend class pool;
 
@@ -818,6 +828,11 @@ template <typename K, typename OPS> class pool
         const_iterator(const pool *ptr, int index) : ptr(ptr), index(index) {}
 
       public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = K;
+        using difference_type = std::ptrdiff_t;
+        using pointer = K*;
+        using reference = K&;
         const_iterator() {}
         const_iterator operator++()
         {
@@ -830,7 +845,7 @@ template <typename K, typename OPS> class pool
         const K *operator->() const { return &ptr->entries[index].udata; }
     };
 
-    class iterator : public std::iterator<std::forward_iterator_tag, K>
+    class iterator
     {
         friend class pool;
 
@@ -840,6 +855,11 @@ template <typename K, typename OPS> class pool
         iterator(pool *ptr, int index) : ptr(ptr), index(index) {}
 
       public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = K;
+        using difference_type = std::ptrdiff_t;
+        using pointer = K*;
+        using reference = K&;
         iterator() {}
         iterator operator++()
         {
@@ -1035,7 +1055,7 @@ template <typename K, int offset, typename OPS> class idict
     pool<K, OPS> database;
 
   public:
-    class const_iterator : public std::iterator<std::forward_iterator_tag, K>
+    class const_iterator
     {
         friend class idict;
 
@@ -1045,6 +1065,11 @@ template <typename K, int offset, typename OPS> class idict
         const_iterator(const idict &container, int index) : container(container), index(index) {}
 
       public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = K;
+        using difference_type = std::ptrdiff_t;
+        using pointer = K*;
+        using reference = K&;
         const_iterator() {}
         const_iterator operator++()
         {

--- a/gui/fpgaviewwidget.cc
+++ b/gui/fpgaviewwidget.cc
@@ -721,7 +721,7 @@ void FPGAViewWidget::mousePressEvent(QMouseEvent *event)
     bool shift = QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier);
     bool ctrl = QApplication::keyboardModifiers().testFlag(Qt::ControlModifier);
     bool btn_right = event->buttons() & Qt::RightButton;
-    bool btn_mid = event->buttons() & Qt::MidButton;
+    bool btn_mid = event->buttons() & Qt::MiddleButton;
     bool btn_left = event->buttons() & Qt::LeftButton;
 
     if (btn_right || btn_mid || (btn_left && shift)) {
@@ -761,7 +761,7 @@ void FPGAViewWidget::mouseMoveEvent(QMouseEvent *event)
 
     bool shift = QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier);
     bool btn_right = event->buttons() & Qt::RightButton;
-    bool btn_mid = event->buttons() & Qt::MidButton;
+    bool btn_mid = event->buttons() & Qt::MiddleButton;
     bool btn_left = event->buttons() & Qt::LeftButton;
 
     if (btn_right || btn_mid || (btn_left && shift)) {


### PR DESCRIPTION
I got a bit annoyed at the lack of C++17 in nextpnr, so here's a PR to upgrade the C++ standard, as well as a fix to hashlib to remove the deprecated `std::iterator` usage.