### PR TITLE
himbaechel: Extend API to enable cell delay override

### DIFF
--- a/himbaechel/arch.cc
+++ b/himbaechel/arch.cc
@@ -454,14 +454,13 @@ TimingPortClass Arch::lookup_port_tmg_type(int type_idx, IdString port, PortType
     }
 }
 
-// TODO: adding uarch overrides for these?
-bool Arch::getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const
+bool Arch::get_cell_delay_default(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const
 {
     if (cell->timing_index == -1)
         return false;
     return lookup_cell_delay(cell->timing_index, fromPort, toPort, delay);
 }
-TimingPortClass Arch::getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const
+TimingPortClass Arch::get_port_timing_class_default(const CellInfo *cell, IdString port, int &clockInfoCount) const
 {
     if (cell->timing_index == -1)
         return TMG_IGNORE;
@@ -474,7 +473,7 @@ TimingPortClass Arch::getPortTimingClass(const CellInfo *cell, IdString port, in
     }
     return type;
 }
-TimingClockingInfo Arch::getPortClockingInfo(const CellInfo *cell, IdString port, int index) const
+TimingClockingInfo Arch::get_port_clocking_info_default(const CellInfo *cell, IdString port, int index) const
 {
     TimingClockingInfo result;
     NPNR_ASSERT(cell->timing_index != -1);

--- a/himbaechel/arch.h
+++ b/himbaechel/arch.h
@@ -864,13 +864,25 @@ struct Arch : BaseArch<ArchRanges>
     // Attempt to look up port type based on timing database
     TimingPortClass lookup_port_tmg_type(int type_idx, IdString port, PortType dir) const;
 
+    bool get_cell_delay_default(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const;
+    TimingPortClass get_port_timing_class_default(const CellInfo *cell, IdString port, int &clockInfoCount) const;
+    TimingClockingInfo get_port_clocking_info_default(const CellInfo *cell, IdString port, int index) const;
     // -------------------------------------------------
 
-    bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const override;
+    bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const override
+    {
+        return uarch->getCellDelay(cell, fromPort, toPort, delay);
+    };
     // Get the port class, also setting clockInfoCount to the number of TimingClockingInfos associated with a port
-    TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const override;
+    TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const override
+    {
+        return uarch->getPortTimingClass(cell, port, clockInfoCount);
+    };
     // Get the TimingClockingInfo of a port
-    TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const override;
+    TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const override
+    {
+        return uarch->getPortClockingInfo(cell, port, index);
+    };
 
     // -------------------------------------------------
     void init_tiles();

--- a/himbaechel/chipdb.h
+++ b/himbaechel/chipdb.h
@@ -214,6 +214,8 @@ NPNR_PACKED_STRUCT(struct SpeedGradePOD {
     RelSlice<PipTimingPOD> pip_classes;
     RelSlice<NodeTimingPOD> node_classes;
     RelSlice<CellTimingPOD> cell_types;
+
+    RelPtr<uint8_t> extra_data;
 });
 
 NPNR_PACKED_STRUCT(struct ConstIDDataPOD {

--- a/himbaechel/himbaechel_api.cc
+++ b/himbaechel/himbaechel_api.cc
@@ -87,6 +87,21 @@ bool HimbaechelAPI::getClusterPlacement(ClusterId cluster, BelId root_bel,
 
 void HimbaechelAPI::expandBoundingBox(BoundingBox &bb) const { ctx->BaseArch::expandBoundingBox(bb); }
 
+bool HimbaechelAPI::getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const
+{
+    return ctx->get_cell_delay_default(cell, fromPort, toPort, delay);
+}
+
+TimingPortClass HimbaechelAPI::getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const
+{
+    return ctx->get_port_timing_class_default(cell, port, clockInfoCount);
+}
+
+TimingClockingInfo HimbaechelAPI::getPortClockingInfo(const CellInfo *cell, IdString port, int index) const
+{
+    return ctx->get_port_clocking_info_default(cell, port, index);
+}
+
 HimbaechelArch *HimbaechelArch::list_head;
 HimbaechelArch::HimbaechelArch(const std::string &name) : name(name)
 {
@@ -118,4 +133,5 @@ HimbaechelArch *HimbaechelArch::find_match(const std::string &device)
     }
     return nullptr;
 }
+
 NEXTPNR_NAMESPACE_END

--- a/himbaechel/himbaechel_api.h
+++ b/himbaechel/himbaechel_api.h
@@ -118,6 +118,11 @@ struct HimbaechelAPI
 
     virtual void drawGroup(std::vector<GraphicElement> &g, GroupId group, Loc loc) {};
 
+    // Cell delay
+    virtual bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const;
+    virtual TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const;
+    virtual TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const;
+
     // Routing methods
     virtual void expandBoundingBox(BoundingBox &bb) const;
     // --- Flow hooks ---


### PR DESCRIPTION
Add user ability to override:
```
    bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayQuad &delay) const;
    TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const;
    TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const;
```

And also add SpeedGradePOD extra_data so we can store additional timing information per speed grade in chip database