### PR TITLE
CMake: add support for exporting and importing .bba files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,8 @@ add_subdirectory(rust)
 
 add_subdirectory(tests/gui)
 
+add_custom_target(nextpnr-all-bba)
+
 function(add_nextpnr_architecture target)
     cmake_parse_arguments(arg "" "MAIN_SOURCE" "CORE_SOURCES;TEST_SOURCES;CURRENT_SOURCE_DIR;CURRENT_BINARY_DIR" ${ARGN})
 
@@ -324,6 +326,10 @@ function(add_nextpnr_architecture target)
     add_sanitizers(nextpnr-${target}-core)
 
     # Chip database
+
+    add_library(nextpnr-${target}-bba INTERFACE)
+
+    add_dependencies(nextpnr-all-bba nextpnr-${target}-bba)
 
     add_library(nextpnr-${target}-chipdb INTERFACE)
 

--- a/ecp5/CMakeLists.txt
+++ b/ecp5/CMakeLists.txt
@@ -43,6 +43,7 @@ foreach (device ${ECP5_DEVICES})
     endif()
 
     add_bba_produce_command(
+        TARGET  nextpnr-${family}-bba
         COMMAND ${Python3_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/trellis_import.py
             -L ${TRELLIS_LIBDIR}

--- a/gowin/CMakeLists.txt
+++ b/gowin/CMakeLists.txt
@@ -34,6 +34,7 @@ foreach (device ${GOWIN_DEVICES})
     endif()
 
     add_bba_produce_command(
+        TARGET  nextpnr-${family}-bba
         COMMAND ${GOWIN_BBA_EXECUTABLE}
             -d ${device}
             -i ${CMAKE_CURRENT_SOURCE_DIR}/constids.inc

--- a/himbaechel/CMakeLists.txt
+++ b/himbaechel/CMakeLists.txt
@@ -49,6 +49,10 @@ else()
 
         target_sources(nextpnr-himbaechel-core INTERFACE ${arg_CORE_SOURCES})
 
+        add_library(nextpnr-himbaechel-${microtarget}-bba INTERFACE)
+
+        add_dependencies(nextpnr-himbaechel-bba nextpnr-himbaechel-${microtarget}-bba)
+
         add_library(nextpnr-himbaechel-${microtarget}-chipdb INTERFACE)
 
         target_link_libraries(nextpnr-himbaechel-core INTERFACE nextpnr-himbaechel-${microtarget}-chipdb)

--- a/himbaechel/uarch/example/CMakeLists.txt
+++ b/himbaechel/uarch/example/CMakeLists.txt
@@ -19,6 +19,7 @@ foreach (device ${HIMBAECHEL_EXAMPLE_DEVICES})
     endif()
 
     add_bba_produce_command(
+        TARGET  nextpnr-himbaechel-example-bba
         COMMAND ${Python3_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/example_arch_gen.py
             ${CMAKE_CURRENT_BINARY_DIR}/chipdb-${device}.bba.new

--- a/himbaechel/uarch/gowin/CMakeLists.txt
+++ b/himbaechel/uarch/gowin/CMakeLists.txt
@@ -32,6 +32,7 @@ foreach (device ${HIMBAECHEL_GOWIN_DEVICES})
     endif()
 
     add_bba_produce_command(
+        TARGET  nextpnr-himbaechel-gowin-bba
         COMMAND ${apycula_Python3_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/gowin_arch_gen.py
             -d ${device}

--- a/himbaechel/uarch/ng-ultra/CMakeLists.txt
+++ b/himbaechel/uarch/ng-ultra/CMakeLists.txt
@@ -41,6 +41,7 @@ foreach (device ${HIMBAECHEL_NGULTRA_DEVICES})
     string(TOUPPER ${device} device_upper)
 
     add_bba_produce_command(
+        TARGET  nextpnr-himbaechel-ng-ultra-bba
         COMMAND ${Python3_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/gen/arch_gen.py
             --db ${HIMBAECHEL_PRJBEYOND_DB}

--- a/himbaechel/uarch/xilinx/CMakeLists.txt
+++ b/himbaechel/uarch/xilinx/CMakeLists.txt
@@ -34,6 +34,7 @@ message(STATUS "Enabled Himbaechel-Xilinx devices: ${HIMBAECHEL_XILINX_DEVICES}"
 
 foreach (device ${HIMBAECHEL_XILINX_DEVICES})
     add_bba_produce_command(
+        TARGET  nextpnr-himbaechel-xilinx-bba
         COMMAND /usr/bin/pypy3 ${CMAKE_CURRENT_SOURCE_DIR}/gen/xilinx_gen.py
             --xray ${HIMBAECHEL_PRJXRAY_DB}/artix7
             --device ${device}

--- a/ice40/CMakeLists.txt
+++ b/ice40/CMakeLists.txt
@@ -64,6 +64,7 @@ foreach (device ${ICE40_DEVICES})
     endif()
 
     add_bba_produce_command(
+        TARGET  nextpnr-${family}-bba
         COMMAND ${Python3_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/chipdb.py
             -p ${CMAKE_CURRENT_SOURCE_DIR}/constids.inc

--- a/machxo2/CMakeLists.txt
+++ b/machxo2/CMakeLists.txt
@@ -43,6 +43,7 @@ foreach (device ${MACHXO2_DEVICES})
     endif()
 
     add_bba_produce_command(
+        TARGET  nextpnr-${family}-bba
         COMMAND ${Python3_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/facade_import.py
             -L ${TRELLIS_LIBDIR}

--- a/nexus/CMakeLists.txt
+++ b/nexus/CMakeLists.txt
@@ -35,6 +35,7 @@ foreach (subfamily ${NEXUS_FAMILIES})
     endif()
 
     add_bba_produce_command(
+        TARGET  nextpnr-${family}-bba
         COMMAND ${PRJOXIDE_TOOL}
             bba-export ${subfamily}
             ${CMAKE_CURRENT_SOURCE_DIR}/constids.inc


### PR DESCRIPTION
This is useful for certain cross-compilation workloads, and to cache rarely changing build products.

To use this functionality, build e.g. as follows:

    cmake . -B build-export -DEXPORT_BBA_FILES=../bba-files -DARCH=all
    cmake --build build-export -t nextpnr-all-bba

    cmake . -B build-import -DIMPORT_BBA_FILES=../bba-files -DARCH=all
    cmake --build build-import