### PR TITLE
Add trivially copyable invariant for ID types

### DIFF
--- a/common/kernel/nextpnr_types.cc
+++ b/common/kernel/nextpnr_types.cc
@@ -23,7 +23,14 @@
 
 #include "nextpnr_namespaces.h"
 
+#include <type_traits>
+
 NEXTPNR_NAMESPACE_BEGIN
+
+// Invariant: architecture ID types must all be trivially copyable
+static_assert(std::is_trivially_copyable<BelId>::value == true);
+static_assert(std::is_trivially_copyable<WireId>::value == true);
+static_assert(std::is_trivially_copyable<PipId>::value == true);
 
 void CellInfo::addInput(IdString name)
 {


### PR DESCRIPTION
This has always been a design intent of nextpnr, and is now strictly required by #1260.