### PR TITLE
Fixed header files for boost 1.85.0

### DIFF
--- a/bba/main.cc
+++ b/bba/main.cc
@@ -19,7 +19,7 @@
  */
 
 #include <assert.h>
-#include <boost/filesystem/convenience.hpp>
+#include <boost/filesystem/path.hpp>
 #include <boost/program_options.hpp>
 #include <iostream>
 #include <map>

--- a/common/kernel/command.cc
+++ b/common/kernel/command.cc
@@ -29,7 +29,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/join.hpp>
-#include <boost/filesystem/convenience.hpp>
+#include <boost/filesystem/path.hpp>
 #include <boost/program_options.hpp>
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
nextpnr does not compile with the newest boost version 1.85.0 because the header file "boost/filesystem/convenience.hpp" does not exist anymore (removed because of deprecation). See

https://www.boost.org/users/history/version_1_85_0.html

This pull request replaces convenience.hpp with the correct header file.
