### PR TITLE
static: First pass at timing-driven placement

### DIFF
--- a/common/place/placer_static.cc
+++ b/common/place/placer_static.cc
@@ -795,7 +795,19 @@ class StaticPlacer
                          wl_coeff.at(axis) * pd.max_exp.at(axis) * x_max_sum) /
                         (max_sum * max_sum);
             }
-            gradient += (d_min - d_max);
+            float crit = 0.0;
+            if (cfg.timing_driven) {
+                if (port.second.type == PORT_IN) {
+                    crit = tmg.get_criticality(CellPortKey(cell->name, port.first));
+                } else if (port.second.type == PORT_OUT) {
+                    if (ni && ni->users.entries() < 5) {
+                        for (auto usr : ni->users)
+                            crit = std::max(crit, tmg.get_criticality(CellPortKey(usr)));
+                    }
+                }
+            }
+            float weight = 1.0 + 5 * std::pow(crit, 2);
+            gradient += weight * (d_min - d_max);
         }
 
         return gradient;
@@ -975,6 +987,7 @@ class StaticPlacer
                 initial_steplength *= 10;
             }
         }
+        update_timing();
     }
 
     RealPair clamp_loc(RealPair loc)
@@ -1034,6 +1047,26 @@ class StaticPlacer
         update_gradients(true);
         log_info("   system potential: %f hpwl: %f\n", system_potential(), system_hpwl());
         compute_overlap();
+        if ((iter % 5) == 0)
+            update_timing();
+    }
+
+    void update_timing()
+    {
+        if (!cfg.timing_driven)
+            return;
+        for (auto &net : nets) {
+            NetInfo *ni = net.ni;
+            if (ni->driver.cell == nullptr)
+                continue;
+            RealPair drv_loc = cell_loc(ni->driver.cell, false);
+            for (auto usr : ni->users.enumerate()) {
+                RealPair usr_loc = cell_loc(usr.value.cell, false);
+                delay_t est_delay = cfg.timing_c + cfg.timing_mx * std::abs(drv_loc.x - usr_loc.x) + cfg.timing_my * std::abs(drv_loc.y - usr_loc.y);
+                tmg.set_route_delay(CellPortKey(usr.value), DelayPair(est_delay));
+            }
+        }
+        tmg.run(false);
     }
 
     void legalise_step(bool dsp_bram)
@@ -1342,6 +1375,8 @@ class StaticPlacer
             : ctx(ctx), cfg(cfg), fast_bels(ctx, true, 8), tmg(ctx), pool(ctx->setting<int>("threads", 8))
     {
         groups.resize(cfg.cell_groups.size());
+        tmg.setup_only = true;
+        tmg.setup();
     };
     void place()
     {

--- a/ecp5/arch.cc
+++ b/ecp5/arch.cc
@@ -627,6 +627,9 @@ void configure_static(Arch *arch, PlacerStaticCfg &cfg)
         comb.bel_area[id_MULT18X18D] = StaticRect(2.0f, 1.0f);
         comb.spacer_rect = StaticRect(2.0f, 1.0f);
     }
+    cfg.timing_c = (120 - 22 * arch->args.speed) * 6;
+    cfg.timing_mx = (120 - 22 * arch->args.speed);
+    cfg.timing_my = (120 - 22 * arch->args.speed);
 }
 } // namespace
 


### PR DESCRIPTION
A quick and non-scientific test shows about a 10% improvement over plain static on picorv32.