### PR TITLE
Add expandBoundingBox method to API

### DIFF
--- a/common/kernel/arch_api.h
+++ b/common/kernel/arch_api.h
@@ -147,6 +147,9 @@ template <typename R> struct ArchAPI : BaseCtx
     virtual bool isClusterStrict(const CellInfo *cell) const = 0;
     virtual bool getClusterPlacement(ClusterId cluster, BelId root_bel,
                                      std::vector<std::pair<CellInfo *, BelId>> &placement) const = 0;
+    // Routing methods
+    virtual void expandBoundingBox(BoundingBox &bb) const = 0;
+
     // Flow methods
     virtual bool pack() = 0;
     virtual bool place() = 0;

--- a/common/kernel/base_arch.h
+++ b/common/kernel/base_arch.h
@@ -442,6 +442,14 @@ template <typename R> struct BaseArch : ArchAPI<R>
         });
     }
 
+    // Routing methods
+    virtual void expandBoundingBox(BoundingBox &bb) const override {
+        bb.x0 = std::max(bb.x0 - 1, 0);
+        bb.y0 = std::max(bb.y0 - 1, 0);
+        bb.x1 = std::min(bb.x1 + 1, this->getGridDimX());
+        bb.y1 = std::min(bb.y1 + 1, this->getGridDimY());
+    }
+
     // Flow methods
     virtual void assignArchInfo() override {};
 

--- a/common/route/router2.cc
+++ b/common/route/router2.cc
@@ -1013,14 +1013,7 @@ struct Router2
             ++net_data.fail_count;
             if ((net_data.fail_count % 3) == 0) {
                 // Every three times a net fails to route, expand the bounding box to increase the search space
-#ifndef ARCH_MISTRAL
-                // This patch seems to make thing worse for CycloneV, as it slows down the resolution of TD congestion,
-                // disable it
-                net_data.bb.x0 = std::max(net_data.bb.x0 - 1, 0);
-                net_data.bb.y0 = std::max(net_data.bb.y0 - 1, 0);
-                net_data.bb.x1 = std::min(net_data.bb.x1 + 1, ctx->getGridDimX());
-                net_data.bb.y1 = std::min(net_data.bb.y1 + 1, ctx->getGridDimY());
-#endif
+                ctx->expandBoundingBox(net_data.bb);
             }
         }
     }

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -771,4 +771,6 @@ Router Methods
 
 ### void expandBoundingBox(BoundingBox &bb) const
 
-Updates bounding box to expand search space when routing is failing to find possible route.
+As part of `router2` implementation, during congestion update, every third time a net fails to route, this method is executed to expand the bounding box to increase the search space.
+
+Default implementation expands by one tile in each direction.

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -765,3 +765,10 @@ Returns `true` if the cell **must** be placed according to the cluster; for exam
 Gets an exact placement of the cluster, with the root cell placed on or near `root_bel` (and always within the same tile). Returns false if no placement is viable, otherwise returns `true` and populates `placement` with a list of cells inside the cluster and bels they should be placed at.
 
 This approach of allowing architectures to define cluster placements enables easier handling of irregular fabrics than requiring strict and constant x, y and z offsets.
+
+Router Methods
+---------------
+
+### void expandBoundingBox(BoundingBox &bb) const
+
+Updates bounding box to expand search space when routing is failing to find possible route.

--- a/himbaechel/arch.h
+++ b/himbaechel/arch.h
@@ -708,6 +708,10 @@ struct Arch : BaseArch<ArchRanges>
     DecalXY getGroupDecal(GroupId group) const override;
 
     // ------------------------------------------------
+    // Routing methods
+    void expandBoundingBox(BoundingBox &bb) const override { uarch->expandBoundingBox(bb); };
+
+    // ------------------------------------------------
 
     bool pack() override;
     bool place() override;

--- a/himbaechel/himbaechel_api.cc
+++ b/himbaechel/himbaechel_api.cc
@@ -85,6 +85,11 @@ bool HimbaechelAPI::getClusterPlacement(ClusterId cluster, BelId root_bel,
     return ctx->BaseArch::getClusterPlacement(cluster, root_bel, placement);
 }
 
+void HimbaechelAPI::expandBoundingBox(BoundingBox &bb) const
+{
+    ctx->BaseArch::expandBoundingBox(bb);
+}
+
 HimbaechelArch *HimbaechelArch::list_head;
 HimbaechelArch::HimbaechelArch(const std::string &name) : name(name)
 {

--- a/himbaechel/himbaechel_api.h
+++ b/himbaechel/himbaechel_api.h
@@ -114,6 +114,8 @@ struct HimbaechelAPI
     virtual void drawPip(std::vector<GraphicElement> &g,GraphicElement::style_t style, Loc loc,
                 WireId src, IdString src_type, int32_t src_id, WireId dst, IdString dst_type, int32_t dst_id) {};
 
+    // Routing methods
+    virtual void expandBoundingBox(BoundingBox &bb) const;
     // --- Flow hooks ---
     virtual void pack() {}; // replaces the pack function
     // Called before and after main placement and routing

--- a/mistral/arch.h
+++ b/mistral/arch.h
@@ -451,6 +451,10 @@ struct Arch : BaseArch<ArchRanges>
     BelBucketId getBelBucketForBel(BelId bel) const override;
 
     // -------------------------------------------------
+    // Expanding bounding box seems to make thing worse for CycloneV
+    // as it slows down the resolution of TD congestion, disabling it
+    void expandBoundingBox(BoundingBox &bb) const override {};
+    // -------------------------------------------------
 
     void assignArchInfo() override;
     bool pack() override;


### PR DESCRIPTION
Add expandBoundingBox method to main nextpnr API and Himbaechel API to be able to handle architectures and uarch that have different needs for expanding bound box.

Used oportunity to remove Mistral specifics in router2.cc and move it into architecture specific file.