### PR TITLE
Fix path to shared fallback on windows

### DIFF
--- a/common/kernel/command.cc
+++ b/common/kernel/command.cc
@@ -197,7 +197,7 @@ void init_share_dirname()
         npnr_share_dirname = proc_share_path;
         return;
     }
-    proc_share_path = proc_self_path + "..\\share\\";
+    proc_share_path = proc_self_path + "..\\share\\" + "nextpnr\\";
     if (check_file_exists(proc_share_path, true)) {
         npnr_share_dirname = proc_share_path;
         return;

--- a/himbaechel/arch.cc
+++ b/himbaechel/arch.cc
@@ -22,6 +22,7 @@
 #include "chipdb.h"
 #include "log.h"
 #include "nextpnr.h"
+#include <boost/filesystem/convenience.hpp>
 
 #include "command.h"
 #include "placer1.h"
@@ -61,16 +62,11 @@ void Arch::load_chipdb(const std::string &path)
     if (!args.chipdb_override.empty()) {
         db_path = args.chipdb_override;
     } else {
-        std::string separator;
-#if defined(_WIN32)
-        separator = "\\";
-#else
-        separator = "/";
-#endif
         db_path = proc_share_dirname();
-        db_path += "himbaechel";
-        db_path += separator;
+        db_path += "himbaechel/";
         db_path += path;
+        boost::filesystem::path p(db_path);
+        db_path = p.make_preferred().string();
     }
     try {
         blob_file.open(db_path);

--- a/himbaechel/arch.cc
+++ b/himbaechel/arch.cc
@@ -22,7 +22,7 @@
 #include "chipdb.h"
 #include "log.h"
 #include "nextpnr.h"
-#include <boost/filesystem/convenience.hpp>
+#include <boost/filesystem/path.hpp>
 
 #include "command.h"
 #include "placer1.h"

--- a/himbaechel/arch.cc
+++ b/himbaechel/arch.cc
@@ -61,8 +61,15 @@ void Arch::load_chipdb(const std::string &path)
     if (!args.chipdb_override.empty()) {
         db_path = args.chipdb_override;
     } else {
+        std::string separator;
+#if defined(_WIN32)
+        separator = "\\";
+#else
+        separator = "/";
+#endif
         db_path = proc_share_dirname();
-        db_path += "/himbaechel/";
+        db_path += "himbaechel";
+        db_path += separator;
         db_path += path;
     }
     try {

--- a/himbaechel/uarch/gowin/gowin.cc
+++ b/himbaechel/uarch/gowin/gowin.cc
@@ -128,17 +128,7 @@ void GowinImpl::init_database(Arch *arch)
         }
     }
 
-    char separator;
-#if defined(_WIN32)
-    separator = '\\';
-#else
-    separator = '/';
-#endif
-    arch->load_chipdb(stringf(
-        "gowin%cchipdb-%s.bin",
-        separator,
-        family.c_str()
-    ));
+    arch->load_chipdb(stringf("gowin/chipdb-%s.bin", family.c_str()));
 
     // These fields go in the header of the output JSON file and can help
     // gowin_pack support different architectures

--- a/himbaechel/uarch/gowin/gowin.cc
+++ b/himbaechel/uarch/gowin/gowin.cc
@@ -128,7 +128,17 @@ void GowinImpl::init_database(Arch *arch)
         }
     }
 
-    arch->load_chipdb(stringf("gowin/chipdb-%s.bin", family.c_str()));
+    char separator;
+#if defined(_WIN32)
+    separator = '\\';
+#else
+    separator = '/';
+#endif
+    arch->load_chipdb(stringf(
+        "gowin%cchipdb-%s.bin",
+        separator,
+        family.c_str()
+    ));
 
     // These fields go in the header of the output JSON file and can help
     // gowin_pack support different architectures


### PR DESCRIPTION
The nextpnr directory was missing from the fallback shared directory on windows only causing the chip db to not be found when using nextpnr-himbaechel through OSS-Cad-suite