### PR TITLE
Fix: misc warnings

### DIFF
--- a/common/kernel/base_arch.h
+++ b/common/kernel/base_arch.h
@@ -143,8 +143,8 @@ template <typename R> struct BaseArch : ArchAPI<R>
 
     // Basic config
     virtual IdString archId() const override { return this->id(NPNR_STRINGIFY(ARCHNAME)); }
-    virtual IdString archArgsToId(typename R::ArchArgsT args) const override { return IdString(); }
-    virtual int getTilePipDimZ(int x, int y) const override { return 1; }
+    virtual IdString archArgsToId(typename R::ArchArgsT /*args*/) const override { return IdString(); }
+    virtual int getTilePipDimZ(int /*x*/, int /*y*/) const override { return 1; }
     virtual char getNameDelimiter() const override { return ' '; }
 
     // Bel methods
@@ -170,9 +170,9 @@ template <typename R> struct BaseArch : ArchAPI<R>
         this->refreshUiBel(bel);
     }
 
-    virtual bool getBelHidden(BelId bel) const override { return false; }
+    virtual bool getBelHidden(BelId /*bel*/) const override { return false; }
 
-    virtual bool getBelGlobalBuf(BelId bel) const override { return false; }
+    virtual bool getBelGlobalBuf(BelId /*bel*/) const override { return false; }
     virtual bool checkBelAvail(BelId bel) const override { return getBoundBelCell(bel) == nullptr; };
     virtual CellInfo *getBoundBelCell(BelId bel) const override
     {
@@ -180,18 +180,18 @@ template <typename R> struct BaseArch : ArchAPI<R>
         return fnd == base_bel2cell.end() ? nullptr : fnd->second;
     }
     virtual CellInfo *getConflictingBelCell(BelId bel) const override { return getBoundBelCell(bel); }
-    virtual typename R::BelAttrsRangeT getBelAttrs(BelId bel) const override
+    virtual typename R::BelAttrsRangeT getBelAttrs(BelId /*bel*/) const override
     {
         return empty_if_possible<typename R::BelAttrsRangeT>();
     }
 
-    virtual typename R::CellBelPinRangeT getBelPinsForCellPin(const CellInfo *cell_info, IdString pin) const override
+    virtual typename R::CellBelPinRangeT getBelPinsForCellPin(const CellInfo * /*cell_info*/, IdString pin) const override
     {
         return return_if_match<std::array<IdString, 1>, typename R::CellBelPinRangeT>({pin});
     }
 
     // Wire methods
-    virtual IdString getWireType(WireId wire) const override { return IdString(); }
+    virtual IdString getWireType(WireId /*wire*/) const override { return IdString(); }
     virtual typename R::WireAttrsRangeT getWireAttrs(WireId) const override
     {
         return empty_if_possible<typename R::WireAttrsRangeT>();
@@ -237,10 +237,10 @@ template <typename R> struct BaseArch : ArchAPI<R>
     }
     virtual WireId getConflictingWireWire(WireId wire) const override { return wire; };
     virtual NetInfo *getConflictingWireNet(WireId wire) const override { return getBoundWireNet(wire); }
-    virtual IdString getWireConstantValue(WireId wire) const override { return {}; }
+    virtual IdString getWireConstantValue(WireId /*wire*/) const override { return {}; }
 
     // Pip methods
-    virtual IdString getPipType(PipId pip) const override { return IdString(); }
+    virtual IdString getPipType(PipId /*pip*/) const override { return IdString(); }
     virtual typename R::PipAttrsRangeT getPipAttrs(PipId) const override
     {
         return empty_if_possible<typename R::PipAttrsRangeT>();
@@ -285,60 +285,60 @@ template <typename R> struct BaseArch : ArchAPI<R>
         auto fnd = base_pip2net.find(pip);
         return fnd == base_pip2net.end() ? nullptr : fnd->second;
     }
-    virtual WireId getConflictingPipWire(PipId pip) const override { return WireId(); }
+    virtual WireId getConflictingPipWire(PipId /*pip*/) const override { return WireId(); }
     virtual NetInfo *getConflictingPipNet(PipId pip) const override { return getBoundPipNet(pip); }
 
     // Group methods
