### PR TITLE
readme: update build prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Prerequisites
 The following packages need to be installed for building nextpnr, independent
 of the selected architecture:
 
-- CMake 3.3 or later
-- Modern C++14 compiler (`clang-format` required for development)
+- CMake 3.13 or later
+- Modern C++17 compiler (`clang-format` required for development)
 - Python 3.5 or later, including development libraries (`python3-dev` for Ubuntu)
   - Python 3.9 or later is required for `nextpnr-himbaechel`
   - on Windows make sure to install same version as supported by [vcpkg](https://github.com/Microsoft/vcpkg/blob/master/ports/python3/CONTROL)


### PR DESCRIPTION
Update the readme to specify C++17 as of #1268, and CMake 3.13 as of #989.