### PR TITLE
CMake: add_custom_target does not require EXCLUDE_FROM_ALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,7 @@ add_subdirectory(rust)
 
 add_subdirectory(tests/gui)
 
-add_custom_target(nextpnr-all-bba EXCLUDE_FROM_ALL)
+add_custom_target(nextpnr-all-bba)
 
 function(add_nextpnr_architecture target)
     cmake_parse_arguments(arg "" "MAIN_SOURCE" "CORE_SOURCES;TEST_SOURCES;CURRENT_SOURCE_DIR;CURRENT_BINARY_DIR" ${ARGN})


### PR DESCRIPTION
add_custom_target syntax does not support EXCLUDE_FROM_ALL, actually it is reveresed, you need to add ALL if you wish to add it to `all` target. 

Without this change you would get
```
make nextpnr-all-bba -j9

[ 20%] Generating chipdb-384.bba
[ 60%] Generating chipdb-1k.bba
[ 60%] Generating chipdb-8k.bba
[100%] Generating chipdb-u4k.bba
[100%] Generating chipdb-5k.bba
[100%] Built target nextpnr-ice40-bba
make[3]: EXCLUDE_FROM_ALL: No such file or directory
make[3]: *** [CMakeFiles/nextpnr-all-bba.dir/build.make:70: CMakeFiles/nextpnr-all-bba] Error 127
make[2]: *** [CMakeFiles/Makefile2:383: CMakeFiles/nextpnr-all-bba.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:390: CMakeFiles/nextpnr-all-bba.dir/rule] Error 2

```