### PR TITLE
Find all components of Python at the same time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_policy(SET CMP0079 NEW)
 # compilation database as not all clang/gcc share the same implicit includes
 # leading to essentially non-working compile_commands.json
 if(CMAKE_EXPORT_COMPILE_COMMANDS)
-  set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES 
+  set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES
       ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 endif()
 
@@ -191,11 +191,11 @@ if (BUILD_GUI)
     set(CMAKE_ENABLE_EXPORTS ON)
 endif()
 
-find_package(Python3 3.5 REQUIRED COMPONENTS Interpreter)
 if (BUILD_PYTHON)
     # TODO: sensible minimum Python version
-    find_package(Python3 3.5 REQUIRED COMPONENTS Development)
+    find_package(Python3 3.5 REQUIRED COMPONENTS Interpreter Development.Embed)
 else()
+    find_package(Python3 3.5 REQUIRED COMPONENTS Interpreter)
     add_definitions("-DNO_PYTHON")
 endif()
 

--- a/ecp5/CMakeLists.txt
+++ b/ecp5/CMakeLists.txt
@@ -9,8 +9,6 @@ message(STATUS "Enabled ECP5 devices: ${ECP5_DEVICES}")
 if(DEFINED ECP5_CHIPDB)
     add_custom_target(chipdb-ecp5-bbas ALL)
 else()
-    find_package(Python3 3.5 REQUIRED COMPONENTS Interpreter)
-
     # shared among all families
     set(SERIALIZE_CHIPDBS TRUE CACHE BOOL
         "Serialize device data preprocessing to minimize memory use")

--- a/himbaechel/uarch/gowin/CMakeLists.txt
+++ b/himbaechel/uarch/gowin/CMakeLists.txt
@@ -2,7 +2,6 @@ message(STATUS "Configuring Himbaechel-Gowin uarch")
 cmake_minimum_required(VERSION 3.5)
 project(himbaechel-gowin-chipdb NONE)
 
-find_package(Python3 3.5 REQUIRED COMPONENTS Interpreter)
 set(ALL_HIMBAECHEL_GOWIN_DEVICES GW1N-1 GW1NZ-1 GW1N-4 GW1N-9 GW1N-9C GW1NS-4 GW2A-18 GW2A-18C)
 set(HIMBAECHEL_GOWIN_DEVICES "" CACHE STRING
     "Include support for these Gowin devices (available: ${ALL_HIMBAECHEL_GOWIN_DEVICES})")

--- a/ice40/CMakeLists.txt
+++ b/ice40/CMakeLists.txt
@@ -9,8 +9,6 @@ message(STATUS "Enabled iCE40 devices: ${ICE40_DEVICES}")
 if(DEFINED ICE40_CHIPDB)
     add_custom_target(chipdb-ice40-bbas ALL)
 else()
-    find_package(Python3 3.5 REQUIRED COMPONENTS Interpreter)
-
     # shared among all families
     set(SERIALIZE_CHIPDBS TRUE CACHE BOOL
         "Serialize device data preprocessing to minimize memory use")

--- a/machxo2/CMakeLists.txt
+++ b/machxo2/CMakeLists.txt
@@ -9,8 +9,6 @@ message(STATUS "Enabled MachXO2/XO3 devices: ${MACHXO2_DEVICES}")
 if(DEFINED MACHXO2_CHIPDB)
     add_custom_target(chipdb-machxo2-bbas ALL)
 else()
-    find_package(Python3 3.5 REQUIRED COMPONENTS Interpreter)
-
     # shared among all families
     set(SERIALIZE_CHIPDBS TRUE CACHE BOOL
         "Serialize device data preprocessing to minimize memory use")


### PR DESCRIPTION
This is explicitly recommended by the FindPython module documentation and is required to avoid failed builds on some systems. See: https://cmake.org/cmake/help/latest/module/FindPython.html

See also https://github.com/YosysHQ/prjtrellis/pull/243.