### PR TITLE
Various fixes for clang/libc++ build

### DIFF
--- a/common/kernel/command.cc
+++ b/common/kernel/command.cc
@@ -35,6 +35,7 @@
 #include <iostream>
 #include <random>
 #include <set>
+#include <cinttypes>
 
 #include "command.h"
 #include "design_utils.h"
@@ -459,7 +460,7 @@ void CommandHandler::setupContext(Context *ctx)
         std::uniform_int_distribution<uint64_t> distrib{1};
         auto seed = distrib(randDev);
         ctx->rngstate = seed;
-        log_info("Generated random seed: %lu\n", seed);
+        log_info("Generated random seed: %" PRIu64 "\n", seed);
     }
 
     if (vm.count("slack_redist_iter")) {

--- a/himbaechel/uarch/example/example.cc
+++ b/himbaechel/uarch/example/example.cc
@@ -194,7 +194,7 @@ struct ExampleImpl : HimbaechelAPI
     }
 
     void drawWire(std::vector<GraphicElement> &g, GraphicElement::style_t style, Loc loc, IdString wire_type,
-                  int32_t tilewire, IdString tile_type)
+                  int32_t tilewire, IdString tile_type) override
     {
         GraphicElement el;
         el.type = GraphicElement::TYPE_LINE;
@@ -308,7 +308,7 @@ struct ExampleImpl : HimbaechelAPI
     }
 
     void drawPip(std::vector<GraphicElement> &g, GraphicElement::style_t style, Loc loc, WireId src, IdString src_type,
-                 int32_t src_id, WireId dst, IdString dst_type, int32_t dst_id)
+                 int32_t src_id, WireId dst, IdString dst_type, int32_t dst_id) override
     {
         GraphicElement el;
         el.type = GraphicElement::TYPE_ARROW;
@@ -329,7 +329,7 @@ struct ExampleArch : HimbaechelArch
 {
     ExampleArch() : HimbaechelArch("example") {};
     bool match_device(const std::string &device) override { return device == "EXAMPLE"; }
-    std::unique_ptr<HimbaechelAPI> create(const std::string &device, const dict<std::string, std::string> &args)
+    std::unique_ptr<HimbaechelAPI> create(const std::string &device, const dict<std::string, std::string> &args) override
     {
         return std::make_unique<ExampleImpl>();
     }

--- a/himbaechel/uarch/gowin/gowin.cc
+++ b/himbaechel/uarch/gowin/gowin.cc
@@ -1,4 +1,5 @@
 #include <regex>
+#include <map>
 
 #include "himbaechel_api.h"
 #include "himbaechel_helpers.h"

--- a/himbaechel/uarch/gowin/gowin.cc
+++ b/himbaechel/uarch/gowin/gowin.cc
@@ -44,9 +44,9 @@ struct GowinImpl : HimbaechelAPI
     bool checkPipAvail(PipId pip) const override;
 
     // Cluster
-    bool isClusterStrict(const CellInfo *cell) const { return true; }
+    bool isClusterStrict(const CellInfo *cell) const override { return true; }
     bool getClusterPlacement(ClusterId cluster, BelId root_bel,
-                             std::vector<std::pair<CellInfo *, BelId>> &placement) const;
+                             std::vector<std::pair<CellInfo *, BelId>> &placement) const override;
 
   private:
     HimbaechelHelpers h;
@@ -110,7 +110,7 @@ struct GowinArch : HimbaechelArch
 
     bool match_device(const std::string &device) override { return device.size() > 2 && device.substr(0, 2) == "GW"; }
 
-    std::unique_ptr<HimbaechelAPI> create(const std::string &device, const dict<std::string, std::string> &args)
+    std::unique_ptr<HimbaechelAPI> create(const std::string &device, const dict<std::string, std::string> &args) override
     {
         return std::make_unique<GowinImpl>();
     }

--- a/himbaechel/uarch/gowin/pack.cc
+++ b/himbaechel/uarch/gowin/pack.cc
@@ -1740,7 +1740,7 @@ struct GowinPacker
                     }
                     // always prepend first ALU with carry generator block
                     // three cases: CIN == 0, CIN == 1 and CIN == ?
