### PR TITLE
Add NetBSD support.

### DIFF
--- a/common/kernel/command.cc
+++ b/common/kernel/command.cc
@@ -61,7 +61,7 @@
 #include <unistd.h>
 #endif
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__NetBSD__)
 #include <sys/sysctl.h>
 #endif
 
@@ -90,10 +90,14 @@ std::string proc_self_dirname()
         buflen--;
     return std::string(path, buflen);
 }
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__NetBSD__)
 std::string proc_self_dirname()
 {
+#ifdef __NetBSD__
+    int mib[4] = {CTL_KERN, KERN_PROC_ARGS, getpid(), KERN_PROC_PATHNAME};
+#else
     int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
+#endif
     size_t buflen;
     char *buffer;
     std::string path;


### PR DESCRIPTION
Tweak the FreeBSD version of proc_self_dirname() to work on NetBSD and use it.

Resolves issue #1298.