### PR TITLE
Change Hash Embed check to check for erroneous signed #embed

### DIFF
--- a/cmake/CheckCXXCompilerHashEmbed.cmake
+++ b/cmake/CheckCXXCompilerHashEmbed.cmake
@@ -9,11 +9,15 @@
 # set(CMAKE_CXX_FLAGS ${CXX_FLAGS_HASH_EMBED} ${CMAKE_CXX_FLAGS})
 #
 function(check_cxx_compiler_hash_embed VAR FLAGS_VAR)
+    # Create a binary file with at least one byte that will check for #embed treating things as signed chars
+    execute_process(
+          COMMAND python3 -c "with open('${CMAKE_CURRENT_BINARY_DIR}/unsigned_bin', 'wb') as f: f.write(b'\\xA5\\x27\\x00')")
+
     try_compile(
         ${VAR}
         SOURCE_FROM_CONTENT
             compiletest.cc
-            "const char s[] = {\n#embed \"${CMAKE_CURRENT_FUNCTION_LIST_FILE}\"\n};\nint main() {}"
+            "const unsigned char s[] = {\n#embed \"${CMAKE_CURRENT_BINARY_DIR}/unsigned_bin\"\n};\nint main() {}"
     )
     if (${VAR})
         if (FLAGS_VAR)


### PR DESCRIPTION
Apple Clang++ 17.0.0 (Xcode build tool installed version for macOS 15.6) fails to compile nextpnr@master because clang++ treats hash embeds as signed data (even though the same version of clang handles the same exact file just fine). [Minimum example for behavior reproduction](https://github.com/Willmac16/macos-embed-bug) on the right clang version.

Here's the error I get when compiling against master:
```bash
/Users/wmac/orange/nextpnr/build/ecp5/chipdb-45k.bin.cc:5:1: error: constant expression evaluates to -96 which cannot be narrowed to type 'uint8_t' (aka 'unsigned char') [-Wc++11-narrowing]
    5 | #embed "/Users/wmac/orange/nextpnr/build/ecp5/chipdb-45k.bin"
      | ^
/Users/wmac/orange/nextpnr/build/ecp5/chipdb-45k.bin.cc:5:1: note: insert an explicit cast to silence this issue
    5 | #embed "/Users/wmac/orange/nextpnr/build/ecp5/chipdb-45k.bin"
      | ^
      | static_cast<uint8_t>( )
```

This PR changes the hash embed check to pass in some values larger than decimal 127 (since the existing code only tests against ASCII which allows my buggy compiler version to pass the check).

