### PR TITLE
himbaechel: xilinx: misc `CMakeLists.txt` improvements

### DIFF
--- a/himbaechel/uarch/xilinx/CMakeLists.txt
+++ b/himbaechel/uarch/xilinx/CMakeLists.txt
@@ -35,7 +35,8 @@ message(STATUS "Enabled Himbaechel-Xilinx devices: ${HIMBAECHEL_XILINX_DEVICES}"
 foreach (device ${HIMBAECHEL_XILINX_DEVICES})
     add_bba_produce_command(
         TARGET  nextpnr-himbaechel-xilinx-bba
-        COMMAND /usr/bin/pypy3 ${CMAKE_CURRENT_SOURCE_DIR}/gen/xilinx_gen.py
+        COMMAND ${Python3_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/gen/xilinx_gen.py
             --xray ${HIMBAECHEL_PRJXRAY_DB}/artix7
             --device ${device}
             --bba ${CMAKE_CURRENT_BINARY_DIR}/chipdb-${device}.bba.new

--- a/himbaechel/uarch/xilinx/CMakeLists.txt
+++ b/himbaechel/uarch/xilinx/CMakeLists.txt
@@ -24,7 +24,7 @@ add_nextpnr_himbaechel_microarchitecture(${uarch}
 
 set(HIMBAECHEL_PRJXRAY_DB "" CACHE STRING
     "Path to a project x-ray database")
-if (NOT HIMBAECHEL_PRJXRAY_DB)
+if (NOT HIMBAECHEL_PRJXRAY_DB AND NOT IMPORT_BBA_FILES)
     message(FATAL_ERROR "HIMBAECHEL_PRJXRAY_DB must be set to a prjxray database checkout")
 endif()
 

--- a/himbaechel/uarch/xilinx/CMakeLists.txt
+++ b/himbaechel/uarch/xilinx/CMakeLists.txt
@@ -28,14 +28,22 @@ if (NOT HIMBAECHEL_PRJXRAY_DB AND NOT IMPORT_BBA_FILES)
     message(FATAL_ERROR "HIMBAECHEL_PRJXRAY_DB must be set to a prjxray database checkout")
 endif()
 
-set(HIMBAECHEL_XILINX_DEVICES "" CACHE STRING
-    "Include support for these Xilinx devices")
+set(ALL_HIMBAECHEL_XILINX_DEVICES xc7a100t xc7a200t xc7a50t xc7s50 xc7z010 xc7z020)
+set(HIMBAECHEL_XILINX_DEVICES ${ALL_HIMBAECHEL_XILINX_DEVICES} CACHE STRING
+    "Include support for these Xilinx devices (available: ${ALL_HIMBAECHEL_XILINX_DEVICES})")
+if (HIMBAECHEL_XILINX_DEVICES STREQUAL "all")
+    set(HIMBAECHEL_XILINX_DEVICES ${ALL_HIMBAECHEL_XILINX_DEVICES})
+endif()
 message(STATUS "Enabled Himbaechel-Xilinx devices: ${HIMBAECHEL_XILINX_DEVICES}")
+
+if (NOT XilinxChipdb_Python3_EXECUTABLE)
+    find_program(XilinxChipdb_Python3_EXECUTABLE NAMES pypy3 python3)
+endif()
 
 foreach (device ${HIMBAECHEL_XILINX_DEVICES})
     add_bba_produce_command(
         TARGET  nextpnr-himbaechel-xilinx-bba
-        COMMAND ${Python3_EXECUTABLE}
+        COMMAND ${XilinxChipdb_Python3_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/gen/xilinx_gen.py
             --xray ${HIMBAECHEL_PRJXRAY_DB}/artix7
             --device ${device}


### PR DESCRIPTION
This PR brings `himbaechel/uarch/xilinx/CMakeLists.txt` closer to its counterparts.

1. Replace hardcoded `/usr/bin/python3` with the more common `${Python3_EXECUTABLE}`, which can be set when calling `cmake`.
2. Recognize `IMPORT_BBA_FILES`, making it possible to use `.bba` files without setting `HIMBAECHEL_PRJXRAY_DB`.
3. Recognize "all" as a valid value for `HIMBAECHEL_XILINX_DEVICES`, defaulting to the list of devices that can be built from [f4pga/prjxray-db](https://github.com/f4pga/prjxray-db).

These changes were made while trying to enable support for Xilinx devices on a fork of `oss-cad-suite-build`. I've split them all in different commits to facilitate rejecting any of them separately, but I could also squash them together if that's desirable.