### PR TITLE
frontend: don't connect a const net to ports connected to `x`

### DIFF
--- a/frontend/frontend_base.h
+++ b/frontend/frontend_base.h
@@ -472,7 +472,10 @@ template <typename FrontendType> struct GenericFrontend
                 ci->ports[port_bit_ids].type = dir;
                 // Resolve connectivity
                 NetInfo *net;
-                if (impl.is_vector_bit_constant(bits, i)) {
+                if (impl.is_vector_bit_undef(bits, i)) {
+                    // Don't connect it if it's an `x`
+                    continue;
+                } else if (impl.is_vector_bit_constant(bits, i)) {
                     // Create a constant driver if one is needed
                     net = create_constant_net(m, inst_name.str(ctx) + "." + port_bit_name + "$const",
                                               impl.get_vector_bit_constval(bits, i));

--- a/frontend/json_frontend.cc
+++ b/frontend/json_frontend.cc
@@ -161,6 +161,12 @@ struct JsonFrontendImpl
 
     int get_vector_length(BitVectorDataType &bits) const { return int(bits.size()); }
 
+    bool is_vector_bit_undef(BitVectorDataType &bits, int i) const
+    {
+        NPNR_ASSERT(i < int(bits.size()));
+        return bits[i] == "x";
+    }
+
     bool is_vector_bit_constant(BitVectorDataType &bits, int i) const
     {
         NPNR_ASSERT(i < int(bits.size()));


### PR DESCRIPTION
prjunnamed normalizes ports that are not present in the primitive to be all-x. On iCE40, this can cause a false placement conflict between `SB_IO` cells where one's clock input is `x` and another's is some other net.

I haven't tested every other architecture (nor do I have the means to) so I can't know for sure this change won't have some other fallout, but it seems pretty weird to treat an absent port differently from an all-x port so arguably that would be an architecture bug.

Alternatively an iCE40-specific workaround in `arch_place.cc` could be used.