### PR TITLE
gatemate: include DDR route-throughs in clock router

### DIFF
--- a/himbaechel/uarch/gatemate/gatemate.h
+++ b/himbaechel/uarch/gatemate/gatemate.h
@@ -64,6 +64,7 @@ struct GateMateImpl : HimbaechelAPI
 
     std::set<IdString> available_pads;
     std::map<BelId, const PadInfoPOD *> bel_to_pad;
+    pool<IdString> ddr_nets;
 
   private:
     bool getChildPlacement(const BaseClusterInfo *cluster, Loc root_loc,

--- a/himbaechel/uarch/gatemate/pack_io.cc
+++ b/himbaechel/uarch/gatemate/pack_io.cc
@@ -476,6 +476,7 @@ void GateMatePacker::pack_io_sel()
                     } else {
                         oddr->movePortTo(id_DDR, &ci, id_DDR);
                         cpe_half = move_ram_o(&ci, id_DDR, false);
+                        uarch->ddr_nets.insert(cpe_half->getPort(id_IN1)->name);
                         ctx->bindBel(get_bank_cpe(pad->pad_bank), cpe_half, PlaceStrength::STRENGTH_FIXED);
                         ddr[pad->pad_bank] = cpe_half;
                     }

--- a/himbaechel/uarch/gatemate/route_clock.cc
+++ b/himbaechel/uarch/gatemate/route_clock.cc
@@ -85,19 +85,17 @@ void GateMateImpl::route_clock()
                 auto clk_sink_wire = ctx->getNetinfoSinkWire(net, usr, 0);
                 reserve(clk_sink_wire, net);
 
-                auto en_port = usr.cell->ports.find(id_EN);
-                if (en_port != usr.cell->ports.end() && en_port->second.net != nullptr) {
-                    auto en_sink_wire = ctx->getNetinfoSinkWire(
-                            en_port->second.net, en_port->second.net->users.at(en_port->second.user_idx), 0);
-                    reserve(en_sink_wire, en_port->second.net);
-                }
+                auto reserve_port_if_needed = [&](IdString port_name) {
+                    auto port = usr.cell->ports.find(port_name);
+                    if (port != usr.cell->ports.end() && port->second.net != nullptr) {
+                        auto sink_wire = ctx->getNetinfoSinkWire(port->second.net,
+                                                                 port->second.net->users.at(port->second.user_idx), 0);
+                        reserve(sink_wire, port->second.net);
+                    }
+                };
 
-                auto sr_port = usr.cell->ports.find(id_SR);
-                if (sr_port != usr.cell->ports.end() && sr_port->second.net != nullptr) {
-                    auto sr_sink_wire = ctx->getNetinfoSinkWire(
-                            sr_port->second.net, sr_port->second.net->users.at(sr_port->second.user_idx), 0);
-                    reserve(sr_sink_wire, sr_port->second.net);
-                }
+                reserve_port_if_needed(id_EN);
+                reserve_port_if_needed(id_SR);
             }
         }
 


### PR DESCRIPTION
DDR I/O requires a route-through CPE to pass the clock in, but since it doesn't go through the CPE CLK port, it wasn't guaranteed that the clock would be routed by the clock router, leading to clock-skew problems in some designs.

Thus we pass the DDR nets from the packer to the clock router to ensure they get routed.

I also included a small cleanup patch just to make that section a little nicer.
