### PR TITLE
Set CXX standard for BBA  and remove boost lib

### DIFF
--- a/bba/CMakeLists.txt
+++ b/bba/CMakeLists.txt
@@ -1,15 +1,15 @@
 cmake_minimum_required(VERSION 3.25)
 project(bba CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+
 find_package(Boost REQUIRED COMPONENTS
     program_options
-    filesystem
     system)
 
 add_executable(bbasm
     main.cc)
 target_link_libraries(bbasm LINK_PRIVATE
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
-    ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY})
 export(TARGETS bbasm FILE ${CMAKE_BINARY_DIR}/bba-export.cmake)


### PR DESCRIPTION
This fixes use case (as in oss-cad-suite) where BBA tool is built as separate project out of this CMakeList.txt file.
It also removes not needed boost library dependency.