### PR TITLE
CMake: Add include guards when IMPORT_BBA_FILES is used

### DIFF
--- a/ecp5/CMakeLists.txt
+++ b/ecp5/CMakeLists.txt
@@ -1,4 +1,6 @@
-include(FindTrellis)
+if (NOT IMPORT_BBA_FILES)
+    include(FindTrellis)
+endif()
 
 set(SOURCES
     arch.cc

--- a/gowin/CMakeLists.txt
+++ b/gowin/CMakeLists.txt
@@ -1,4 +1,6 @@
-include(FindApycula)
+if (NOT IMPORT_BBA_FILES)
+    include(FindApycula)
+endif()
 
 set(SOURCES
     arch.cc

--- a/himbaechel/uarch/gowin/CMakeLists.txt
+++ b/himbaechel/uarch/gowin/CMakeLists.txt
@@ -1,4 +1,6 @@
-include(FindApycula)
+if (NOT IMPORT_BBA_FILES)
+    include(FindApycula)
+endif()
 
 set(SOURCES
     constids.inc

--- a/ice40/CMakeLists.txt
+++ b/ice40/CMakeLists.txt
@@ -1,4 +1,6 @@
-include(FindIceStorm)
+if (NOT IMPORT_BBA_FILES)
+    include(FindIceStorm)
+endif()
 
 set(SOURCES
     arch.cc

--- a/machxo2/CMakeLists.txt
+++ b/machxo2/CMakeLists.txt
@@ -1,4 +1,6 @@
-include(FindTrellis)
+if (NOT IMPORT_BBA_FILES)
+    include(FindTrellis)
+endif()
 
 set(SOURCES
     arch.cc
@@ -36,6 +38,9 @@ message(STATUS "Enabled MachXO2/XO3 devices: ${MACHXO2_DEVICES}")
 configure_file(machxo2_available.h.in ${CMAKE_CURRENT_BINARY_DIR}/machxo2_available.h)
 target_sources(nextpnr-${family}-core PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/machxo2_available.h)
 target_include_directories(nextpnr-${family}-core INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
+if (BUILD_GUI)
+    target_include_directories(nextpnr-${family}-gui PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+endif()
 
 foreach (device ${MACHXO2_DEVICES})
     if (NOT device IN_LIST ALL_MACHXO2_DEVICES)

--- a/nexus/CMakeLists.txt
+++ b/nexus/CMakeLists.txt
@@ -1,4 +1,6 @@
-include(FindOxide)
+if (NOT IMPORT_BBA_FILES)
+    include(FindOxide)
+endif()
 
 set(SOURCES
     arch.cc


### PR DESCRIPTION
This one also includes small patch for machxo arch to properly build with GUI enabled