### PR TITLE
machxo3d: minor fixes for I3C pins and RPLL

### DIFF
--- a/machxo2/bitstream.cc
+++ b/machxo2/bitstream.cc
@@ -214,8 +214,8 @@ struct MachXO2Bitgen
         static const std::set<std::string> pio_l = {"PIC_L0",       "PIC_L1",        "PIC_L2",        "PIC_L3",
                                                     "PIC_LS0",      "PIC_L0_VREF3",  "PIC_L0_VREF4",  "PIC_L0_VREF5",
                                                     "PIC_L1_VREF3", "PIC_L1_VREF4",  "PIC_L1_VREF5",  "PIC_L2_VREF4",
-                                                    "PIC_L2_VREF5", "PIC_L3_VREF4",  "PIC_L3_VREF5",  "LLC0PIC",
-                                                    "LLC1PIC",      "LLC0PIC_VREF3", "LLC3PIC_VREF3", "ULC3PIC"};
+                                                    "PIC_L2_VREF5", "PIC_L3_VREF4",  "PIC_L3_VREF5",  "LLC0PIC", "LLC0PIC_I3C_VREF3",
+                                                    "LLC1PIC",      "LLC0PIC_VREF3", "LLC3PIC_VREF3", "ULC3PIC", "PIC_L0_I3C"};
         static const std::set<std::string> pio_r = {"PIC_R0",      "PIC_R1",   "PIC_RS0",  "PIC_R0_256", "PIC_R1_640",
                                                     "PIC_RS0_256", "LRC1PIC1", "LRC1PIC2", "URC1PIC"};
 
@@ -267,7 +267,7 @@ struct MachXO2Bitgen
         if (name == "LPLL") {
             tiles.push_back(ctx->get_tile_by_type_loc(loc.y - 1, loc.x - 1, "GPLL_L0"));
         } else if (name == "RPLL") {
-            tiles.push_back(ctx->get_tile_by_type_loc(loc.y + 1, loc.x - 1, "GPLL_R0"));
+            tiles.push_back(ctx->get_tile_by_type_loc(loc.y - 1, loc.x + 1, "GPLL_R0"));
         } else {
             NPNR_ASSERT_FALSE_STR("bad PLL loc " + name);
         }


### PR DESCRIPTION
When using nextpnr and trying to build a design that uses the pins that have I3C functionality, for example `LCMXO3D-9400HC-6SG72I`, I would get an error:
```
Terminate called after throwing an instance of 'nextpnr_machxo2::assertion_failure'
  what():  Assertion failure: no tile at (0, 29) with type in set (/home/via/dev/nextpnr/machxo2/arch.h:1026)
Aborted
```

I get a similar error when using RPLL, and after debugging I saw that the GPLL_R0 location was close but didn't match. I'm assuming this is just a typo and the second PLL hasn't been tested, but I don't know much about these things and don't know if this fix is appropriate (or might break other machxo(2) chips)