### PR TITLE
CMake: disallow in-tree builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)
+    message(FATAL_ERROR "In-tree builds are not supported. Instead, run:\ncmake . -B build <options> && cmake --build build")
+endif()
+
 cmake_minimum_required(VERSION 3.25)
 project(nextpnr CXX)
 


### PR DESCRIPTION
In-tree builds pollute the source directory and make version control more difficult to use effectively.

See https://github.com/YosysHQ/nextpnr/pull/1422#issuecomment-2606815347 for prior discussion.