### PR TITLE
Enable user to override setupArchContext in Himbaechel arch

### DIFF
--- a/himbaechel/himbaechel_api.h
+++ b/himbaechel/himbaechel_api.h
@@ -57,7 +57,9 @@ struct PlacerHeapCfg;
 
 struct HimbaechelAPI
 {
+    // Architecture specific context initialization
     virtual void init(Context *ctx);
+    // Called after context is initialized, but before any commands are executed
     virtual void setupArchContext() {}
     // If constids are being used, this is used to set them up early
     // then it is responsible for loading the db blob with arch->load_chipdb()

--- a/himbaechel/himbaechel_api.h
+++ b/himbaechel/himbaechel_api.h
@@ -58,6 +58,7 @@ struct PlacerHeapCfg;
 struct HimbaechelAPI
 {
     virtual void init(Context *ctx);
+    virtual void setupArchContext() {}
     // If constids are being used, this is used to set them up early
     // then it is responsible for loading the db blob with arch->load_chipdb()
     virtual void init_database(Arch *arch) = 0;

--- a/himbaechel/main.cc
+++ b/himbaechel/main.cc
@@ -33,7 +33,7 @@ class HimbaechelCommandHandler : public CommandHandler
     HimbaechelCommandHandler(int argc, char **argv);
     virtual ~HimbaechelCommandHandler(){};
     std::unique_ptr<Context> createContext(dict<std::string, Property> &values) override;
-    void setupArchContext(Context *ctx) override{};
+    void setupArchContext(Context *ctx) override;
     void customBitstream(Context *ctx) override;
 
   protected:
@@ -57,6 +57,8 @@ po::options_description HimbaechelCommandHandler::getArchOptions()
 
     return specific;
 }
+
+void HimbaechelCommandHandler::setupArchContext(Context *ctx) { ctx->uarch->setupArchContext(); }
 
 void HimbaechelCommandHandler::customBitstream(Context *ctx) {}
 


### PR DESCRIPTION
This enables  Himbaechel uarch to override and implement additional operations on already constructed context, like loading of generated bitstream back to nextpnr