### PR TITLE
gatemate: propagate clock constraints on input ports

### DIFF
--- a/himbaechel/uarch/gatemate/bitstream.cc
+++ b/himbaechel/uarch/gatemate/bitstream.cc
@@ -154,7 +154,7 @@ struct BitstreamBackend
     {
         ChipConfig cc;
         cc.chip_name = device;
-        int bank[9] = { 0 };
+        int bank[9] = {0};
         for (auto &cell : ctx->cells) {
             CfgLoc loc = get_config_loc(cell.second.get()->bel.tile);
             auto &params = cell.second.get()->params;

--- a/himbaechel/uarch/gatemate/pack.cc
+++ b/himbaechel/uarch/gatemate/pack.cc
@@ -222,6 +222,23 @@ void GateMatePacker::remove_not_used()
     }
 }
 
+void GateMatePacker::copy_constraint(NetInfo *in_net, NetInfo *out_net)
+{
+    if (!in_net || !out_net)
+        return;
+    if (ctx->debug)
+        log_info("copy clock period constraint on net '%s' from net '%s'\n", out_net->name.c_str(ctx),
+                 in_net->name.c_str(ctx));
+    if (out_net->clkconstr.get() != nullptr)
+        log_warning("found multiple clock constraints on net '%s'\n", out_net->name.c_str(ctx));
+    if (in_net->clkconstr) {
+        out_net->clkconstr = std::unique_ptr<ClockConstraint>(new ClockConstraint());
+        out_net->clkconstr->low = in_net->clkconstr->low;
+        out_net->clkconstr->high = in_net->clkconstr->high;
+        out_net->clkconstr->period = in_net->clkconstr->period;
+    }
+}
+
 void GateMateImpl::pack()
 {
     const ArchArgs &args = ctx->args;

--- a/himbaechel/uarch/gatemate/pack.h
+++ b/himbaechel/uarch/gatemate/pack.h
@@ -65,6 +65,7 @@ struct GateMatePacker
     CellInfo *create_cell_ptr(IdString type, IdString name);
     void flush_cells();
     void pack_ram_cell(CellInfo &ci, CellInfo *cell, int num, bool is_split);
+    void copy_constraint(NetInfo *in_net, NetInfo *out_net);
 
     pool<IdString> packed_cells;
     std::map<NetInfo *, int> global_signals;

--- a/himbaechel/uarch/gatemate/pack_bram.cc
+++ b/himbaechel/uarch/gatemate/pack_bram.cc
@@ -66,7 +66,6 @@ uint8_t GateMatePacker::ram_clk_signal(CellInfo *cell, IdString port)
             val = 0b00010011;
             break;
         }
-        cell->disconnectPort(port);
         return val;
     }
 }

--- a/himbaechel/uarch/gatemate/pack_clocking.cc
+++ b/himbaechel/uarch/gatemate/pack_clocking.cc
@@ -131,14 +131,7 @@ void GateMatePacker::pack_bufg()
             if (is_cpe_source) {
                 ci.cluster = ci.name;
             }
-
-            if (in_net->clkconstr) {
-                NetInfo *o_net = ci.getPort(id_O);
-                o_net->clkconstr = std::unique_ptr<ClockConstraint>(new ClockConstraint());
-                o_net->clkconstr->low = in_net->clkconstr->low;
-                o_net->clkconstr->high = in_net->clkconstr->high;
-                o_net->clkconstr->period = in_net->clkconstr->period;
-            }
+            copy_constraint(in_net, ci.getPort(id_O));
         }
         ci.type = id_BUFG;
     }

--- a/himbaechel/uarch/gatemate/pack_io.cc
+++ b/himbaechel/uarch/gatemate/pack_io.cc
@@ -168,6 +168,13 @@ void GateMatePacker::pack_io()
         if (ci.type == id_CC_LVDS_TOBUF && !ci.getPort(id_T))
             ci.type = id_CC_LVDS_OBUF;
 
+        if (ci.type.in(id_CC_IBUF, id_CC_IOBUF))
+            copy_constraint(ci.getPort(id_I), ci.getPort(id_Y));
+        if (ci.type.in(id_CC_LVDS_IBUF, id_CC_LVDS_IOBUF)) {
+            copy_constraint(ci.getPort(id_I_P), ci.getPort(id_Y));
+            copy_constraint(ci.getPort(id_I_N), ci.getPort(id_Y));
+        }
+
         std::vector<IdString> keys;
         for (auto &p : ci.params) {
 


### PR DESCRIPTION
This change propagates clock constraints for input ports as well making SDC files usable on this uarch.
Removed disconnecting global clock (even routing already exported fine as config only) since otherwise clock does not get covered by nextpnr timing analysis.

P.S. Also have run clangformat and that change is in due to that.