### PR TITLE
gatemate: don't place cells all at once

### DIFF
--- a/himbaechel/uarch/gatemate/gatemate.cc
+++ b/himbaechel/uarch/gatemate/gatemate.cc
@@ -200,11 +200,6 @@ void GateMateImpl::postRoute()
     }
 }
 
-void GateMateImpl::configurePlacerHeap(PlacerHeapCfg &cfg)
-{
-    cfg.placeAllAtOnce = true;
-}
-
 int GateMateImpl::get_dff_config(CellInfo *dff) const
 {
     int val = 0;

--- a/himbaechel/uarch/gatemate/gatemate.h
+++ b/himbaechel/uarch/gatemate/gatemate.h
@@ -58,8 +58,6 @@ struct GateMateImpl : HimbaechelAPI
 
     Loc getRelativeConstraint(Loc &root_loc, IdString id) const;
 
-    void configurePlacerHeap(PlacerHeapCfg &cfg) override;
-
     bool isPipInverting(PipId pip) const override;
 
     const GateMateTileExtraDataPOD *tile_extra_data(int tile) const;


### PR DESCRIPTION
Follow-up to #1527.

As an idle experiment, I also tried to quantify the effects of the `placeAllAtOnce = true` setting on performance, using the same experiment.

placeAllAtOnce | 0% | 25% | 50% | 75% | 100%
-- | -- | -- | -- | -- | --
TRUE | 18.19 | 22.8725 | 24.485 | 28.485 | 32.99
FALSE | 18.36 | 24.955 | 27.1 | 29.135 | 32.95

so I guess that's being turned off too. that leaves gatemate using the default heap configuration, so we can remove the override.