-    virtual GroupId getGroupByName(IdStringList name) const override { return GroupId(); };
-    virtual IdStringList getGroupName(GroupId group) const override { return IdStringList(); };
+    virtual GroupId getGroupByName(IdStringList /*name*/) const override { return GroupId(); };
+    virtual IdStringList getGroupName(GroupId /*group*/) const override { return IdStringList(); };
     virtual typename R::AllGroupsRangeT getGroups() const override
     {
         return empty_if_possible<typename R::AllGroupsRangeT>();
     }
     // Default implementation of these assumes no groups so never called
-    virtual typename R::GroupBelsRangeT getGroupBels(GroupId group) const override
+    virtual typename R::GroupBelsRangeT getGroupBels(GroupId /*group*/) const override
     {
         NPNR_ASSERT_FALSE("unreachable");
     };
-    virtual typename R::GroupWiresRangeT getGroupWires(GroupId group) const override
+    virtual typename R::GroupWiresRangeT getGroupWires(GroupId /*group*/) const override
     {
         NPNR_ASSERT_FALSE("unreachable");
     };
-    virtual typename R::GroupPipsRangeT getGroupPips(GroupId group) const override
+    virtual typename R::GroupPipsRangeT getGroupPips(GroupId /*group*/) const override
     {
         NPNR_ASSERT_FALSE("unreachable");
     };
-    virtual typename R::GroupGroupsRangeT getGroupGroups(GroupId group) const override
+    virtual typename R::GroupGroupsRangeT getGroupGroups(GroupId /*group*/) const override
     {
         NPNR_ASSERT_FALSE("unreachable");
     };
 
     // Delay methods
-    virtual bool getArcDelayOverride(const NetInfo *net_info, const PortRef &sink, DelayQuad &delay) const override
+    virtual bool getArcDelayOverride(const NetInfo * /*net_info*/, const PortRef &/*sink*/, DelayQuad &/*delay*/) const override
     {
         return false;
     }
 
     // Decal methods
-    virtual typename R::DecalGfxRangeT getDecalGraphics(DecalId decal) const override
+    virtual typename R::DecalGfxRangeT getDecalGraphics(DecalId /*decal*/) const override
     {
         return empty_if_possible<typename R::DecalGfxRangeT>();
     };
-    virtual DecalXY getBelDecal(BelId bel) const override { return DecalXY(); }
-    virtual DecalXY getWireDecal(WireId wire) const override { return DecalXY(); }
-    virtual DecalXY getPipDecal(PipId pip) const override { return DecalXY(); }
-    virtual DecalXY getGroupDecal(GroupId group) const override { return DecalXY(); }
+    virtual DecalXY getBelDecal(BelId /*bel*/) const override { return DecalXY(); }
+    virtual DecalXY getWireDecal(WireId /*wire*/) const override { return DecalXY(); }
+    virtual DecalXY getPipDecal(PipId /*pip*/) const override { return DecalXY(); }
+    virtual DecalXY getGroupDecal(GroupId /*group*/) const override { return DecalXY(); }
 
     // Cell timing methods
-    virtual bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const override
+    virtual bool getCellDelay(const CellInfo * /*cell*/, IdString /*fromPort*/, IdString /*toPort*/, DelayQuad &/*delay*/) const override
     {
         return false;
     }
-    virtual TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const override
+    virtual TimingPortClass getPortTimingClass(const CellInfo * /*cell*/, IdString /*port*/, int &/*clockInfoCount*/) const override
     {
         return TMG_IGNORE;
     }
-    virtual TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const override
+    virtual TimingClockingInfo getPortClockingInfo(const CellInfo * /*cell*/, IdString /*port*/, int /*index*/) const override
     {
         NPNR_ASSERT_FALSE("unreachable");
     }
@@ -358,7 +358,7 @@ template <typename R> struct BaseArch : ArchAPI<R>
     {
         return getBelBucketByName(cell_type);
     };
-    virtual bool isBelLocationValid(BelId bel, bool explain_invalid = false) const override { return true; }
+    virtual bool isBelLocationValid(BelId /*bel*/, bool /*explain_invalid*/ = false) const override { return true; }
     virtual typename R::CellTypeRangeT getCellTypes() const override
     {
         NPNR_ASSERT(cell_types_initialised);
@@ -400,7 +400,7 @@ template <typename R> struct BaseArch : ArchAPI<R>
                                          [](const BaseClusterInfo *c) { return Loc(c->constr_x, c->constr_y, 0); });
     }
 
