### PR TITLE
ice40: Fix Python bindings for pip iterators

### DIFF
--- a/ice40/arch_pybindings.cc
+++ b/ice40/arch_pybindings.cc
@@ -81,8 +81,8 @@ void arch_wrap_python(py::module &m)
     readonly_wrapper<BelPin, decltype(&BelPin::bel), &BelPin::bel, conv_to_str<BelId>>::def_wrap(belpin_cls, "bel");
     readonly_wrapper<BelPin, decltype(&BelPin::pin), &BelPin::pin, conv_to_str<IdString>>::def_wrap(belpin_cls, "pin");
 
-    typedef const PipRange UphillPipRange;
-    typedef const PipRange DownhillPipRange;
+    typedef PipRange UphillPipRange;
+    typedef PipRange DownhillPipRange;
 
     typedef const std::vector<BelBucketId> &BelBucketRange;
     typedef const std::vector<BelId> &BelRangeForBelBucket;


### PR DESCRIPTION
It seems that the pip iterator types should not be declared `const` to allow mapping the retun type of  `ctx.getPipsDownhill(...` `ctx.getPipsUphill(..`  to python types.

Same as:

- 52b02f7377a1fc88a7e1678e57af803f4d1bcc0c
- 6ee3daf06a4f1d1f26c2bf9a328bff726e5a12ea
- bd525d3548df30b5e4831348fdad7fe5fd5180c2