### PR TITLE
Gowin. Implement MIPI IO.

### DIFF
--- a/himbaechel/uarch/gowin/constids.inc
+++ b/himbaechel/uarch/gowin/constids.inc
@@ -1313,6 +1313,16 @@ X(LSREN)
 // EMCU
 X(EMCU)
 
+// MIPI
+X(IL)
+X(OH)
+X(OL)
+X(OENB)
+X(MIPI_IBUF)
+X(MIPI_OBUF)
+X(MIPI_OBUF_A)
+X(MODESEL)
+
 // Register placement options
 X(IREG_IN_IOB)
 X(OREG_IN_IOB)

--- a/himbaechel/uarch/gowin/gowin.cc
+++ b/himbaechel/uarch/gowin/gowin.cc
@@ -1,5 +1,5 @@
-#include <regex>
 #include <map>
+#include <regex>
 
 #include "himbaechel_api.h"
 #include "himbaechel_helpers.h"
@@ -110,7 +110,8 @@ struct GowinArch : HimbaechelArch
 
     bool match_device(const std::string &device) override { return device.size() > 2 && device.substr(0, 2) == "GW"; }
 
-    std::unique_ptr<HimbaechelAPI> create(const std::string &device, const dict<std::string, std::string> &args) override
+    std::unique_ptr<HimbaechelAPI> create(const std::string &device,
+                                          const dict<std::string, std::string> &args) override
     {
         return std::make_unique<GowinImpl>();
     }
@@ -639,6 +640,9 @@ IdString GowinImpl::getBelBucketForCellType(IdString cell_type) const
     if (cell_type.in(id_IBUF, id_OBUF)) {
         return id_IOB;
     }
+    if (cell_type.in(id_MIPI_OBUF, id_MIPI_OBUF_A)) {
+        return id_MIPI_OBUF;
+    }
     if (type_is_lut(cell_type)) {
         return id_LUT4;
     }
@@ -675,6 +679,9 @@ bool GowinImpl::isValidBelForCellType(IdString cell_type, BelId bel) const
     IdString bel_type = ctx->getBelType(bel);
     if (bel_type == id_IOB) {
         return cell_type.in(id_IBUF, id_OBUF);
+    }
+    if (bel_type == id_MIPI_OBUF) {
+        return cell_type.in(id_MIPI_OBUF, id_MIPI_OBUF_A);
     }
     if (bel_type == id_LUT4) {
         return type_is_lut(cell_type);

--- a/himbaechel/uarch/gowin/gowin.h
+++ b/himbaechel/uarch/gowin/gowin.h
@@ -32,6 +32,10 @@ inline bool type_is_diffio(IdString cell_type)
 }
 inline bool is_diffio(const CellInfo *cell) { return type_is_diffio(cell->type); }
 
+// MIPI
+inline bool type_is_mipi(IdString cell_type) { return cell_type.in(id_MIPI_OBUF, id_MIPI_OBUF_A, id_MIPI_IBUF); }
+inline bool is_mipi(const CellInfo *cell) { return type_is_mipi(cell->type); }
+
 // IOLOGIC input and output separately
 
 inline bool type_is_iologico(IdString cell_type)
@@ -198,6 +202,9 @@ enum
     USERFLASH_Z = 298,
 
     EMCU_Z = 300,
+
+    MIPIOBUF_Z = 301,
+    MIPIIBUF_Z = 302,
 
     // The two least significant bits encode Z for 9-bit adders and
     // multipliers, if they are equal to 0, then we get Z of their common

--- a/himbaechel/uarch/gowin/gowin_arch_gen.py
+++ b/himbaechel/uarch/gowin/gowin_arch_gen.py
@@ -55,8 +55,10 @@ DHCEN_Z = 288 # : 298
 
 USERFLASH_Z = 298
 
-
 EMCU_Z      = 300
+
+MIPIOBUF_Z  = 301
+MIPIIBUF_Z  = 302
 
 DSP_Z          = 509
 
@@ -580,6 +582,23 @@ def create_extra_funcs(tt: TileType, db: chipdb, x: int, y: int):
                         tt.add_bel_pin(bel, port, wire, PinType.OUTPUT)
                     else:
                         tt.add_bel_pin(bel, port, wire, PinType.INPUT)
+        elif func == 'mipi_obuf':
+            bel = tt.create_bel('MIPI_OBUF', 'MIPI_OBUF', MIPIOBUF_Z)
+        elif func == 'mipi_ibuf':
+            bel = tt.create_bel('MIPI_IBUF', 'MIPI_IBUF', MIPIIBUF_Z)
+            wire = desc['HSREN']
+            if not tt.has_wire(wire):
+                tt.create_wire(wire)
+            tt.add_bel_pin(bel, 'HSREN', wire, PinType.INPUT)
+            wire = 'MIPIOL'
+            if not tt.has_wire(wire):
+                tt.create_wire(wire)
+            tt.add_bel_pin(bel, 'OL', wire, PinType.OUTPUT)
+            for i in range(2):
+                wire = f'MIPIEN{i}'
+                if not tt.has_wire(wire):
+                    tt.create_wire(wire)
+                tt.add_bel_pin(bel, f'MIPIEN{i}', wire, PinType.INPUT)
         elif func == 'buf':
             for buf_type, wires in desc.items():
                 for i, wire in enumerate(wires):

--- a/himbaechel/uarch/gowin/pack.cc
+++ b/himbaechel/uarch/gowin/pack.cc
@@ -322,7 +322,7 @@ struct GowinPacker
                 continue;
             }
             switch (ci.type.hash()) {
-            case ID_MIPI_OBUF_A: /* fallt-hrough */
+            case ID_MIPI_OBUF_A: /* fall-through */
             case ID_MIPI_OBUF: {
                 // check for MIPI-capable pin
                 CellInfo *out_iob = net_only_drives(ctx, ci.ports.at(id_O).net, is_iob, id_I, true);


### PR DESCRIPTION
Adds output (MIPI_OBUF and MIPI_OBUF_A) and input (MIPI_IBUF) primitives to allow the use of “real” MIPI (not emulation) ports capable of operating in both HS and LP modes.