-    virtual bool isClusterStrict(const CellInfo *cell) const override { return true; }
+    virtual bool isClusterStrict(const CellInfo * /*cell*/) const override { return true; }
 
     virtual bool getClusterPlacement(ClusterId cluster, BelId root_bel,
                                      std::vector<std::pair<CellInfo *, BelId>> &placement) const override

--- a/common/kernel/command.h
+++ b/common/kernel/command.h
@@ -34,7 +34,7 @@ class CommandHandler
 {
   public:
     CommandHandler(int argc, char **argv);
-    virtual ~CommandHandler(){};
+    virtual ~CommandHandler() { }
 
     int exec();
     void load_json(Context *ctx, std::string filename);
@@ -45,9 +45,9 @@ class CommandHandler
     virtual void setupArchContext(Context *ctx) = 0;
     virtual std::unique_ptr<Context> createContext(dict<std::string, Property> &values) = 0;
     virtual po::options_description getArchOptions() = 0;
-    virtual void validate(){};
-    virtual void customAfterLoad(Context *ctx){};
-    virtual void customBitstream(Context *ctx){};
+    virtual void validate() { }
+    virtual void customAfterLoad(Context * /*ctx*/) { }
+    virtual void customBitstream(Context * /*ctx*/) { }
     void conflicting_options(const boost::program_options::variables_map &vm, const char *opt1, const char *opt2);
 
   private:

--- a/common/kernel/idstringlist.h
+++ b/common/kernel/idstringlist.h
@@ -35,10 +35,10 @@ struct IdStringList
 {
     SSOArray<IdString, 4> ids;
 
-    IdStringList() : ids(1, IdString()){};
-    explicit IdStringList(size_t n) : ids(n, IdString()){};
-    explicit IdStringList(IdString id) : ids(1, id){};
-    template <typename Tlist> explicit IdStringList(const Tlist &list) : ids(list){};
+    IdStringList() : ids(1, IdString()) { }
+    explicit IdStringList(size_t n) : ids(n, IdString()) { }
+    explicit IdStringList(IdString id) : ids(1, id) { }
+    template <typename Tlist> explicit IdStringList(const Tlist &list) : ids(list) { }
 
     static IdStringList parse(Context *ctx, const std::string &str);
     void build_str(const Context *ctx, std::string &str) const;

--- a/common/kernel/nextpnr_types.h
+++ b/common/kernel/nextpnr_types.h
@@ -81,10 +81,10 @@ struct PortRef
 struct DelayPair
 {
     DelayPair(){};
-    explicit DelayPair(delay_t delay) : min_delay(delay), max_delay(delay){};
-    DelayPair(delay_t min_delay, delay_t max_delay) : min_delay(min_delay), max_delay(max_delay){};
-    delay_t minDelay() const { return min_delay; };
-    delay_t maxDelay() const { return max_delay; };
+    explicit DelayPair(delay_t delay) : min_delay(delay), max_delay(delay) { }
+    DelayPair(delay_t min_delay, delay_t max_delay) : min_delay(min_delay), max_delay(max_delay) { }
+    delay_t minDelay() const { return min_delay; }
+    delay_t maxDelay() const { return max_delay; }
     delay_t min_delay, max_delay;
     DelayPair operator+(const DelayPair &other) const
     {
@@ -100,21 +100,21 @@ struct DelayPair
 struct DelayQuad
 {
     DelayPair rise, fall;
-    DelayQuad(){};
-    explicit DelayQuad(delay_t delay) : rise(delay), fall(delay){};
-    DelayQuad(delay_t min_delay, delay_t max_delay) : rise(min_delay, max_delay), fall(min_delay, max_delay){};
-    DelayQuad(DelayPair rise, DelayPair fall) : rise(rise), fall(fall){};
+    DelayQuad() { }
+    explicit DelayQuad(delay_t delay) : rise(delay), fall(delay) { }
+    DelayQuad(delay_t min_delay, delay_t max_delay) : rise(min_delay, max_delay), fall(min_delay, max_delay) { }
+    DelayQuad(DelayPair rise, DelayPair fall) : rise(rise), fall(fall) { }
     DelayQuad(delay_t min_rise, delay_t max_rise, delay_t min_fall, delay_t max_fall)
-            : rise(min_rise, max_rise), fall(min_fall, max_fall){};
+            : rise(min_rise, max_rise), fall(min_fall, max_fall) { }
 
-    delay_t minRiseDelay() const { return rise.minDelay(); };
-    delay_t maxRiseDelay() const { return rise.maxDelay(); };
-    delay_t minFallDelay() const { return fall.minDelay(); };
-    delay_t maxFallDelay() const { return fall.maxDelay(); };
-    delay_t minDelay() const { return std::min<delay_t>(rise.minDelay(), fall.minDelay()); };
-    delay_t maxDelay() const { return std::max<delay_t>(rise.maxDelay(), fall.maxDelay()); };
+    delay_t minRiseDelay() const { return rise.minDelay(); }
+    delay_t maxRiseDelay() const { return rise.maxDelay(); }
+    delay_t minFallDelay() const { return fall.minDelay(); }
+    delay_t maxFallDelay() const { return fall.maxDelay(); }
+    delay_t minDelay() const { return std::min<delay_t>(rise.minDelay(), fall.minDelay()); }
+    delay_t maxDelay() const { return std::max<delay_t>(rise.maxDelay(), fall.maxDelay()); }
 
-    DelayPair delayPair() const { return DelayPair(minDelay(), maxDelay()); };
+    DelayPair delayPair() const { return DelayPair(minDelay(), maxDelay()); }
 
     DelayQuad operator+(const DelayQuad &other) const { return {rise + other.rise, fall + other.fall}; }
     DelayQuad operator-(const DelayQuad &other) const { return {rise - other.rise, fall - other.fall}; }
@@ -124,7 +124,7 @@ struct ClockConstraint;
 
 struct NetInfo : ArchNetInfo
 {
-    explicit NetInfo(IdString name) : name(name){};
+    explicit NetInfo(IdString name) : name(name) { }
     IdString name, hierpath;
     int32_t udata = 0;
 
@@ -203,14 +203,14 @@ struct PseudoCell
 
 struct RegionPlug : PseudoCell
 {
-    RegionPlug(Loc loc) : loc(loc){}; // 'loc' is a notional location for the placer only
+    RegionPlug(Loc loc) : loc(loc) { } // 'loc' is a notional location for the placer only
     Loc getLocation() const override { return loc; }
     WireId getPortWire(IdString port) const override { return port_wires.at(port); }
 
     // TODO: partial reconfiguration region timing
-    bool getDelay(IdString fromPort, IdString toPort, DelayQuad &delay) const override { return false; }
-    TimingPortClass getPortTimingClass(IdString port, int &clockInfoCount) const override { return TMG_IGNORE; }
-    TimingClockingInfo getPortClockingInfo(IdString port, int index) const override { return TimingClockingInfo{}; }
+    bool getDelay(IdString /*fromPort*/, IdString /*toPort*/, DelayQuad &/*delay*/) const override { return false; }
+    TimingPortClass getPortTimingClass(IdString /*port*/, int &/*clockInfoCount*/) const override { return TMG_IGNORE; }
+    TimingClockingInfo getPortClockingInfo(IdString /*port*/, int /*index*/) const override { return TimingClockingInfo{}; }
 
     dict<IdString, WireId> port_wires;
     Loc loc;
@@ -218,7 +218,7 @@ struct RegionPlug : PseudoCell
 
 struct CellInfo : ArchCellInfo
 {
-    CellInfo(Context *ctx, IdString name, IdString type) : ctx(ctx), name(name), type(type){};
+    CellInfo(Context *ctx, IdString name, IdString type) : ctx(ctx), name(name), type(type) { }
     Context *ctx = nullptr;
 
     IdString name, type, hierpath;

--- a/common/kernel/pycontainers.h
+++ b/common/kernel/pycontainers.h
@@ -290,7 +290,7 @@ template <typename T1, typename T2> struct pair_wrapper
             x.second = val.cast<T2>();
     }
 
-    static int len(T &x) { return 2; }
+    static int len(T &/*x*/) { return 2; }
 
     static iter_pair<T &, int> iter(T &x) { return iter_pair<T &, int>(boost::ref(x), 0); };
 
@@ -348,7 +348,7 @@ template <typename T1, typename T2, typename value_conv> struct map_pair_wrapper
                                                                                                        x.base.first));
     }
 
-    static int len(wrapped_pair &x) { return 2; }
+    static int len(wrapped_pair &/*x*/) { return 2; }
 
     static iter_pair<wrapped_pair &, int> iter(wrapped_pair &x)
     {
@@ -469,14 +469,14 @@ template <typename T1, typename T2> struct map_pair_wrapper_uptr
 
     static py::object get(wrapped_pair &x, int i)
     {
-        if ((i >= 2) || (i < 0))
+        if (i >= 2 || i < 0)
             KeyError();
-        return (i == 1) ? py::cast(PythonConversion::ContextualWrapper<V &>(x.ctx, *x.base.second.get()))
+        return i == 1 ? py::cast(PythonConversion::ContextualWrapper<V &>(x.ctx, *x.base.second.get()))
                         : py::cast(PythonConversion::string_converter<decltype(x.base.first)>().to_str(x.ctx,
                                                                                                        x.base.first));
     }
 
-    static int len(wrapped_pair &x) { return 2; }
+    static int len(wrapped_pair &/*x*/) { return 2; }
 
     static iter_pair<wrapped_pair &, int> iter(wrapped_pair &x)
     {

--- a/common/kernel/pywrappers.h
+++ b/common/kernel/pywrappers.h
@@ -35,9 +35,9 @@ template <typename T> struct ContextualWrapper
     Context *ctx;
     T base;
 
-    inline ContextualWrapper(Context *c, T x) : ctx(c), base(x){};
+    inline ContextualWrapper(Context *c, T x) : ctx(c), base(x) { }
 
-    inline operator T() { return base; };
+    inline operator T() { return base; }
     typedef T base_type;
 };
 
@@ -83,7 +83,7 @@ class bad_wrap
 // Action options
 template <typename T> struct pass_through
 {
-    inline T operator()(Context *ctx, T x) { return x; }
+    inline T operator()(Context * /*ctx*/, T x) { return x; }
 
     using ret_type = T;
     using arg_type = T;
@@ -99,7 +99,7 @@ template <typename T> struct wrap_context
 
 template <typename T> struct unwrap_context
 {
-    inline T operator()(Context *ctx, ContextualWrapper<T> x) { return x.base; }
+    inline T operator()(Context * /*ctx*/, ContextualWrapper<T> x) { return x.base; }
 
     using ret_type = T;
     using arg_type = ContextualWrapper<T>;
@@ -136,7 +136,7 @@ template <typename T> struct deref_and_wrap
 
 template <typename T> struct addr_and_unwrap
 {
-    inline T *operator()(Context *ctx, ContextualWrapper<T &> x) { return &(x.base); }
+    inline T *operator()(Context * /*ctx*/, ContextualWrapper<T &> x) { return &(x.base); }
 
     using arg_type = ContextualWrapper<T &>;
     using ret_type = T *;

--- a/common/place/timing_opt.h
+++ b/common/place/timing_opt.h
@@ -24,7 +24,7 @@ NEXTPNR_NAMESPACE_BEGIN
 
 struct TimingOptCfg
 {
-    TimingOptCfg(Context *ctx) {}
+    TimingOptCfg(Context * /*ctx*/) { }
 
     // The timing optimiser will *only* optimise cells of these types
     // Normally these would only be logic cells (or tiles if applicable), the algorithm makes little sense

--- a/gui/treemodel.h
+++ b/gui/treemodel.h
@@ -71,7 +71,7 @@ class Item
         if (parent_ != nullptr) {
             parent_->addChild(this);
         }
-    };
+    }
 
     // Number of children.
     int count() const { return children_.count(); }
@@ -102,9 +102,9 @@ class Item
     virtual bool canFetchMore() const { return false; }
     virtual void fetchMore() {}
 
-    virtual boost::optional<Item *> getById(IdStringList id) { return boost::none; }
-    virtual void search(QList<Item *> &results, QString text, int limit) {}
-    virtual void updateElements(Context *ctx, std::vector<IdStringList> elements) {}
+    virtual boost::optional<Item *> getById(IdStringList /*id*/) { return boost::none; }
+    virtual void search(QList<Item *> &/*results*/, QString /*text*/, int /*limit*/) { }
+    virtual void updateElements(Context * /*ctx*/, std::vector<IdStringList> /*elements*/) { }
 
     virtual ~Item()
     {
@@ -147,7 +147,7 @@ class IdList : public Item
   public:
     // Create an IdList at given parent that will contain elements of
     // the given type.
-    IdList(ElementType type) : Item("root", nullptr), child_type_(type) {}
+    IdList(ElementType type) : Item("root", nullptr), child_type_(type) { }
 
     // Split a name into alpha/non-alpha parts, which is then used for sorting
     // of children.

--- a/ice40/arch_pybindings.h
+++ b/ice40/arch_pybindings.h
@@ -78,7 +78,7 @@ template <> struct string_converter<PipId>
 
 template <> struct string_converter<BelPin>
 {
-    BelPin from_str(Context *ctx, std::string name)
+    BelPin from_str(Context * /*ctx*/, std::string /*name*/)
     {
         NPNR_ASSERT_FALSE("string_converter<BelPin>::from_str not implemented");
     }

--- a/ice40/cells.h
+++ b/ice40/cells.h
@@ -30,61 +30,61 @@ NEXTPNR_NAMESPACE_BEGIN
 std::unique_ptr<CellInfo> create_ice_cell(Context *ctx, IdString type, std::string name = "");
 
 // Return true if a cell is a LUT
-inline bool is_lut(const BaseCtx *ctx, const CellInfo *cell) { return cell->type == id_SB_LUT4; }
+inline bool is_lut(const BaseCtx * /*ctx*/, const CellInfo *cell) { return cell->type == id_SB_LUT4; }
 
 // Return true if a cell is a flipflop
-inline bool is_ff(const BaseCtx *ctx, const CellInfo *cell)
+inline bool is_ff(const BaseCtx * /*ctx*/, const CellInfo *cell)
 {
     return cell->type.in(id_SB_DFF, id_SB_DFFE, id_SB_DFFSR, id_SB_DFFR, id_SB_DFFSS, id_SB_DFFS, id_SB_DFFESR,
                          id_SB_DFFER, id_SB_DFFESS, id_SB_DFFES, id_SB_DFFN, id_SB_DFFNE, id_SB_DFFNSR, id_SB_DFFNR,
                          id_SB_DFFNSS, id_SB_DFFNS, id_SB_DFFNESR, id_SB_DFFNER, id_SB_DFFNESS, id_SB_DFFNES);
 }
 
-inline bool is_carry(const BaseCtx *ctx, const CellInfo *cell) { return cell->type == id_SB_CARRY; }
+inline bool is_carry(const BaseCtx * /*ctx*/, const CellInfo *cell) { return cell->type == id_SB_CARRY; }
 
-inline bool is_lc(const BaseCtx *ctx, const CellInfo *cell) { return cell->type == id_ICESTORM_LC; }
+inline bool is_lc(const BaseCtx * /*ctx*/, const CellInfo *cell) { return cell->type == id_ICESTORM_LC; }
 
 // Return true if a cell is a SB_IO
-inline bool is_sb_io(const BaseCtx *ctx, const CellInfo *cell) { return cell->type == id_SB_IO; }
+inline bool is_sb_io(const BaseCtx * /*ctx*/, const CellInfo *cell) { return cell->type == id_SB_IO; }
 
 // Return true if a cell is a SB_GB_IO
-inline bool is_sb_gb_io(const BaseCtx *ctx, const CellInfo *cell) { return cell->type == id_SB_GB_IO; }
+inline bool is_sb_gb_io(const BaseCtx * /*ctx*/, const CellInfo *cell) { return cell->type == id_SB_GB_IO; }
 
 // Return true if a cell is a global buffer
-inline bool is_gbuf(const BaseCtx *ctx, const CellInfo *cell) { return cell->type == id_SB_GB; }
+inline bool is_gbuf(const BaseCtx * /*ctx*/, const CellInfo *cell) { return cell->type == id_SB_GB; }
 
 // Return true if a cell is a RAM
-inline bool is_ram(const BaseCtx *ctx, const CellInfo *cell)
+inline bool is_ram(const BaseCtx * /*ctx*/, const CellInfo *cell)
 {
     return cell->type.in(id_SB_RAM40_4K, id_SB_RAM40_4KNR, id_SB_RAM40_4KNW, id_SB_RAM40_4KNRNW);
 }
 
-inline bool is_sb_lfosc(const BaseCtx *ctx, const CellInfo *cell) { return cell->type == id_SB_LFOSC; }
+inline bool is_sb_lfosc(const BaseCtx * /*ctx*/, const CellInfo *cell) { return cell->type == id_SB_LFOSC; }
 
-inline bool is_sb_hfosc(const BaseCtx *ctx, const CellInfo *cell) { return cell->type == id_SB_HFOSC; }
+inline bool is_sb_hfosc(const BaseCtx * /*ctx*/, const CellInfo *cell) { return cell->type == id_SB_HFOSC; }
 
-inline bool is_sb_spram(const BaseCtx *ctx, const CellInfo *cell) { return cell->type == id_SB_SPRAM256KA; }
+inline bool is_sb_spram(const BaseCtx * /*ctx*/, const CellInfo *cell) { return cell->type == id_SB_SPRAM256KA; }
 
-inline bool is_sb_mac16(const BaseCtx *ctx, const CellInfo *cell) { return cell->type == id_SB_MAC16; }
+inline bool is_sb_mac16(const BaseCtx * /*ctx*/, const CellInfo *cell) { return cell->type == id_SB_MAC16; }
 
-inline bool is_sb_rgba_drv(const BaseCtx *ctx, const CellInfo *cell) { return cell->type == id_SB_RGBA_DRV; }
+inline bool is_sb_rgba_drv(const BaseCtx * /*ctx*/, const CellInfo *cell) { return cell->type == id_SB_RGBA_DRV; }
 
-inline bool is_sb_rgb_drv(const BaseCtx *ctx, const CellInfo *cell) { return cell->type == id_SB_RGB_DRV; }
+inline bool is_sb_rgb_drv(const BaseCtx * /*ctx*/, const CellInfo *cell) { return cell->type == id_SB_RGB_DRV; }
 
-inline bool is_sb_led_drv_cur(const BaseCtx *ctx, const CellInfo *cell) { return cell->type == id_SB_LED_DRV_CUR; }
+inline bool is_sb_led_drv_cur(const BaseCtx * /*ctx*/, const CellInfo *cell) { return cell->type == id_SB_LED_DRV_CUR; }
 
-inline bool is_sb_ledda_ip(const BaseCtx *ctx, const CellInfo *cell) { return cell->type == id_SB_LEDDA_IP; }
+inline bool is_sb_ledda_ip(const BaseCtx * /*ctx*/, const CellInfo *cell) { return cell->type == id_SB_LEDDA_IP; }
 
-inline bool is_sb_i2c(const BaseCtx *ctx, const CellInfo *cell) { return cell->type == id_SB_I2C; }
+inline bool is_sb_i2c(const BaseCtx * /*ctx*/, const CellInfo *cell) { return cell->type == id_SB_I2C; }
 
-inline bool is_sb_spi(const BaseCtx *ctx, const CellInfo *cell) { return cell->type == id_SB_SPI; }
+inline bool is_sb_spi(const BaseCtx * /*ctx*/, const CellInfo *cell) { return cell->type == id_SB_SPI; }
 
-inline bool is_sb_pll40(const BaseCtx *ctx, const CellInfo *cell)
+inline bool is_sb_pll40(const BaseCtx * /*ctx*/, const CellInfo *cell)
 {
     return cell->type.in(id_SB_PLL40_PAD, id_SB_PLL40_2_PAD, id_SB_PLL40_2F_PAD, id_SB_PLL40_CORE, id_SB_PLL40_2F_CORE);
 }
 
-inline bool is_sb_pll40_pad(const BaseCtx *ctx, const CellInfo *cell)
+inline bool is_sb_pll40_pad(const BaseCtx * /*ctx*/, const CellInfo *cell)
 {
     return cell->type.in(id_SB_PLL40_PAD, id_SB_PLL40_2_PAD, id_SB_PLL40_2F_PAD) ||
            (cell->type == id_ICESTORM_PLL && (cell->attrs.at(id_TYPE).as_string() == "SB_PLL40_PAD" ||
@@ -92,7 +92,7 @@ inline bool is_sb_pll40_pad(const BaseCtx *ctx, const CellInfo *cell)
                                               cell->attrs.at(id_TYPE).as_string() == "SB_PLL40_2F_PAD"));
 }
 
-inline bool is_sb_pll40_dual(const BaseCtx *ctx, const CellInfo *cell)
+inline bool is_sb_pll40_dual(const BaseCtx * /*ctx*/, const CellInfo *cell)
 {
     return cell->type.in(id_SB_PLL40_2_PAD, id_SB_PLL40_2F_PAD, id_SB_PLL40_2F_CORE) ||
            (cell->type == id_ICESTORM_PLL && (cell->attrs.at(id_TYPE).as_string() == "SB_PLL40_2_PAD" ||

--- a/rust/rust.cc
+++ b/rust/rust.cc
@@ -16,6 +16,7 @@
  *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <numeric>
 #include "log.h"
 #include "nextpnr.h"
 
@@ -117,15 +118,15 @@ extern "C" {
         return size;
     }
 
-    uint64_t npnr_context_get_wires_leak(const Context *ctx, uint64_t **wires) {
-        auto size = size_t{};
-        for (auto _wire : ctx->getWires()) {
-            NPNR_UNUSED(_wire);
-            size++;
-        }
+    uint64_t npnr_context_get_wires_leak(const Context *const ctx, uint64_t **const wires) {
+        const auto ctx_wires{ctx->getWires()};
+        const auto size{
+            std::accumulate(ctx_wires.begin(), ctx_wires.end(), /*initial value*/ size_t{},
+                [](size_t value, const auto &/*wire*/) { return value + 1U; }
+        )};
         *wires = new uint64_t[size];
         auto idx = 0;
-        for (auto wire : ctx->getWires()) {
+        for (const auto &wire : ctx_wires) {
             (*wires)[idx] = wrap(wire);
             idx++;
         }

--- a/rust/rust.cc
+++ b/rust/rust.cc
@@ -196,7 +196,7 @@ extern "C" {
 #ifdef ARCH_ECP5
     bool npnr_netinfo_is_global(NetInfo *net) { return net->is_global; }
 #else
-    bool npnr_netinfo_is_global(NetInfo *net) { return false; }
+    bool npnr_netinfo_is_global(NetInfo * /*net*/) { return false; }
 #endif
 
     int32_t npnr_netinfo_udata(NetInfo *net) { return net->udata; }

--- a/rust/rust.cc
+++ b/rust/rust.cc
@@ -24,17 +24,12 @@
 namespace {
     USING_NEXTPNR_NAMESPACE;
 
-    // `memcpy` is used here to avoid strict-aliasing problems, but GCC dislikes it.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
-    template<typename T>
-    uint64_t wrap(T thing) {
+    template<typename T> static inline uint64_t wrap(const T &thing) noexcept {
         static_assert(sizeof(T) <= 8, "T is too big for FFI");
         uint64_t b = 0;
         memcpy(&b, &thing, sizeof(T));
         return b;
     }
-#pragma GCC diagnostic pop
 
     template<typename T> static inline T unwrap(const std::array<uint8_t, 8> &value) noexcept {
         static_assert(sizeof(T) <= 8, "T is too big for FFI");

--- a/rust/rust.cc
+++ b/rust/rust.cc
@@ -102,15 +102,15 @@ extern "C" {
     Loc npnr_context_get_pip_location(const Context *ctx, uint64_t pip) { return ctx->getPipLocation(unwrap_pip(pip)); }
     bool npnr_context_check_pip_avail_for_net(const Context *ctx, uint64_t pip, NetInfo *net) { return ctx->checkPipAvailForNet(unwrap_pip(pip), net); }
 
-    uint64_t npnr_context_get_pips_leak(const Context *ctx, uint64_t **pips) {
-        auto size = size_t{};
-        for (auto _pip : ctx->getPips()) {
-            NPNR_UNUSED(_pip);
-            size++;
-        }
+    uint64_t npnr_context_get_pips_leak(const Context *const ctx, uint64_t **const pips) {
+        const auto ctx_pips{ctx->getPips()};
+        const auto size{
+            std::accumulate(ctx_pips.begin(), ctx_pips.end(), /*initial value*/ size_t{},
+                [](size_t value, const auto &/*pip*/) { return value + 1U; }
+        )};
         *pips = new uint64_t[size];
         auto idx = 0;
-        for (auto pip : ctx->getPips()) {
+        for (const auto &pip : ctx_pips) {
             (*pips)[idx] = wrap(pip);
             idx++;
         }


### PR DESCRIPTION
This PR seeks to address some of the sea of unused parameter warnings created when compiling with `-Wall -Wextra  -Wpedantic` on GCC, and the Rust FFI bindings warnings while improving const and reference correctness in this code.

Tested to the best of our abilities with the iCE40 backend.