### PR TITLE
timing_log: Handle potentially missing net when reporting crit path

### DIFF
--- a/common/kernel/timing_log.cc
+++ b/common/kernel/timing_log.cc
@@ -106,6 +106,10 @@ static void log_crit_paths(const Context *ctx, TimingResult &result)
                 log_info("                         Sink %s.%s\n", segment.to.first.c_str(ctx),
                          segment.to.second.c_str(ctx));
 
+                // CLK_TO_CLK has no net and CLK_SKEW might have a net
+                if (ctx->nets.count(segment.net) == 0) {
+                    continue;
+                }
                 const NetInfo *net = ctx->nets.at(segment.net).get();
 
                 if (ctx->verbose) {


### PR DESCRIPTION
Caused by the original code path only handling routing which always has a net. Now with the additional clock delay reporting a net is not always available depending on exactly where it came from. Which lead to a faulty lookup. 

Together with https://github.com/YosysHQ/nextpnr/pull/1380 fixes https://github.com/YosysHQ/nextpnr/issues/1379. 