### PR TITLE
gowin: Himbaechel. Handle SDP OCE

### DIFF
--- a/himbaechel/uarch/gowin/pack.cc
+++ b/himbaechel/uarch/gowin/pack.cc
@@ -1395,6 +1395,7 @@ struct GowinPacker
             ci->renamePort(ctx->idf("BLKSELB[%d]", i), ctx->idf("BLKSELB%d", i));
         }
 
+        bsram_handle_sp_oce(ci, id_CEB, id_OCE);
         ci->copyPortTo(id_OCE, ci, id_OCEB);
 
         // Port A


### PR DESCRIPTION
Semi-dual port BSRAM (in Gowin terminology) has the same feature as Single Port - the CE and OCE signals must be synchronized.

Such a sin has not yet been noticed for Dual Port.