### PR TITLE
Add flag to restart place-and-route on failed target frequency

### DIFF
--- a/common/kernel/context.h
+++ b/common/kernel/context.h
@@ -38,6 +38,8 @@ struct Context : Arch, DeterministicRNG
     bool disable_critical_path_source_print = false;
     // True when detailed per-net timing is to be stored / reported
     bool detailed_timing_report = false;
+    // Default to true, will update when timing analysis is run
+    bool target_frequency_achieved = true;
 
     ArchArgs arch_args;
 

--- a/common/kernel/timing.cc
+++ b/common/kernel/timing.cc
@@ -1339,6 +1339,16 @@ void timing_analysis(Context *ctx, bool print_slack_histogram, bool print_fmax, 
 
     if (update_results)
         ctx->timing_result = result;
+
+    ctx->target_frequency_achieved = true;
+    for (auto &clock : result.clock_paths) {
+        float fmax = result.clock_fmax[clock.first].achieved;
+        float target = result.clock_fmax[clock.first].constraint;
+        bool passed = target < fmax;
+        if (!passed) {
+            ctx->target_frequency_achieved = false;
+        }
+    }
 }
 
 NEXTPNR_NAMESPACE_END


### PR DESCRIPTION
* Add --restart-on-failed-target-frequency flag and logic to restart the place-and-route process if the target frequency is not achieved.

* This flag is intended to be used with the --randomize-seed option to generate a new random seed for every run. This can significantly improve the chances of achieving a higher clock frequency compared to using the default seed.

* Move print_net_source out of log_crit_paths() to remove the 'static' keyword, which could otherwise cause a segmentation fault if the context is changed.