### PR TITLE
Fix gowin ALU SUB mode ports

### DIFF
--- a/himbaechel/uarch/gowin/pack.cc
+++ b/himbaechel/uarch/gowin/pack.cc
@@ -1423,6 +1423,12 @@ struct GowinPacker
                             ci->renamePort(id_I0, id_I3);
                             ci->renamePort(id_I2, id_I0);
                         }
+                        // XXX mode 1 - SUB
+                        else if (ci->params.at(id_ALU_MODE).as_int64() == 1) {
+                            ci->renamePort(id_I3, id_I2);
+                            ci->renamePort(id_I1, id_I3);
+                            ci->renamePort(id_I2, id_I1);
+                        }
                         // XXX I2 is pin C which must be set to 1 for all ALU modes except MUL
                         // we use only mode 2 ADDSUB so create and connect this pin
                         ci->addInput(id_I2);


### PR DESCRIPTION
By examining the output of `nextpnr`, I see an `ALU` in mode 1 (`SUB`) is wired like this:

```
Verilog I0    I0
Verilog I1    I1
Verilog I3    I3
```

When parsed by `gowin_pack`, this would result in an `ALU` that computes `I0 - I3`.
This PR swaps ports `I1` and `I3` to produce the following (verified in `nextpnr` output):

```
Verilog I0    I0
Verilog I1    I3
Verilog I3    I1
```

This matches Apicula documentation, as well as `ADDSUB` ports.
Can't test on real hardware at the time (used my Tang Nano 1K and 20K on a project, haven't ordered replacement yet).