### PR TITLE
Support building nextpnr with nix flakes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ install_manifest.txt
 *.phys
 *.dcp
 *.bit
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1709150264,
+        "narHash": "sha256-HofykKuisObPUfj0E9CJVfaMhawXkYx3G8UIFR/XQ38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9099616b93301d5cf84274b184a3a5ec69e94e08",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  description = "A flake for the nextpnr FPGA place and route tool";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [];
+        };
+        # Define custom overrides or additional packages
+        myPythonPackages = pkgs.python3Packages.override {
+          overrides = self: super: {
+            apycula = super.apycula.override {
+              # Place any necessary overrides here
+            };
+          };
+        };
+        enableGui = false;
+      in
+      {
+        packages = {
+          nextpnr = pkgs.stdenv.mkDerivation {
+            pname = "nextpnr";
+            version = "0.6";
+            src = ./.;
+
+            nativeBuildInputs = [ pkgs.cmake ]
+              ++ (pkgs.lib.optional enableGui pkgs.qt6.wrapQtAppsHook);
+            buildInputs = [
+              (pkgs.boost.override { python = pkgs.python3; enablePython = true; })
+              pkgs.python3
+              pkgs.eigen
+              myPythonPackages.apycula
+              pkgs.icestorm
+              pkgs.trellis
+            ] ++ (pkgs.lib.optional enableGui pkgs.qt6.qtbase)
+              ++ (pkgs.lib.optional pkgs.stdenv.cc.isClang pkgs.llvmPackages.openmp);
+
+            cmakeFlags = [
+              "-DARCH=generic;ice40;ecp5;gowin"
+              "-DBUILD_TESTS=ON"
+              "-DICESTORM_INSTALL_PREFIX=${pkgs.icestorm}"
+              "-DTRELLIS_INSTALL_PREFIX=${pkgs.trellis}"
+              "-DTRELLIS_LIBDIR=${pkgs.trellis}/lib/trellis"
+              "-DGOWIN_BBA_EXECUTABLE=${myPythonPackages.apycula}/bin/gowin_bba"
+              "-DUSE_OPENMP=ON"
+              # warning: high RAM usage
+              "-DSERIALIZE_CHIPDBS=OFF"
+            ] ++ (pkgs.lib.optional enableGui "-DBUILD_GUI=ON");
+
+            meta = with pkgs.lib; {
+              description = "Place and route tool for FPGAs";
+              homepage = "https://github.com/yosyshq/nextpnr";
+              license = licenses.isc;
+              platforms = platforms.all;
+              maintainers = with maintainers; [ thoughtpolice emily ];
+            };
+          };
+        };
+
+        packages.default = self.packages.${system}.nextpnr;
+      });
+}


### PR DESCRIPTION
So far GUI is disabled, because nixpkgs has only qt6, and not qt5.

If enabling the GUI is required, with a little more love it should be doable. 