### PR TITLE
Nexus: Allow LFD2NX devices to be specified

### DIFF
--- a/nexus/arch.cc
+++ b/nexus/arch.cc
@@ -48,7 +48,7 @@ void IdString::initialize_arch(const BaseCtx *ctx)
 Arch::Arch(ArchArgs args) : args(args)
 {
     // Parse device string
-    if (boost::starts_with(args.device, "LIFCL")) {
+    if (boost::starts_with(args.device, "LIFCL") || boost::starts_with(args.device, "LFD2NX")) {
         family = "LIFCL";
     } else {
         log_error("Unknown device string '%s' (expected device name like 'LIFCL-40-8SG72C')\n", args.device.c_str());


### PR DESCRIPTION
While `nextpnr-nexus --list-devices` shows several LFD2NX parts, the check in `arch.cc` prevents them from being passed to `--device`.

This PR treats them as the same family as the LIFCL parts as is done in the database.