### PR TITLE
Gowin. Preparing to support the 5A series.

### DIFF
--- a/himbaechel/uarch/gowin/gowin.cc
+++ b/himbaechel/uarch/gowin/gowin.cc
@@ -129,14 +129,19 @@ void GowinImpl::init_database(Arch *arch)
         if (GW2) {
             log_error("For the GW2A series you need to specify --vopt family=GW2A-18 or --vopt family=GW2A-18C\n");
         } else {
-            std::regex devicere = std::regex("GW1N([SZ]?)[A-Z]*-(LV|UV|UX)([0-9])(C?).*");
-            std::smatch match;
-            if (!std::regex_match(args.device, match, devicere)) {
-                log_error("Invalid device %s\n", args.device.c_str());
-            }
-            family = stringf("GW1N%s-%s", match[1].str().c_str(), match[3].str().c_str());
-            if (family.rfind("GW1N-9", 0) == 0) {
-                log_error("For the GW1N-9 series you need to specify --vopt family=GW1N-9 or --vopt family=GW1N-9C\n");
+            if (args.device.rfind("GW5A", 0) == 0) {
+                family = "GW5A-25A";
+            } else {
+                std::regex devicere = std::regex("GW1N([SZ]?)[A-Z]*-(LV|UV|UX)([0-9])(C?).*");
+                std::smatch match;
+                if (!std::regex_match(args.device, match, devicere)) {
+                    log_error("Invalid device %s\n", args.device.c_str());
+                }
+                family = stringf("GW1N%s-%s", match[1].str().c_str(), match[3].str().c_str());
+                if (family.rfind("GW1N-9", 0) == 0) {
+                    log_error("For the GW1N-9 series you need to specify --vopt family=GW1N-9 or --vopt "
+                              "family=GW1N-9C\n");
+                }
             }
         }
     }
@@ -175,17 +180,17 @@ void GowinImpl::init(Context *ctx)
         spd = ctx->id(match[2]);
         ctx->set_speed_grade(match[2]);
     } else {
-        if (pn.length() > 2 && pn.compare(pn.length() - 2, 2, "ES")) {
-            package_idx = ctx->id(pn.substr(pn.length() - 2));
+        if (pn.length() > 2 && pn.compare(pn.length() - 3, 2, "ES")) {
+            package_idx = ctx->id(pn.substr(0, pn.length() - 2));
             spd = ctx->id("ES");
             ctx->set_speed_grade("ES");
         }
     }
 
-    // log_info("packages:%ld\n", ctx->chip_info->packages.ssize());
+    // log_info("search for %s, packages:%ld\n", package_idx.c_str(ctx), ctx->chip_info->packages.ssize());
     for (int i = 0; i < ctx->chip_info->packages.ssize(); ++i) {
+        // log_info("i:%d %s\n", i, IdString(ctx->chip_info->packages[i].name).c_str(ctx));
         if (IdString(ctx->chip_info->packages[i].name) == package_idx) {
-            // log_info("i:%d %s\n", i, package_idx.c_str(ctx));
             ctx->package_info = &ctx->chip_info->packages[i];
             break;
         }

--- a/himbaechel/uarch/gowin/gowin_arch_gen.py
+++ b/himbaechel/uarch/gowin/gowin_arch_gen.py
@@ -512,7 +512,7 @@ def create_switch_matrix(tt: TileType, db: chipdb, x: int, y: int):
             tt.create_pip(src, dst, get_tm_class(db, src))
 
     # clock wires
-    for dst, srcs in db.grid[y][x].pure_clock_pips.items():
+    for dst, srcs in db.grid[y][x].clock_pips.items():
         if not tt.has_wire(dst):
             tt.create_wire(dst, "GLOBAL_CLK")
         for src in srcs.keys():
@@ -1426,7 +1426,7 @@ def create_timing_info(chip: Chip, db: chipdb.Device):
         return TimingValue(min(ff, fr, rf, rr), max(ff, fr, rf, rr))
 
     speed_grades = []
-    for speed, _ in db.timing.items():
+    for speed in db.timing.keys():
         speed_grades.append(speed)
 
     tmg = chip.set_speed_grades(speed_grades)


### PR DESCRIPTION
Family recognition is added, as well as minor fixes, but base generation itself is not allowed for GW5A - this gives the ability to test the next Apicula release and still not break installations for those who simply specify `HIMBAECHEL_GOWIN_DEVICES = "all"`.