### PR TITLE
CMake: exclude *-bba and *-chipdb targets from `make all`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,7 @@ add_subdirectory(rust)
 
 add_subdirectory(tests/gui)
 
-add_custom_target(nextpnr-all-bba)
+add_custom_target(nextpnr-all-bba EXCLUDE_FROM_ALL)
 
 function(add_nextpnr_architecture target)
     cmake_parse_arguments(arg "" "MAIN_SOURCE" "CORE_SOURCES;TEST_SOURCES;CURRENT_SOURCE_DIR;CURRENT_BINARY_DIR" ${ARGN})
@@ -331,11 +331,11 @@ function(add_nextpnr_architecture target)
 
     # Chip database
 
-    add_library(nextpnr-${target}-bba INTERFACE)
+    add_library(nextpnr-${target}-bba INTERFACE EXCLUDE_FROM_ALL)
 
     add_dependencies(nextpnr-all-bba nextpnr-${target}-bba)
 
-    add_library(nextpnr-${target}-chipdb INTERFACE)
+    add_library(nextpnr-${target}-chipdb INTERFACE EXCLUDE_FROM_ALL)
 
     target_link_libraries(nextpnr-${target}-core INTERFACE nextpnr-${target}-chipdb)
 

--- a/himbaechel/CMakeLists.txt
+++ b/himbaechel/CMakeLists.txt
@@ -49,11 +49,11 @@ else()
 
         target_sources(nextpnr-himbaechel-core INTERFACE ${arg_CORE_SOURCES})
 
-        add_library(nextpnr-himbaechel-${microtarget}-bba INTERFACE)
+        add_library(nextpnr-himbaechel-${microtarget}-bba INTERFACE EXCLUDE_FROM_ALL)
 
         add_dependencies(nextpnr-himbaechel-bba nextpnr-himbaechel-${microtarget}-bba)
 
-        add_library(nextpnr-himbaechel-${microtarget}-chipdb INTERFACE)
+        add_library(nextpnr-himbaechel-${microtarget}-chipdb INTERFACE EXCLUDE_FROM_ALL)
 
         target_link_libraries(nextpnr-himbaechel-core INTERFACE nextpnr-himbaechel-${microtarget}-chipdb)
 


### PR DESCRIPTION
Due to the way CMake-generated Makefiles evaluate dependencies, this calls the `.bba` generation custom command twice, which then fails as they both use the same `.bba.new` file as an output and one of them moves it first.

This broke builds using `make -j` but not builds using `make -j nextpnr-himbaechel-example`.