### PR TITLE
Rust bindings cleanup

### DIFF
--- a/rust/nextpnr/src/lib.rs
+++ b/rust/nextpnr/src/lib.rs
@@ -32,7 +32,7 @@ pub struct NetInfo {
 }
 
 impl NetInfo {
-    pub fn driver(&mut self) -> &mut PortRef {
+    pub fn driver(&mut self) -> Option<&mut PortRef> {
         unsafe { npnr_netinfo_driver(self) }
     }
 
@@ -412,7 +412,7 @@ extern "C" {
     fn npnr_context_get_pips_uphill(ctx: &Context, wire: WireId) -> &mut RawUphillIter;
     fn npnr_delete_uphill_iter(iter: &mut RawUphillIter);
 
-    fn npnr_netinfo_driver(net: &mut NetInfo) -> &mut PortRef;
+    fn npnr_netinfo_driver(net: &mut NetInfo) -> Option<&mut PortRef>;
     fn npnr_netinfo_users_leak(net: &NetInfo, users: *mut *mut *const PortRef) -> u32;
     fn npnr_netinfo_is_global(net: &NetInfo) -> bool;
     fn npnr_netinfo_udata(net: &NetInfo) -> NetIndex;

--- a/rust/nextpnr/src/lib.rs
+++ b/rust/nextpnr/src/lib.rs
@@ -61,9 +61,8 @@ pub struct PortRef {
 }
 
 impl PortRef {
-    pub fn cell_mut(&mut self) -> Option<&mut CellInfo> {
-        // SAFETY: handing out &mut is safe when we have &mut self
-        // as getting multiple &mut CellInfo would require multiple &mut PortRef.
+    pub fn cell(&self) -> Option<&CellInfo> {
+        // SAFETY: handing out &s is safe when we have &self.
         unsafe { npnr_portref_cell(self) }
     }
 }
@@ -419,7 +418,7 @@ extern "C" {
     fn npnr_netinfo_udata(net: &NetInfo) -> NetIndex;
     fn npnr_netinfo_udata_set(net: &mut NetInfo, value: NetIndex);
 
-    fn npnr_portref_cell(port: &mut PortRef) -> Option<&mut CellInfo>;
+    fn npnr_portref_cell(port: &PortRef) -> Option<&CellInfo>;
     fn npnr_cellinfo_get_location(info: &CellInfo) -> Loc;
 
     fn npnr_inc_downhill_iter(iter: &mut RawDownhillIter);

--- a/rust/nextpnr/src/lib.rs
+++ b/rust/nextpnr/src/lib.rs
@@ -438,9 +438,6 @@ pub struct Nets<'a> {
     _data: PhantomData<&'a Context>,
 }
 
-unsafe impl Send for Nets<'_> {}
-unsafe impl Sync for Nets<'_> {}
-
 impl<'a> Nets<'a> {
     /// Create a new store for the nets of a context.
     ///

--- a/rust/nextpnr/src/lib.rs
+++ b/rust/nextpnr/src/lib.rs
@@ -390,9 +390,9 @@ extern "C" {
     fn npnr_context_check(ctx: &Context);
     fn npnr_context_debug(ctx: &Context) -> bool;
     fn npnr_context_id(ctx: &Context, s: *const c_char) -> IdString;
-    fn npnr_context_name_of(ctx: &Context, s: IdString) -> &libc::c_char;
-    fn npnr_context_name_of_pip(ctx: &Context, pip: PipId) -> &libc::c_char;
-    fn npnr_context_name_of_wire(ctx: &Context, wire: WireId) -> &libc::c_char;
+    fn npnr_context_name_of(ctx: &Context, s: IdString) -> *const libc::c_char;
+    fn npnr_context_name_of_pip(ctx: &Context, pip: PipId) -> *const libc::c_char;
+    fn npnr_context_name_of_wire(ctx: &Context, wire: WireId) -> *const libc::c_char;
     fn npnr_context_verbose(ctx: &Context) -> bool;
 
     fn npnr_context_get_netinfo_source_wire(ctx: &Context, net: &NetInfo) -> WireId;

--- a/rust/rust.cc
+++ b/rust/rust.cc
@@ -129,7 +129,7 @@ bool npnr_context_check_pip_avail_for_net(const Context *ctx, uint64_t pip, NetI
     return ctx->checkPipAvailForNet(unwrap_pip(pip), net);
 }
 
-uint64_t npnr_context_get_pips_leak(const Context *const ctx, uint64_t **const pips)
+uint64_t npnr_context_get_pips_leak(const Context *ctx, uint64_t **const pips)
 {
     const auto ctx_pips{ctx->getPips()};
     const auto size{std::accumulate(ctx_pips.begin(), ctx_pips.end(), /*initial value*/ size_t{},
@@ -144,7 +144,7 @@ uint64_t npnr_context_get_pips_leak(const Context *const ctx, uint64_t **const p
     return size;
 }
 
-uint64_t npnr_context_get_wires_leak(const Context *const ctx, uint64_t **const wires)
+uint64_t npnr_context_get_wires_leak(const Context *ctx, uint64_t **const wires)
 {
     const auto ctx_wires{ctx->getWires()};
     const auto size{std::accumulate(ctx_wires.begin(), ctx_wires.end(), /*initial value*/ size_t{},

--- a/rust/rust.cc
+++ b/rust/rust.cc
@@ -214,7 +214,7 @@ PortRef *npnr_netinfo_driver(NetInfo *net)
     return &net->driver;
 }
 
-uint32_t npnr_netinfo_users_leak(NetInfo *net, PortRef ***users)
+uint32_t npnr_netinfo_users_leak(const NetInfo *net, const PortRef ***users)
 {
     auto size = net->users.entries();
     *users = new PortRef *[size];

--- a/rust/rust.cc
+++ b/rust/rust.cc
@@ -217,7 +217,7 @@ PortRef *npnr_netinfo_driver(NetInfo *net)
 uint32_t npnr_netinfo_users_leak(const NetInfo *net, const PortRef ***users)
 {
     auto size = net->users.entries();
-    *users = new PortRef *[size];
+    *users = new const PortRef *[size];
     auto idx = 0;
     for (auto &item : net->users) {
         (*users)[idx] = &item;


### PR DESCRIPTION
I apologise for the code churn, but this will make it more pleasant to use, instead of fighting raw pointers everywhere.

- a mutex is added to guard manipulation of the architecture backend; this might get broken into finer-grained locking in the future, but it'll do for now.
- the big change is that the FFI function declarations take references instead of pointers, because pretty much all functions would choke on a null pointer anyway; this reduces the number of functions that clippy demands to be marked as `unsafe` as a helpful side-effect.
- while doing this, I decided to change the API of `netinfo_users_leak` a bit, because I'm reasonably sure `PortRef`s shouldn't be modified (and then changed `npnr_portref_cell` to reflect this).
- since `Nets` doesn't contain any raw pointers, I can remove the manual implementations of `Send`/`Sync` (in hindsight this commit is badly named)