### PR TITLE
himbaechel: gatemate: replace VLA with C++ features

### DIFF
--- a/himbaechel/uarch/gatemate/bitstream.cc
+++ b/himbaechel/uarch/gatemate/bitstream.cc
@@ -223,7 +223,7 @@ struct BitstreamBackend
     {
         ChipConfig cc;
         cc.chip_name = device;
-        int bank[uarch->dies][9] = {0};
+        std::vector<std::array<int, 9>> bank(uarch->dies);
         for (auto &cell : ctx->cells) {
             CfgLoc loc = get_config_loc(cell.second.get()->bel.tile);
             auto &params = cell.second.get()->params;

--- a/himbaechel/uarch/gatemate/pack_clocking.cc
+++ b/himbaechel/uarch/gatemate/pack_clocking.cc
@@ -329,7 +329,7 @@ void GateMatePacker::remove_clocking()
 
 void GateMatePacker::pack_pll()
 {
-    int pll_index[uarch->dies] = {0};
+    std::vector<int> pll_index(uarch->dies);
     log_info("Packing PLLss..\n");
     for (auto &cell : ctx->cells) {
         CellInfo &ci = *cell.second;

--- a/himbaechel/uarch/gatemate/pack_io.cc
+++ b/himbaechel/uarch/gatemate/pack_io.cc
@@ -326,7 +326,7 @@ void GateMatePacker::pack_io_sel()
         cells.push_back(&ci);
     }
 
-    CellInfo *ddr[uarch->dies][9] = {nullptr}; // for each bank
+    std::vector<std::array<CellInfo *, 9>> ddr(uarch->dies); // for each bank
 
     auto set_out_clk = [&](CellInfo *cell, CellInfo *target) -> bool {
         NetInfo *clk_net = cell->getPort(id_CLK);


### PR DESCRIPTION
Apparently `clang` doesn't like VLAs that much, and neither do I or C++ in general (they are not in the language spec). Using vectors is not exactly identical but it should work the same.

After these changes, [`nextpnr-himbaechel` can be build for `darwin-arm64`](https://github.com/jmi2k/oss-cad-suite-build/actions/runs/16005189044).

Unfortunately, I don't own a device to test these changes (neither an Apple device nor a Gatemate FPGA) so these changes are not tested.