### PR TITLE
Gowin. Add HCLK wires to PLL.

### DIFF
--- a/himbaechel/uarch/gowin/globals.cc
+++ b/himbaechel/uarch/gowin/globals.cc
@@ -282,8 +282,9 @@ struct GowinGlobalRouter
         if (driver.cell->type.in(id_CLKDIV, id_CLKDIV2)) {
             if (driver.port.in(id_CLKOUT)) {
                 if (ctx->debug) {
-                    log_info("%s out:%s:%s\n", driver.cell->type.c_str(ctx),
-                             ctx->getBelName(driver.cell->bel).str(ctx).c_str(), driver.port.c_str(ctx));
+                    log_info("%s out:%s:%s:%s\n", driver.cell->type.c_str(ctx),
+                             ctx->getBelName(driver.cell->bel).str(ctx).c_str(), driver.port.c_str(ctx),
+                             ctx->nameOfWire(ctx->getBelPinWire(driver.cell->bel, driver.port)));
                 }
                 return true;
             }

--- a/himbaechel/uarch/gowin/gowin.h
+++ b/himbaechel/uarch/gowin/gowin.h
@@ -93,6 +93,10 @@ inline bool type_is_userflash(IdString cell_type)
 }
 inline bool is_userflash(const CellInfo *cell) { return type_is_userflash(cell->type); }
 
+// Return true if a cell is a PLL
+inline bool type_is_pll(IdString cell_type) { return cell_type.in(id_rPLL, id_PLLVR); }
+inline bool is_pll(const CellInfo *cell) { return type_is_pll(cell->type); }
+
 // Return true if a cell is a EMCU
 inline bool type_is_emcu(IdString cell_type) { return cell_type == id_EMCU; }
 inline bool is_emcu(const CellInfo *cell) { return type_is_emcu(cell->type); }
@@ -168,6 +172,8 @@ NPNR_PACKED_STRUCT(struct Extra_chip_data_POD {
     static constexpr int32_t NEED_BSRAM_OUTREG_FIX = 4;
     static constexpr int32_t NEED_BLKSEL_FIX = 8;
     static constexpr int32_t HAS_BANDGAP = 16;
+    static constexpr int32_t HAS_PLL_HCLK = 32;
+    static constexpr int32_t HAS_CLKDIV_HCLK = 64;
 });
 
 } // namespace

--- a/himbaechel/uarch/gowin/gowin_arch_gen.py
+++ b/himbaechel/uarch/gowin/gowin_arch_gen.py
@@ -20,6 +20,8 @@ CHIP_NEED_SP_FIX           = 0x2
 CHIP_NEED_BSRAM_OUTREG_FIX = 0x4
 CHIP_NEED_BLKSEL_FIX       = 0x8
 CHIP_HAS_BANDGAP           = 0x10
+CHIP_HAS_PLL_HCLK          = 0x20
+CHIP_HAS_CLKDIV_HCLK       = 0x40
 
 # Tile flags
 TILE_I3C_CAPABLE_IO        = 0x1
@@ -1442,6 +1444,10 @@ def main():
             chip_flags |= CHIP_NEED_BLKSEL_FIX;
         if "HAS_BANDGAP" in db.chip_flags:
             chip_flags |= CHIP_HAS_BANDGAP;
+        if "HAS_PLL_HCLK" in db.chip_flags:
+            chip_flags |= CHIP_HAS_PLL_HCLK;
+        if "HAS_CLKDIV_HCLK" in db.chip_flags:
+            chip_flags |= CHIP_HAS_CLKDIV_HCLK;
 
     X = db.cols;
     Y = db.rows;

--- a/himbaechel/uarch/gowin/gowin_utils.cc
+++ b/himbaechel/uarch/gowin/gowin_utils.cc
@@ -190,6 +190,18 @@ bool GowinUtils::need_BLKSEL_fix(void)
     return extra->chip_flags & Extra_chip_data_POD::NEED_BLKSEL_FIX;
 }
 
+bool GowinUtils::has_PLL_HCLK(void)
+{
+    const Extra_chip_data_POD *extra = reinterpret_cast<const Extra_chip_data_POD *>(ctx->chip_info->extra_data.get());
+    return extra->chip_flags & Extra_chip_data_POD::HAS_PLL_HCLK;
+}
+
+bool GowinUtils::has_CLKDIV_HCLK(void)
+{
+    const Extra_chip_data_POD *extra = reinterpret_cast<const Extra_chip_data_POD *>(ctx->chip_info->extra_data.get());
+    return extra->chip_flags & Extra_chip_data_POD::HAS_CLKDIV_HCLK;
+}
+
 IdString GowinUtils::create_aux_name(IdString main_name, int idx, const char *str_suffix)
 {
     return idx ? ctx->idf("%s%s%d", main_name.c_str(ctx), str_suffix, idx)

--- a/himbaechel/uarch/gowin/gowin_utils.h
+++ b/himbaechel/uarch/gowin/gowin_utils.h
@@ -57,6 +57,8 @@ struct GowinUtils
     bool need_SP_fix(void);
     bool need_BSRAM_OUTREG_fix(void);
     bool need_BLKSEL_fix(void);
+    bool has_PLL_HCLK(void);
+    bool has_CLKDIV_HCLK(void);
 
     // Power saving
     bool has_BANDGAP(void);


### PR DESCRIPTION
Adds the ability to use high-speed clock lines (together with CLKDIV2 type frequency dividers operating on them) as signals for the CLKIN and CLKFB inputs of the rPLL and PLLVR primitives (these cover the full range of supported Gowin chips).