### PR TITLE
Fix handling of RNG seed

### DIFF
--- a/common/kernel/command.cc
+++ b/common/kernel/command.cc
@@ -343,7 +343,7 @@ po::options_description CommandHandler::getGeneralOptions()
     general.add_options()("json", po::value<std::string>(), "JSON design file to ingest");
     general.add_options()("write", po::value<std::string>(), "JSON design file to write");
     general.add_options()("top", po::value<std::string>(), "name of top module");
-    general.add_options()("seed", po::value<int>(), "seed value for random number generator");
+    general.add_options()("seed", po::value<uint64_t>(), "seed value for random number generator");
     general.add_options()("randomize-seed,r", "randomize seed value for random number generator");
 
     general.add_options()(
@@ -447,7 +447,7 @@ void CommandHandler::setupContext(Context *ctx)
     }
 
     if (vm.count("seed")) {
-        ctx->rngseed(vm["seed"].as<int>());
+        ctx->rngstate = vm["seed"].as<uint64_t>();
     }
 
     if (vm.count("threads")) {
@@ -456,10 +456,10 @@ void CommandHandler::setupContext(Context *ctx)
 
     if (vm.count("randomize-seed")) {
         std::random_device randDev{};
-        std::uniform_int_distribution<int> distrib{1};
+        std::uniform_int_distribution<uint64_t> distrib{1};
         auto seed = distrib(randDev);
-        ctx->rngseed(seed);
-        log_info("Generated random seed: %d\n", seed);
+        ctx->rngstate = seed;
+        log_info("Generated random seed: %lu\n", seed);
     }
 
     if (vm.count("slack_redist_iter")) {
@@ -565,7 +565,7 @@ void CommandHandler::setupContext(Context *ctx)
 
     ctx->settings[ctx->id("arch.name")] = std::string(ctx->archId().c_str(ctx));
     ctx->settings[ctx->id("arch.type")] = std::string(ctx->archArgsToId(ctx->archArgs()).c_str(ctx));
-    ctx->settings[ctx->id("seed")] = ctx->rngstate;
+    ctx->settings[ctx->id("seed")] = Property(ctx->rngstate, 64);
 
     if (ctx->settings.find(ctx->id("placerHeap/alpha")) == ctx->settings.end())
         ctx->settings[ctx->id("placerHeap/alpha")] = std::to_string(0.1);


### PR DESCRIPTION
Hi,

There are a couple of problems with the handling of the RNG seed.

First, the seed value used for the deterministic RNG is being truncated from 64 bits to 32 (int instead of uint64) when written to the header of the output JSON file.

When using the --seed option on the command line, the argument needs to be a signed value.

If using the --seed or --randomize-seed option, it is not the originally supplied or randomized seed value that is written to the output JSON file, but a value that has been run through the rngseed() function, which permutes the value before it is stored and then used for the output JSON file.

This patch fixes these problems.

Regards
Jonas