### PR TITLE
gatemate: fix SER_CLK wiring from CLKIN to PLL

### DIFF
--- a/himbaechel/uarch/gatemate/pack_clocking.cc
+++ b/himbaechel/uarch/gatemate/pack_clocking.cc
@@ -275,14 +275,14 @@ void GateMatePacker::insert_bufg(CellInfo *cell, IdString port)
             NetInfo *net = ctx->createNet(ctx->idf("%s", bufg->name.c_str(ctx)));
             cell->connectPort(port, net);
             bufg->connectPort(id_I, net);
-            log_info("Added BUFG for cell '%s' signal %s\n", cell->name.c_str(ctx), port.c_str(ctx));
+            log_info("    Added BUFG for cell '%s' signal %s\n", cell->name.c_str(ctx), port.c_str(ctx));
         }
     }
 }
 
 void GateMatePacker::insert_pll_bufg()
 {
-    log_info("Insert BUFGs for PLLs..\n");
+    log_info("Insert clocking cells..\n");
     for (int i = 0; i < uarch->dies; i++) {
         Loc fixed_loc = uarch->locations[std::make_pair(id_CLKIN, i)];
         clkin.push_back(create_cell_ptr(id_CLKIN, ctx->idf("CLKIN%d", i)));
@@ -293,6 +293,7 @@ void GateMatePacker::insert_pll_bufg()
         BelId glbout_bel = ctx->getBelByLocation(fixed_loc);
         ctx->bindBel(glbout_bel, glbout.back(), PlaceStrength::STRENGTH_FIXED);
     }
+    log_info("Insert BUFGs for PLLs..\n");
     std::vector<CellInfo *> cells;
     for (auto &cell : ctx->cells) {
         CellInfo &ci = *cell.second;

--- a/himbaechel/uarch/gatemate/pll.cc
+++ b/himbaechel/uarch/gatemate/pll.cc
@@ -263,7 +263,7 @@ PllCfgRecord GateMatePacker::get_pll_settings(double f_ref, double f_core, int m
                         if (pll_cfg_arr[0].f_core_delta == 0) {
                             get_DCO_ext_feedback(f_core, f_ref, pll_cfg_arr[0], f_dco_min, f_dco_max, f_dco,
                                                  max_input_freq);
-                            log_info("PLL fout= %.4f MHz (fout error %.5f%% of requested %.4f MHz)\n",
+                            log_info("    PLL fout= %.4f MHz (fout error %.5f%% of requested %.4f MHz)\n",
                                      pll_cfg_arr[0].f_core,
                                      100 - (100 * std::min(pll_cfg_arr[0].f_core, f_core_par) /
                                             std::max(pll_cfg_arr[0].f_core, f_core_par)),
@@ -344,7 +344,7 @@ PllCfgRecord GateMatePacker::get_pll_settings(double f_ref, double f_core, int m
                 return a.core_weight < b.core_weight;
             });
     PllCfgRecord val = pll_cfg_arr.at(std::distance(pll_cfg_arr.begin(), it));
-    log_info("PLL fout= %.4f MHz (fout error %.5f%% of requested %.4f MHz)\n", val.f_core,
+    log_info("    PLL fout= %.4f MHz (fout error %.5f%% of requested %.4f MHz)\n", val.f_core,
              100 - (100 * std::min(val.f_core, f_core_par) / std::max(val.f_core, f_core_par)), f_core);
     return val;
 }


### PR DESCRIPTION
Also makes sure to properly configure CLKIN, and formatted output messages.