### PR TITLE
gowin: Himbaechel. Deal with SP BSRAM ports.

### DIFF
--- a/himbaechel/uarch/gowin/constids.inc
+++ b/himbaechel/uarch/gowin/constids.inc
@@ -934,6 +934,9 @@ X(GSR)
 X(GSR0)
 X(GSRI)
 
+// inverter
+X(INV)
+
 // Oscillators
 X(OSC)
 X(OSCZ)

--- a/himbaechel/uarch/gowin/globals.cc
+++ b/himbaechel/uarch/gowin/globals.cc
@@ -40,6 +40,8 @@ struct GowinGlobalRouter
 
     GowinGlobalRouter(Context *ctx) : ctx(ctx) { gwu.init(ctx); };
 
+    bool checkPipAvail(PipId pip) const { return gwu.is_global_pip(pip) || ctx->checkPipAvail(pip); };
+
     // allow io->global, global->global and global->tile clock
     bool global_pip_filter(PipId pip) const
     {
@@ -91,7 +93,7 @@ struct GowinGlobalRouter
             // Search uphill pips
             for (PipId pip : ctx->getPipsUphill(cursor)) {
                 // Skip pip if unavailable, and not because it's already used for this net
-                if (!ctx->checkPipAvail(pip) && ctx->getBoundPipNet(pip) != net) {
+                if (!checkPipAvail(pip) && ctx->getBoundPipNet(pip) != net) {
                     continue;
                 }
                 WireId prev = ctx->getPipSrcWire(pip);

--- a/himbaechel/uarch/gowin/globals.cc
+++ b/himbaechel/uarch/gowin/globals.cc
@@ -40,7 +40,7 @@ struct GowinGlobalRouter
 
     GowinGlobalRouter(Context *ctx) : ctx(ctx) { gwu.init(ctx); };
 
-    bool checkPipAvail(PipId pip) const { return gwu.is_global_pip(pip) || ctx->checkPipAvail(pip); };
+    bool global_pip_available(PipId pip) const { return gwu.is_global_pip(pip) || ctx->checkPipAvail(pip); };
 
     // allow io->global, global->global and global->tile clock
     bool global_pip_filter(PipId pip) const
@@ -93,7 +93,7 @@ struct GowinGlobalRouter
             // Search uphill pips
             for (PipId pip : ctx->getPipsUphill(cursor)) {
                 // Skip pip if unavailable, and not because it's already used for this net
-                if (!checkPipAvail(pip) && ctx->getBoundPipNet(pip) != net) {
+                if (!global_pip_available(pip) && ctx->getBoundPipNet(pip) != net) {
                     continue;
                 }
                 WireId prev = ctx->getPipSrcWire(pip);

--- a/himbaechel/uarch/gowin/gowin.cc
+++ b/himbaechel/uarch/gowin/gowin.cc
@@ -38,6 +38,9 @@ struct GowinImpl : HimbaechelAPI
 
     bool isValidBelForCellType(IdString cell_type, BelId bel) const override;
 
+    // wires
+    bool checkPipAvail(PipId pip) const override;
+
   private:
     HimbaechelHelpers h;
     GowinUtils gwu;
@@ -153,6 +156,9 @@ void GowinImpl::init(Context *ctx)
         ctx->settings[ctx->id("cst.filename")] = args.options.at("cst");
     }
 }
+
+// We do not allow the use of global wires that bypass a special router.
+bool GowinImpl::checkPipAvail(PipId pip) const { return !gwu.is_global_pip(pip); }
 
 void GowinImpl::pack()
 {

--- a/himbaechel/uarch/gowin/gowin_utils.h
+++ b/himbaechel/uarch/gowin/gowin_utils.h
@@ -38,6 +38,21 @@ struct GowinUtils
 
     // wires
     inline bool is_wire_type_default(IdString wire_type) { return wire_type == IdString(); }
+    // If wire is an important part of the global network (like SPINExx)
+    inline bool is_global_wire(WireId wire) const
+    {
+        return ctx->getWireName(wire)[1].in(
+                id_SPINE0, id_SPINE1, id_SPINE2, id_SPINE3, id_SPINE4, id_SPINE5, id_SPINE6, id_SPINE7, id_SPINE8,
+                id_SPINE9, id_SPINE10, id_SPINE11, id_SPINE12, id_SPINE13, id_SPINE14, id_SPINE15, id_SPINE16,
+                id_SPINE17, id_SPINE18, id_SPINE19, id_SPINE20, id_SPINE21, id_SPINE22, id_SPINE23, id_SPINE24,
+                id_SPINE25, id_SPINE26, id_SPINE27, id_SPINE28, id_SPINE29, id_SPINE30, id_SPINE31);
+    }
+
+    // pips
+    inline bool is_global_pip(PipId pip) const
+    {
+        return is_global_wire(ctx->getPipSrcWire(pip)) || is_global_wire(ctx->getPipDstWire(pip));
+    }
 
     // chip dependent
     bool have_SP32(void);


### PR DESCRIPTION
The OCE signal in the SP(X)9B primitive is intended to control the built-in output register. The documentation states that this port is invalid when READ_MODE=0 is used. However, it has been experimentally established that you cannot simply apply VCC or GND to it and forget it
- the discrepancy between the signal on this port and the signal on the CE port leads to both skipping data reading and unnecessary reading after CE has switched to 0.
Here we force these ports to be connected to the network, except in the case where the user controls the OCE signal using non-constant signals.

Also:
  * All PIPs for clock spines are made inaccessible to the common router - in general, using these routes for signals that have not been processed by a special globals router is fraught with effects that are difficult to detect.
  * The INV primitive has been added purely to speed up development - this primitive is not generated by Yosys, but is almost always present in vendor output files.