### PR TITLE
gatemate: remove placement density restriction

### DIFF
--- a/common/kernel/command.cc
+++ b/common/kernel/command.cc
@@ -382,7 +382,7 @@ po::options_description CommandHandler::getGeneralOptions()
                           "disable printing of the line numbers associated with each net in the critical path");
 
     general.add_options()("placer-heap-alpha", po::value<float>(), "placer heap alpha value (float, default: 0.1)");
-    general.add_options()("placer-heap-beta", po::value<float>(), "placer heap beta value (float, default: 0.9)");
+    general.add_options()("placer-heap-beta", po::value<float>(), "placer heap maximum placement density (float, default: 0.9)");
     general.add_options()("placer-heap-critexp", po::value<int>(),
                           "placer heap criticality exponent (int, default: 2)");
     general.add_options()("placer-heap-timingweight", po::value<int>(), "placer heap timing weight (int, default: 10)");

--- a/himbaechel/uarch/gatemate/gatemate.cc
+++ b/himbaechel/uarch/gatemate/gatemate.cc
@@ -202,7 +202,6 @@ void GateMateImpl::postRoute()
 
 void GateMateImpl::configurePlacerHeap(PlacerHeapCfg &cfg)
 {
-    cfg.beta = 0.5;
     cfg.placeAllAtOnce = true;
 }
 


### PR DESCRIPTION
Since the beginning of the GateMate uarch, the maximum placement density (beta) has been limited to 50%., which was presumably inherited from NG-Ultra. GateMate does not have the routability issues that NG-Ultra has, so this restriction is unnecessary, and provides a free Fmax improvement.

Here's an Fmax comparision between the current limit (0.5) and the nextpnr default (0.9) over 100 seeds of 063-litex-kianv, the worst-performing SoC in our testsuite. Because beta is the *maximum* placement density, in practice it stops being the limiting factor at 0.9.

beta | minimum Fmax (MHz) | 25% quartile (MHz) | median Fmax (MHz) | 75% quartile (MHz) | maximum Fmax (MHz)
-- | -- | -- | -- | -- | --
0.5 | 17.69 | 20.02 | 21.28 | 27.4725 | 30.57
0.9 | 18.19 | 22.8725 | 24.485 | 28.485 | 32.99

(and while I was here, I improved the description of the `--placer-heap-beta` setting.)



