### PR TITLE
Revert "gatemate: don't place cells all at once (#1528)"

### DIFF
--- a/himbaechel/uarch/gatemate/gatemate.cc
+++ b/himbaechel/uarch/gatemate/gatemate.cc
@@ -200,6 +200,11 @@ void GateMateImpl::postRoute()
     }
 }
 
+void GateMateImpl::configurePlacerHeap(PlacerHeapCfg &cfg)
+{
+    cfg.placeAllAtOnce = true;
+}
+
 int GateMateImpl::get_dff_config(CellInfo *dff) const
 {
     int val = 0;

--- a/himbaechel/uarch/gatemate/gatemate.h
+++ b/himbaechel/uarch/gatemate/gatemate.h
@@ -58,6 +58,8 @@ struct GateMateImpl : HimbaechelAPI
 
     Loc getRelativeConstraint(Loc &root_loc, IdString id) const;
 
+    void configurePlacerHeap(PlacerHeapCfg &cfg) override;
+
     bool isPipInverting(PipId pip) const override;
 
     const GateMateTileExtraDataPOD *tile_extra_data(int tile) const;


### PR DESCRIPTION
This causes infinite loops trying to legalise RAMs in large designs, presumably due to clustering. I think we should keep this idea in the back pocket; perhaps with a command line option to change place-all-at-once behaviour, but right now I don't think we can justify breaking the flow for performance gains.