### PR TITLE
apicula: add support for magic sip pins

### DIFF
--- a/himbaechel/chipdb.h
+++ b/himbaechel/chipdb.h
@@ -138,6 +138,7 @@ NPNR_PACKED_STRUCT(struct PadInfoPOD {
 NPNR_PACKED_STRUCT(struct PackageInfoPOD {
     int32_t name;
     RelSlice<PadInfoPOD> pads;
+    RelPtr<uint8_t> extra_data;
 });
 
 NPNR_PACKED_STRUCT(struct TileInstPOD {

--- a/himbaechel/himbaechel_dbgen/chip.py
+++ b/himbaechel/himbaechel_dbgen/chip.py
@@ -411,6 +411,7 @@ class PackageInfo(BBAStruct):
     strs: StringPool
     name: IdString
     pads: list[int] = field(default_factory=list)
+    extra_data: object = None
 
     def create_pad(self, package_pin: str, tile: str, bel: str, pad_function: str, pad_bank: int, flags: int = 0):
         pad = PadInfo(package_pin = self.strs.id(package_pin), tile = self.strs.id(tile), bel = self.strs.id(bel),
@@ -424,10 +425,18 @@ class PackageInfo(BBAStruct):
         bba.label(f"{context}_pads")
         for i, pad in enumerate(self.pads):
             pad.serialise(f"{context}_pad{i}", bba)
+        if self.extra_data is not None:
+            self.extra_data.serialise_lists(f"{context}_extra_data", bba)
+            bba.label(f"{context}_extra_data")
+            self.extra_data.serialise(f"{context}_extra_data", bba)
 
     def serialise(self, context: str, bba: BBAWriter):
         bba.u32(self.name.index)
         bba.slice(f"{context}_pads", len(self.pads))
+        if self.extra_data is not None:
+            bba.ref(f"{context}_extra_data")
+        else:
+            bba.u32(0)
 
 class TimingValue(BBAStruct):
     def __init__(self, fast_min=0, fast_max=None, slow_min=None, slow_max=None):

--- a/himbaechel/uarch/gowin/cst.cc
+++ b/himbaechel/uarch/gowin/cst.cc
@@ -240,8 +240,31 @@ struct GowinCstReader
     }
 };
 
+
+void add_sip_constraints(Context *ctx, const Extra_package_data_POD *extra) {
+    for(auto cst : extra->cst) {
+        auto it = ctx->cells.find(IdString(cst.net));
+        if (it == ctx->cells.end()) {
+            log_info("Cell %s not found\n", IdString(cst.net).c_str(ctx));
+            continue;
+        }
+        Loc loc = Loc(cst.col, cst.row, cst.bel);
+        BelId bel = ctx->getBelByLocation(loc);
+        if (bel == BelId()) {
+            log_error("Pin not found.\n");
+        }
+        it->second->setAttr(IdString(ID_BEL), std::string(ctx->nameOfBel(bel)));
+    }
+}
+
 bool gowin_apply_constraints(Context *ctx, std::istream &in)
 {
+    // implicit constraints from SiP pins
+    const Extra_package_data_POD *extra = reinterpret_cast<const Extra_package_data_POD *>(ctx->package_info->extra_data.get());
+    if(extra != nullptr) {
+        add_sip_constraints(ctx, extra);
+    }
+
     GowinCstReader reader(ctx, in);
     return reader.run();
 }

--- a/himbaechel/uarch/gowin/gowin.h
+++ b/himbaechel/uarch/gowin/gowin.h
@@ -130,6 +130,17 @@ NPNR_PACKED_STRUCT(struct Wire_bel_POD {
     int32_t side;
 });
 
+NPNR_PACKED_STRUCT(struct Constraint_POD {
+    int32_t net;
+    int32_t row;
+    int32_t col;
+    int32_t bel;
+});
+
+NPNR_PACKED_STRUCT(struct Extra_package_data_POD {
+    RelSlice<Constraint_POD> cst;
+});
+
 NPNR_PACKED_STRUCT(struct Extra_chip_data_POD {
     int32_t chip_flags;
     Bottom_io_POD bottom_io;


### PR DESCRIPTION
While we have documented the sdram pins of some devices we lack the ability to automatically place them like the vendor tools do. For better compatibility and user friendliness this PR adds the ability to constrain these magic pin locations.

It seems to load the constraints but I have yet to test if sdram actually functions, which isn't super trivial.