### PR TITLE
Gowin. Add pin configurations bel/cell.

### DIFF
--- a/himbaechel/uarch/gowin/constids.inc
+++ b/himbaechel/uarch/gowin/constids.inc
@@ -1011,6 +1011,11 @@ X(GSRI)
 X(BANDGAP)
 X(BGEN)
 
+// pin function config
+X(PINCFG)
+X(SSPI)
+X(I2C)
+
 // inverter
 X(INV)
 

--- a/himbaechel/uarch/gowin/gowin.h
+++ b/himbaechel/uarch/gowin/gowin.h
@@ -196,6 +196,7 @@ NPNR_PACKED_STRUCT(struct Extra_chip_data_POD {
     static constexpr int32_t HAS_BANDGAP = 16;
     static constexpr int32_t HAS_PLL_HCLK = 32;
     static constexpr int32_t HAS_CLKDIV_HCLK = 64;
+    static constexpr int32_t HAS_PINCFG = 128;
 });
 
 } // namespace
@@ -242,6 +243,8 @@ enum
     MIPIIBUF_Z = 302,
 
     DLLDLY_Z = 303, // : 305 reserve for 2 DLLDLYs
+
+    PINCFG_Z = 400,
 
     // The two least significant bits encode Z for 9-bit adders and
     // multipliers, if they are equal to 0, then we get Z of their common

--- a/himbaechel/uarch/gowin/gowin_arch_gen.py
+++ b/himbaechel/uarch/gowin/gowin_arch_gen.py
@@ -22,6 +22,7 @@ CHIP_NEED_BLKSEL_FIX       = 0x8
 CHIP_HAS_BANDGAP           = 0x10
 CHIP_HAS_PLL_HCLK          = 0x20
 CHIP_HAS_CLKDIV_HCLK       = 0x40
+CHIP_HAS_PINCFG            = 0x80
 
 # Tile flags
 TILE_I3C_CAPABLE_IO        = 0x1
@@ -66,6 +67,8 @@ MIPIOBUF_Z  = 301
 MIPIIBUF_Z  = 302
 
 DLLDLY_Z    = 303 # : 305 reserve for 2 DLLDLYs
+
+PINCFG_Z    = 400 #
 
 DSP_Z          = 509
 
@@ -755,6 +758,13 @@ def create_extra_funcs(tt: TileType, db: chipdb, x: int, y: int):
                     if not tt.has_wire(wire):
                         tt.create_wire(wire, "EMCU_OUT")
                     tt.add_bel_pin(bel, port, wire, PinType.OUTPUT)
+        elif func == 'pincfg':
+                bel = tt.create_bel("PINCFG", "PINCFG", PINCFG_Z)
+                portmap = desc['ins']
+                for port, wire in portmap.items():
+                    if not tt.has_wire(wire):
+                        tt.create_wire(wire, "PINCFG_IN")
+                    tt.add_bel_pin(bel, port, wire, PinType.INPUT)
 
 def create_tiletype(create_func, chip: Chip, db: chipdb, x: int, y: int, ttyp: int):
     has_extra_func = (y, x) in db.extra_func
@@ -1566,6 +1576,8 @@ def main():
             chip_flags |= CHIP_HAS_PLL_HCLK;
         if "HAS_CLKDIV_HCLK" in db.chip_flags:
             chip_flags |= CHIP_HAS_CLKDIV_HCLK;
+        if "HAS_PINCFG" in db.chip_flags:
+            chip_flags |= CHIP_HAS_PINCFG;
 
     X = db.cols;
     Y = db.rows;

--- a/himbaechel/uarch/gowin/gowin_utils.cc
+++ b/himbaechel/uarch/gowin/gowin_utils.cc
@@ -330,6 +330,12 @@ bool GowinUtils::has_BANDGAP(void)
     return extra->chip_flags & Extra_chip_data_POD::HAS_BANDGAP;
 }
 
+bool GowinUtils::has_PINCFG(void)
+{
+    const Extra_chip_data_POD *extra = reinterpret_cast<const Extra_chip_data_POD *>(ctx->chip_info->extra_data.get());
+    return extra->chip_flags & Extra_chip_data_POD::HAS_PINCFG;
+}
+
 bool GowinUtils::has_SP32(void)
 {
     const Extra_chip_data_POD *extra = reinterpret_cast<const Extra_chip_data_POD *>(ctx->chip_info->extra_data.get());

--- a/himbaechel/uarch/gowin/gowin_utils.h
+++ b/himbaechel/uarch/gowin/gowin_utils.h
@@ -96,6 +96,9 @@ struct GowinUtils
     // Power saving
     bool has_BANDGAP(void);
 
+    // Pin function configuration via wires
+    bool has_PINCFG(void);
+
     // DSP
     inline int get_dsp_18_z(int z) const { return z & (~3); }
     inline int get_dsp_9_idx(int z) const { return z & 3; }


### PR DESCRIPTION
Prior to the 5A series, pin functions (GPIO/SSPI/JTAG/DONE/etc) were switched using fuses. This was done during the binary image formation stage for loading into the FPGA using the command line keys of the gowin_pack program.

The 5A series features certain ports that connect to VCC or GND depending on whether the pin is used as SSPI or GPIO, for example. This mechanism exists in parallel with fuses, but it is not described anywhere, nor is there a corresponding primitive.

To generate working images, we have no choice but to simulate this thing at the nextpnr stage, since VCC/GND routing is required.

For now, two flags are added, responsible for the SSPI and I2C pin functions.