-                    new_cells.push_back(std::move(alu_add_cin_block(ctx, ci, cin_net)));
+                    new_cells.push_back(alu_add_cin_block(ctx, ci, cin_net));
                     CellInfo *cin_block_ci = new_cells.back().get();
                     // CIN block is the cluster root and is always placed in ALU0
                     // This is a possible place for further optimization
@@ -1786,7 +1786,7 @@ struct GowinPacker
                             break;
                         }
                         if (CellTypePort(*cout_net->users.begin()) != cell_alu_cin || cout_net->users.entries() > 1) {
-                            new_cells.push_back(std::move(alu_add_cout_block(ctx, ci, cout_net)));
+                            new_cells.push_back(alu_add_cout_block(ctx, ci, cout_net));
                             CellInfo *cout_block_ci = new_cells.back().get();
                             cin_block_ci->constr_children.push_back(cout_block_ci);
                             NPNR_ASSERT(cout_block_ci->cluster == ClusterId());
@@ -1809,7 +1809,7 @@ struct GowinPacker
                     // ALUs are always paired
                     if (alu_chain_len & 1) {
                         // create dummy cell
-                        new_cells.push_back(std::move(alu_add_dummy_block(ctx, ci)));
+                        new_cells.push_back(alu_add_dummy_block(ctx, ci));
                         CellInfo *dummy_block_ci = new_cells.back().get();
                         cin_block_ci->constr_children.push_back(dummy_block_ci);
                         NPNR_ASSERT(dummy_block_ci->cluster == ClusterId());
@@ -1909,7 +1909,7 @@ struct GowinPacker
 
                 // make actual storage cells
                 for (int i = 0; i < 4; ++i) {
-                    new_cells.push_back(std::move(ssram_make_lut(ctx, ci, i)));
+                    new_cells.push_back(ssram_make_lut(ctx, ci, i));
                     CellInfo *lut_ci = new_cells.back().get();
                     ci->constr_children.push_back(lut_ci);
                     lut_ci->cluster = ci->name;

--- a/himbaechel/uarch/gowin/pack.cc
+++ b/himbaechel/uarch/gowin/pack.cc
@@ -1,3 +1,5 @@
+#include <map>
+
 #include "design_utils.h"
 #include "log.h"
 #include "nextpnr.h"

--- a/himbaechel/uarch/ng-ultra/ng_ultra.cc
+++ b/himbaechel/uarch/ng-ultra/ng_ultra.cc
@@ -1060,7 +1060,7 @@ struct NgUltraArch : HimbaechelArch
 {
     NgUltraArch() : HimbaechelArch("ng-ultra") {};
     bool match_device(const std::string &device) override { return device == "NG-ULTRA"; }
-    std::unique_ptr<HimbaechelAPI> create(const std::string &device, const dict<std::string, std::string> &args)
+    std::unique_ptr<HimbaechelAPI> create(const std::string &device, const dict<std::string, std::string> &args) override
     {
         return std::make_unique<NgUltraImpl>();
     }

--- a/himbaechel/uarch/xilinx/xilinx.cc
+++ b/himbaechel/uarch/xilinx/xilinx.cc
@@ -569,7 +569,7 @@ struct XilinxArch : HimbaechelArch
 {
     XilinxArch() : HimbaechelArch("xilinx") {};
     bool match_device(const std::string &device) override { return device.size() > 3 && device.substr(0, 3) == "xc7"; }
-    std::unique_ptr<HimbaechelAPI> create(const std::string &device, const dict<std::string, std::string> &args)
+    std::unique_ptr<HimbaechelAPI> create(const std::string &device, const dict<std::string, std::string> &args) override
     {
         return std::make_unique<XilinxImpl>();
     }


### PR DESCRIPTION
None of these fixes are critical, except for the one that adds missing `#include <map>`, without which Himbaechel is broken on libc++.