### PR TITLE
kernel: look up ports when applying clock constraints

### DIFF
--- a/common/kernel/basectx.cc
+++ b/common/kernel/basectx.cc
@@ -100,12 +100,15 @@ void BaseCtx::addClock(IdString net, float freq)
     cc->period = DelayPair(getCtx()->getDelayFromNS(1000 / freq));
     cc->high = DelayPair(getCtx()->getDelayFromNS(500 / freq));
     cc->low = DelayPair(getCtx()->getDelayFromNS(500 / freq));
-    if (!net_aliases.count(net)) {
-        log_warning("net '%s' does not exist in design, ignoring clock constraint\n", net.c_str(this));
-    } else {
+    if (net_aliases.count(net)) {
         getNetByAlias(net)->clkconstr = std::move(cc);
-        log_info("constraining clock net '%s' to %.02f MHz\n", net.c_str(this), freq);
+    } else if (ports.count(net)) {
+        ports[net].net->clkconstr = std::move(cc);
+    } else {
+        log_warning("net '%s' does not exist in design, ignoring clock constraint\n", net.c_str(this));
+        return;
     }
+    log_info("constraining clock net '%s' to %.02f MHz\n", net.c_str(this), freq);
 }
 
 void BaseCtx::createRectangularRegion(IdString name, int x0, int y0, int x1, int y1)


### PR DESCRIPTION
prjunnamed does not emit a net alias for toplevel ports. This works fine for constraining IOs but breaks clock constraints. This commit expands clock constraint application code to look up net aliases first, ports second.

As far as I can tell there shouldn't be any issues from this for existing flows.