### PR TITLE
Gowin. Use two additional DFFs.

### DIFF
--- a/himbaechel/uarch/gowin/gowin.cc
+++ b/himbaechel/uarch/gowin/gowin.cc
@@ -1060,7 +1060,7 @@ bool GowinImpl::slice_valid(int x, int y, int z) const
             }
         }
         // Check whether the current architecture allows 6 and 7 DFFs
-        if (z > 3 && ctx->getBelByLocation(Loc(x, y, 6 * 2 + 1)) != BelId()) {
+        if (z > 3 && gwu.has_DFF67()) {
             // The 4th, 5th, 6th, and 7th DFFs have the same control wires. Let's check this.
             const int adj_top_ff_z = (5 - (z >> 1)) * 4 + 1;
             for (int i = 0; i < 4; i += 2) {

--- a/himbaechel/uarch/gowin/gowin.h
+++ b/himbaechel/uarch/gowin/gowin.h
@@ -197,6 +197,7 @@ NPNR_PACKED_STRUCT(struct Extra_chip_data_POD {
     static constexpr int32_t HAS_PLL_HCLK = 32;
     static constexpr int32_t HAS_CLKDIV_HCLK = 64;
     static constexpr int32_t HAS_PINCFG = 128;
+    static constexpr int32_t HAS_DFF67 = 256;
 });
 
 } // namespace

--- a/himbaechel/uarch/gowin/gowin_arch_gen.py
+++ b/himbaechel/uarch/gowin/gowin_arch_gen.py
@@ -23,6 +23,7 @@ CHIP_HAS_BANDGAP           = 0x10
 CHIP_HAS_PLL_HCLK          = 0x20
 CHIP_HAS_CLKDIV_HCLK       = 0x40
 CHIP_HAS_PINCFG            = 0x80
+CHIP_HAS_DFF67             = 0x100
 
 # Tile flags
 TILE_I3C_CAPABLE_IO        = 0x1
@@ -964,7 +965,7 @@ def create_logic_tiletype(chip: Chip, db: chipdb, x: int, y: int, ttyp: int, tde
         for j, inp_name in enumerate(lut_inputs):
             tt.add_bel_pin(lut, f"I{j}", f"{inp_name}{i}", PinType.INPUT)
         tt.add_bel_pin(lut, "F", f"F{i}", PinType.OUTPUT)
-        if i < 6 or chip.name == "GW5A-25A":
+        if i < 6 or "HAS_DFF67" in db.chip_flags:
             tt.create_pip(f"F{i}", f"XD{i}", get_tm_class(db, f"F{i}"))
             # also experimental input for FF using SEL wire - this theory will
             # allow to place unrelated LUT and FF next to each other
@@ -1587,6 +1588,8 @@ def main():
             chip_flags |= CHIP_HAS_CLKDIV_HCLK;
         if "HAS_PINCFG" in db.chip_flags:
             chip_flags |= CHIP_HAS_PINCFG;
+        if "HAS_DFF67" in db.chip_flags:
+            chip_flags |= CHIP_HAS_DFF67;
 
     X = db.cols;
     Y = db.rows;

--- a/himbaechel/uarch/gowin/gowin_utils.cc
+++ b/himbaechel/uarch/gowin/gowin_utils.cc
@@ -336,6 +336,12 @@ bool GowinUtils::has_PINCFG(void)
     return extra->chip_flags & Extra_chip_data_POD::HAS_PINCFG;
 }
 
+bool GowinUtils::has_DFF67(void) const
+{
+    const Extra_chip_data_POD *extra = reinterpret_cast<const Extra_chip_data_POD *>(ctx->chip_info->extra_data.get());
+    return extra->chip_flags & Extra_chip_data_POD::HAS_DFF67;
+}
+
 bool GowinUtils::has_SP32(void)
 {
     const Extra_chip_data_POD *extra = reinterpret_cast<const Extra_chip_data_POD *>(ctx->chip_info->extra_data.get());

--- a/himbaechel/uarch/gowin/gowin_utils.h
+++ b/himbaechel/uarch/gowin/gowin_utils.h
@@ -99,6 +99,9 @@ struct GowinUtils
     // Pin function configuration via wires
     bool has_PINCFG(void);
 
+    // Logic cell structure
+    bool has_DFF67(void) const;
+
     // DSP
     inline int get_dsp_18_z(int z) const { return z & (~3); }
     inline int get_dsp_9_idx(int z) const { return z & 3; }


### PR DESCRIPTION
The GW-5A series has 8 flip-flops in a cell instead of 6. These additional flip-flops can be used if the control network matches that for the 4th and 5th DFFs in this cell.