### PR TITLE
Gowin. Implement ALU for the GW5A series.

### DIFF
--- a/himbaechel/uarch/gowin/constids.inc
+++ b/himbaechel/uarch/gowin/constids.inc
@@ -1368,4 +1368,5 @@ X(SEG_WIRES_TO_ISOLATE)
 // routing params
 X(NO_GP_CLOCK_ROUTING)
 
-
+// gw5a alu
+X(CIN_NETTYPE)

--- a/himbaechel/uarch/gowin/gowin.h
+++ b/himbaechel/uarch/gowin/gowin.h
@@ -198,6 +198,7 @@ NPNR_PACKED_STRUCT(struct Extra_chip_data_POD {
     static constexpr int32_t HAS_CLKDIV_HCLK = 64;
     static constexpr int32_t HAS_PINCFG = 128;
     static constexpr int32_t HAS_DFF67 = 256;
+    static constexpr int32_t HAS_CIN_MUX = 512;
 });
 
 } // namespace

--- a/himbaechel/uarch/gowin/gowin_arch_gen.py
+++ b/himbaechel/uarch/gowin/gowin_arch_gen.py
@@ -24,6 +24,7 @@ CHIP_HAS_PLL_HCLK          = 0x20
 CHIP_HAS_CLKDIV_HCLK       = 0x40
 CHIP_HAS_PINCFG            = 0x80
 CHIP_HAS_DFF67             = 0x100
+CHIP_HAS_CIN_MUX           = 0x200
 
 # Tile flags
 TILE_I3C_CAPABLE_IO        = 0x1
@@ -1590,6 +1591,8 @@ def main():
             chip_flags |= CHIP_HAS_PINCFG;
         if "HAS_DFF67" in db.chip_flags:
             chip_flags |= CHIP_HAS_DFF67;
+        if "HAS_CIN_MUX" in db.chip_flags:
+            chip_flags |= CHIP_HAS_CIN_MUX;
 
     X = db.cols;
     Y = db.rows;

--- a/himbaechel/uarch/gowin/gowin_utils.cc
+++ b/himbaechel/uarch/gowin/gowin_utils.cc
@@ -342,6 +342,12 @@ bool GowinUtils::has_DFF67(void) const
     return extra->chip_flags & Extra_chip_data_POD::HAS_DFF67;
 }
 
+bool GowinUtils::has_CIN_MUX(void) const
+{
+    const Extra_chip_data_POD *extra = reinterpret_cast<const Extra_chip_data_POD *>(ctx->chip_info->extra_data.get());
+    return extra->chip_flags & Extra_chip_data_POD::HAS_CIN_MUX;
+}
+
 bool GowinUtils::has_SP32(void)
 {
     const Extra_chip_data_POD *extra = reinterpret_cast<const Extra_chip_data_POD *>(ctx->chip_info->extra_data.get());

--- a/himbaechel/uarch/gowin/gowin_utils.h
+++ b/himbaechel/uarch/gowin/gowin_utils.h
@@ -102,6 +102,9 @@ struct GowinUtils
     // Logic cell structure
     bool has_DFF67(void) const;
 
+    // ALU
+    bool has_CIN_MUX(void) const;
+
     // DSP
     inline int get_dsp_18_z(int z) const { return z & (~3); }
     inline int get_dsp_9_idx(int z) const { return z & 3; }


### PR DESCRIPTION
The ALUs in the GW5A series have undergone changes compared to previous chips.

The most significant change is the appearance of an input MUX for carry — it is now possible to switch between VCC, GND, and COUT of the previous ALU, as well as generate carry in logic.

The granularity of resource allocation for ALUs has also changed — it is now possible to use each half of a slice independently for ALUs.

Not all new features are reflected in this commit:

  - since there is one CIN MUX for every six ALUs and it only works for ALUs with index 0, the new granularity is not very useful: the head of the chain can only be placed in the zero ALU. It is possible to gain one LUT by allocating ALUs in odd numbers, but we will leave that for the future.

  - using CIN MUX to generate carry in logic is interesting, but we have not yet been able to get the vendor IDE to generate such a configuration to figure out which wires are used, so for now we are leaving the old behavior in logic with the allocation of a specialized head ALU.