### PR TITLE
Add arch API function for pip inversion

### DIFF
--- a/common/kernel/arch_api.h
+++ b/common/kernel/arch_api.h
@@ -102,6 +102,7 @@ template <typename R> struct ArchAPI : BaseCtx
     virtual WireId getPipDstWire(PipId pip) const = 0;
     virtual DelayQuad getPipDelay(PipId pip) const = 0;
     virtual Loc getPipLocation(PipId pip) const = 0;
+    virtual bool isPipInverting(PipId pip) const = 0;
     // Group methods
     virtual GroupId getGroupByName(IdStringList name) const = 0;
     virtual IdStringList getGroupName(GroupId group) const = 0;

--- a/common/kernel/base_arch.h
+++ b/common/kernel/base_arch.h
@@ -288,6 +288,7 @@ template <typename R> struct BaseArch : ArchAPI<R>
     }
     virtual WireId getConflictingPipWire(PipId /*pip*/) const override { return WireId(); }
     virtual NetInfo *getConflictingPipNet(PipId pip) const override { return getBoundPipNet(pip); }
+    virtual bool isPipInverting(PipId /*pip*/) const override { return false; }
 
     // Group methods
     virtual GroupId getGroupByName(IdStringList /*name*/) const override { return GroupId(); };

--- a/docs/archapi.md
+++ b/docs/archapi.md
@@ -417,6 +417,12 @@ pip is already bound to that net.
 
 *BaseArch default: returns `getBoundPipNet(pip) == nullptr || getBoundPipNet(pip) == net`*
 
+### bool isPipInverting(PipId pip) const
+
+Returns true if the given pip inverts the net passing through it.
+
+*BaseArch default: returns `false`*
+
 ### NetInfo \*getBoundPipNet(PipId pip) const
 
 Return the net this pip is bound to.

--- a/himbaechel/arch.h
+++ b/himbaechel/arch.h
@@ -662,6 +662,9 @@ struct Arch : BaseArch<ArchRanges>
         uarch->notifyPipChange(pip, nullptr);
         BaseArch::unbindPip(pip);
     }
+    bool isPipInverting(PipId pip) const override {
+        return uarch->isPipInverting(pip);
+    }
 
     // -------------------------------------------------
 

--- a/himbaechel/himbaechel_api.h
+++ b/himbaechel/himbaechel_api.h
@@ -89,6 +89,7 @@ struct HimbaechelAPI
     virtual bool checkWireAvail(WireId wire) const { return true; }
     virtual bool checkPipAvail(PipId pip) const { return true; }
     virtual bool checkPipAvailForNet(PipId pip, const NetInfo *net) const { return checkPipAvail(pip); };
+    virtual bool isPipInverting(PipId pip) const { return false; }
 
     // --- Route lookahead ---
     virtual delay_t estimateDelay(WireId src, WireId dst) const;


### PR DESCRIPTION
GateMate contains inverting switchbox pips, which needs to be handled specially (I suspect Cyclone V does too, but it's been a long while since I looked at that). As part of bringup for that family, add an architecture API function to detect if a pip inverts. 

Inverting pips between two wires are disambiguated from non-inverting for use by e.g. Python by having an `INV` string appended to the name.