### PR TITLE
gowin: Himbaechel. SPX9 BSRAM BUGFIX.

### DIFF
--- a/himbaechel/uarch/gowin/pack.cc
+++ b/himbaechel/uarch/gowin/pack.cc
@@ -1465,9 +1465,6 @@ struct GowinPacker
         NetInfo *vss_net = ctx->nets.at(ctx->id("$PACKER_GND")).get();
 
         IdString cell_type = id_SP;
-        if (bw == 36) {
-            cell_type = id_SPX9;
-        }
         IdString name = ctx->idf("%s_AUX", ctx->nameOf(ci));
 
         auto sp_cell = gwu.create_cell(name, cell_type);


### PR DESCRIPTION
This type setting is not needed here - the packer distinguishes memory features by the X9 attribute, which will be correct anyway.