### PR TITLE
CMake: use imported target for pybind11

### DIFF
--- a/common/kernel/CMakeLists.txt
+++ b/common/kernel/CMakeLists.txt
@@ -76,6 +76,6 @@ target_link_libraries(nextpnr_kernel INTERFACE
 
 if (BUILD_PYTHON)
     target_link_libraries(nextpnr_kernel INTERFACE
-        pybind11_headers
+        pybind11::headers
     )
 endif()


### PR DESCRIPTION
This accounts for the use of either the system or the vendored pybind11.

Fixes #1428.