### PR TITLE
Add attributes to the hierarchical cells

### DIFF
--- a/common/kernel/nextpnr_types.h
+++ b/common/kernel/nextpnr_types.h
@@ -519,6 +519,8 @@ struct HierarchicalCell
     dict<IdString, HierarchicalPort> ports;
     // Name inside cell instance -> global name
     dict<IdString, IdString> hier_cells;
+    // Cell attributes
+    dict<IdString, Property> attrs;
 };
 
 NEXTPNR_NAMESPACE_END

--- a/common/kernel/pybindings.cc
+++ b/common/kernel/pybindings.cc
@@ -283,6 +283,9 @@ PYBIND11_EMBEDDED_MODULE(MODULE_NAME, m)
                      wrap_context<IdIdMap &>>::def_wrap(hierarchy_cls, "nets");
     readonly_wrapper<HierarchicalCell &, decltype(&HierarchicalCell::hier_cells), &HierarchicalCell::hier_cells,
                      wrap_context<IdIdMap &>>::def_wrap(hierarchy_cls, "hier_cells");
+    readonly_wrapper<HierarchicalCell &, decltype(&HierarchicalCell::attrs), &HierarchicalCell::attrs,
+                     wrap_context<AttrMap &>>::def_wrap(hierarchy_cls, "attrs");
+
     WRAP_MAP(m, AttrMap, conv_to_str<Property>, "AttrMap");
     WRAP_MAP(m, PortMap, wrap_context<PortInfo &>, "PortMap");
     WRAP_MAP(m, IdIdMap, conv_to_str<IdString>, "IdIdMap");

--- a/frontend/frontend_base.h
+++ b/frontend/frontend_base.h
@@ -535,6 +535,9 @@ template <typename FrontendType> struct GenericFrontend
         // Do the submodule import
         auto type = impl.get_cell_type(cd);
         import_module(submod, name, type, mod_refs.at(type));
+        // Add current cell attributes to the imported module
+        impl.foreach_attr( cd, [&](const std::string &name, const Property &value)
+              { ctx->hierarchy[submod.path].attrs[ctx->id(name)] = value; } );
     }
 
     // Import the cells section of a module


### PR DESCRIPTION
Hi,

I did not find a way to retrieve attributes (assigned in the verilog) of hierarchical cells even though yosys preserves them in the json netlist.

This patch adds an "attrs" dictionary to the HierarchicalCell structure and expose it through the python bindings.

Those attributes are imported in the front end after the import of the submodule.

This last point I am not sure of and maybe I am not doing this correctly/efficietly.

I wanted to add this feature to mimic the behavior of Xilinx's LOC/RLOC attributes where, in a hierarchy, you can assign a relative location to primitive cells within a module and a global location for instances of this module.