### PR TITLE
Ignore compile artifacts in rust directory

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/


### PR DESCRIPTION
Noticed these appear for rust integration, and there are big number of files in rust/target so best to add it to .gitignore