### PR TITLE
himbaechel: allow subsetting uarches

### DIFF
--- a/himbaechel/family.cmake
+++ b/himbaechel/family.cmake
@@ -1,5 +1,15 @@
 set(HIMBAECHEL_UARCHES "example;gowin;xilinx;ng-ultra")
-foreach(uarch ${HIMBAECHEL_UARCHES})
+
+set(HIMBAECHEL_UARCH "${HIMBAECHEL_UARCHES}" CACHE STRING "Microarchitectures for nextpnr-himbaechel build")
+set_property(CACHE HIMBAECHEL_UARCH PROPERTY STRINGS ${HIMBAECHEL_UARCHES})
+
+foreach(item ${HIMBAECHEL_UARCH})
+    if (NOT item IN_LIST HIMBAECHEL_UARCHES)
+        message(FATAL_ERROR "Microarchitecture '${item}' not in list of supported architectures")
+    endif()
+endforeach()
+
+foreach(uarch ${HIMBAECHEL_UARCH})
 	add_subdirectory(${family}/uarch/${uarch})
     aux_source_directory(${family}/uarch/${uarch} HM_UARCH_FILES)
     foreach(target ${family_targets})


### PR DESCRIPTION
E.g. selecting only Gowin instead of the default shrinks the resulting binary by ~30%.

Not sure exactly what the variables should be named, I did it by analogy with the main `ARCH` cache variable.