### PR TITLE
ecp5: fix frequency constraint on bypassed PLL outputs

### DIFF
--- a/ecp5/pack.cc
+++ b/ecp5/pack.cc
@@ -2875,14 +2875,30 @@ class Ecp5Packer
                         log_info("    Derived VCO frequency %.1f MHz of PLL '%s' is out of legal range [400MHz, "
                                  "800MHz]\n",
                                  vco_freq, ci->name.c_str(ctx));
-                    set_constraint(ci, id_CLKOP,
-                                   simple_clk_contraint(vco_period * int_or_default(ci->params, id_CLKOP_DIV, 1)));
-                    set_constraint(ci, id_CLKOS,
-                                   simple_clk_contraint(vco_period * int_or_default(ci->params, id_CLKOS_DIV, 1)));
-                    set_constraint(ci, id_CLKOS2,
-                                   simple_clk_contraint(vco_period * int_or_default(ci->params, id_CLKOS2_DIV, 1)));
-                    set_constraint(ci, id_CLKOS3,
-                                   simple_clk_contraint(vco_period * int_or_default(ci->params, id_CLKOS3_DIV, 1)));
+
+                    if (str_or_default(ci->params, id_OUTDIVIDER_MUXA, "DIVA") == "REFCLK")
+                      copy_constraint(ci, id_CLKI, id_CLKOP, 1);
+                    else
+                      set_constraint(ci, id_CLKOP,
+                                     simple_clk_contraint(vco_period * int_or_default(ci->params, id_CLKOP_DIV, 1)));
+
+                    if (str_or_default(ci->params, id_OUTDIVIDER_MUXB, "DIVB") == "REFCLK")
+                      copy_constraint(ci, id_CLKI, id_CLKOS, 1);
+                    else
+                      set_constraint(ci, id_CLKOS,
+                                     simple_clk_contraint(vco_period * int_or_default(ci->params, id_CLKOS_DIV, 1)));
+
+                    if (str_or_default(ci->params, id_OUTDIVIDER_MUXC, "DIVC") == "REFCLK")
+                      copy_constraint(ci, id_CLKI, id_CLKOS2, 1);
+                    else
+                      set_constraint(ci, id_CLKOS2,
+                                     simple_clk_contraint(vco_period * int_or_default(ci->params, id_CLKOS2_DIV, 1)));
+
+                    if (str_or_default(ci->params, id_OUTDIVIDER_MUXD, "DIVD") == "REFCLK")
+                      copy_constraint(ci, id_CLKI, id_CLKOS3, 1);
+                    else
+                      set_constraint(ci, id_CLKOS3,
+                                     simple_clk_contraint(vco_period * int_or_default(ci->params, id_CLKOS3_DIV, 1)));
                 } else if (ci->type == id_OSCG) {
                     int div = int_or_default(ci->params, id_DIV, 128);
                     set_constraint(ci, id_OSC, simple_clk_contraint(delay_t((1.0e6 / (2.0 * 155)) * div)));


### PR DESCRIPTION
Each PLL output in ECP5 can be bypassed, which turns it into a wire that passes through ICLK unmodified. When an outputs mux is set to REFCLK, disregard other PLL configuration and copy the input constraint over unchanged.

---

Came across this while adding docs for `OUTDIVIDER_MUX[ABCD]` to https://blog.dave.tf/post/ecp5-pll/ .

Since this is a slightly esoteric corner of ECP5 configuration, I checked the behavior of `OUTDIVIDER_MUXn = REFCLK` on my ulx3s board, by routing all the clocks to I/O and looking at them on the oscilloscope with various PLL configurations. From this I can confirm that setting the output mux to "REFCLK" bypasses the PLL entirely and outputs ICLK unchanged.

---

I believe the ECP5 and MachXO2 PLLs are related enough that the XO2 packer likely needs the same fix, but I don't have any MachXO hardware to test with. I have a dev board on the way, so I can likely send a followup patch for that family next week, or if someone wants to confidently assert that the XO2 PLL needs the same fix, I can update this PR.