### PR TITLE
gowin: Add deprecation message for nextpnr-gowin

### DIFF
--- a/gowin/main.cc
+++ b/gowin/main.cc
@@ -122,5 +122,6 @@ void GowinCommandHandler::customAfterLoad(Context *ctx)
 int main(int argc, char *argv[])
 {
     GowinCommandHandler handler(argc, argv);
+    fprintf(stderr, "WARNING: nextpnr-gowin is deprecated, please use nextpnr-himbaechel instead for Gowin FPGA support.\n\n");
     return handler.exec();
 }


### PR DESCRIPTION
Adds deprecation warining as requested in https://github.com/YosysHQ/nextpnr/pull/1318 
It has to be done as (f)printf since during that time logger is still not active and it is useful to add warning in that particular moment.