### PR TITLE
Gowin. BUGFIX. Do not create missing wires.

### DIFF
--- a/himbaechel/uarch/gowin/gowin_arch_gen.py
+++ b/himbaechel/uarch/gowin/gowin_arch_gen.py
@@ -608,7 +608,6 @@ def create_extra_funcs(tt: TileType, db: chipdb, x: int, y: int):
                 bel = tt.create_bel("EMCU", "EMCU", EMCU_Z)
                 portmap = desc['ins']
                 for port, wire in portmap.items():
-                    print(port, wire)
                     if not tt.has_wire(wire):
                         tt.create_wire(wire, "EMCU_IN")
                     tt.add_bel_pin(bel, port, wire, PinType.INPUT)
@@ -746,7 +745,7 @@ def create_io_tiletype(chip: Chip, db: chipdb, x: int, y: int, ttyp: int, tdesc:
         tt.add_bel_pin(io, "OEN", portmap['OE'], PinType.INPUT)
         tt.add_bel_pin(io, "O", portmap['O'], PinType.OUTPUT)
         # bottom io
-        if 'BOTTOM_IO_PORT_A' in portmap:
+        if 'BOTTOM_IO_PORT_A' in portmap and portmap['BOTTOM_IO_PORT_A']:
             if not tt.has_wire(portmap['BOTTOM_IO_PORT_A']):
                 tt.create_wire(portmap['BOTTOM_IO_PORT_A'], "IO_I")
                 tt.create_wire(portmap['BOTTOM_IO_PORT_B'], "IO_I")

--- a/himbaechel/uarch/gowin/pack.cc
+++ b/himbaechel/uarch/gowin/pack.cc
@@ -857,7 +857,6 @@ struct GowinPacker
                         iologic_o->setAttr(id_OREG_TYPE, ff->type.str(ctx));
                         cells_to_remove.push_back(ff->name);
                     }
-                    break;
                 } while (false);
             }
 
@@ -964,7 +963,6 @@ struct GowinPacker
                         iologic_o->setAttr(id_TREG_TYPE, ff->type.str(ctx));
                         cells_to_remove.push_back(ff->name);
                     }
-                    break;
                 } while (false);
             }
         }


### PR DESCRIPTION
Erroneously created wires for specific IOs on the underside of some chips.

Fixes https://github.com/YosysHQ/nextpnr/issues/1417

Also cosmetic edits.