### PR TITLE
ice40: Fix missing clock pin types

### DIFF
--- a/ice40/cells.cc
+++ b/ice40/cells.cc
@@ -521,6 +521,10 @@ bool is_clock_port(const BaseCtx *ctx, const PortRef &port)
         return port.port == id_CLK;
     if (is_sb_spram(ctx, port.cell) || port.cell->type == id_ICESTORM_SPRAM)
         return port.port == id_CLOCK;
+    if (is_sb_i2c(ctx, port.cell) || is_sb_spi(ctx, port.cell))
+        return port.port == id_SBCLKI;
+    if (is_sb_ledda_ip(ctx, port.cell))
+        return port.port == id_LEDDCLK;
     if (is_sb_io(ctx, port.cell))
         return port.port.in(id_INPUT_CLK, id_OUTPUT_CLK);
     return false;


### PR DESCRIPTION
I spotted in #1379 an unexpected cross-clock path showing up that the hard IP clock pins had been missed and weren't being driven through the global buffer network.

Maybe this even fixes some (but not all, there are also design issues in them reproducible in icestorm/sim models) of the weird issues people have seen over these years with these IPs...

This does fix the crash in #1379, but there's also no reason that the cross-clock path should crash timing analysis, so there's still something there for @rowanG077 to look into too.