### PR TITLE
Fix undefined type error in 3rdparty/json11/json11.cpp

### DIFF
--- a/3rdparty/json11/json11.cpp
+++ b/3rdparty/json11/json11.cpp
@@ -23,6 +23,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstdlib>
+#include <cstdint>
 #include <cstdio>
 #include <climits>
 #include <cerrno>


### PR DESCRIPTION
Under certain conditions (e.g., building on Fedora 42 using gcc-15.0.1), compilation fails with the following error:

    "error: ‘uint8_t’ does not name a type"

Explicitly include `<cstdint>` to prevent that situation.

Also see https://github.com/YosysHQ/yosys/pull/4852 and https://bugzilla.redhat.com/show_bug.cgi?id=2340929
