### PR TITLE
Fix RNG seed initialization when passed as a parameter

### DIFF
--- a/common/kernel/command.cc
+++ b/common/kernel/command.cc
@@ -427,7 +427,7 @@ void script_terminate_handler()
 void CommandHandler::setupContext(Context *ctx)
 {
     if (ctx->settings.find(ctx->id("seed")) != ctx->settings.end())
-        ctx->rngstate = ctx->setting<uint64_t>("seed");
+        ctx->rngseed(ctx->setting<uint64_t>("seed"));
 
     if (vm.count("verbose")) {
         ctx->verbose = true;
@@ -447,7 +447,7 @@ void CommandHandler::setupContext(Context *ctx)
     }
 
     if (vm.count("seed")) {
-        ctx->rngstate = vm["seed"].as<uint64_t>();
+        ctx->rngseed(vm["seed"].as<uint64_t>());
     }
 
     if (vm.count("threads")) {


### PR DESCRIPTION
Fixes the `rngstate` assignment for `DeterministicRNG` when the seed is passed as a parameter. Assigning a seed of zero should be avoided as it leads to a constant zero output that can cause infinite loops, e.g., https://github.com/YosysHQ/nextpnr/blob/7c459805f63c07c44f22e46fbd08734da2578db8/common/place/placer_static.cc#L380-L381