### PR TITLE
Gowin. Remove search for old Apicula.

### DIFF
--- a/cmake/FindApycula.cmake
+++ b/cmake/FindApycula.cmake
@@ -1,8 +1,3 @@
-# nextpnr-gowin only
-
-find_program (GOWIN_BBA_EXECUTABLE gowin_bba)
-message(STATUS "gowin_bba executable: ${GOWIN_BBA_EXECUTABLE}")
-
 # nextpnr-himbaechel-gowin only
 
 if (DEFINED ENV{APYCULA_INSTALL_PREFIX})


### PR DESCRIPTION
This item is likely no longer necessary, as this executable file has been unavailable since May, with the complete transition to Himbaechel.