### PR TITLE
cmake: Use upstream BoostConfig.cmake instead of cmake's own

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,6 @@ else()
     set(BBASM_MODE "string")
 endif()
 
-set(Boost_NO_BOOST_CMAKE ON)
-
 find_package(Threads)
 if (Threads_FOUND)
     find_package(TBB QUIET)


### PR DESCRIPTION
Fixes #1384 

This seems to be a very old workaround forcing it to use the old approach that hopefully isn't needed any more on any of the systems we support.