### PR TITLE
Gowin. Implement on-chip oscillator.

### DIFF
--- a/himbaechel/uarch/gowin/constids.inc
+++ b/himbaechel/uarch/gowin/constids.inc
@@ -1022,6 +1022,7 @@ X(INV)
 
 // Oscillators
 X(OSC)
+X(OSCA)
 X(OSCZ)
 X(OSCH)
 X(OSCF)
@@ -1273,6 +1274,7 @@ X(ALU_CIN)
 X(ALU_COUT)
 X(PLL_O)
 X(PLL_I)
+
 
 // fake dff inputs
 X(XD0)

--- a/himbaechel/uarch/gowin/globals.cc
+++ b/himbaechel/uarch/gowin/globals.cc
@@ -65,11 +65,12 @@ struct GowinGlobalRouter
         bool not_dcs_pip = dst_name != id_CLKOUT;
         IdString src_type = ctx->getWireType(src);
         IdString dst_type = ctx->getWireType(dst);
-        bool src_valid = not_dcs_pip && src_type.in(id_GLOBAL_CLK, id_IO_O, id_PLL_O, id_HCLK, id_DLLDLY, id_OSCOUT);
+        bool src_is_outpin = src_type.in(id_IO_O, id_PLL_O, id_HCLK, id_DLLDLY, id_OSCOUT);
+        bool src_valid = not_dcs_pip && (src_type == id_GLOBAL_CLK || src_is_outpin);
         bool dst_valid = not_dcs_pip && dst_type.in(id_GLOBAL_CLK, id_TILE_CLK, id_PLL_I, id_IO_I, id_HCLK);
 
         bool res;
-        if (src == src_wire && (!src_type.in(id_IO_O, id_HCLK, id_DLLDLY_O, id_OSCOUT))) {
+        if (src == src_wire && (src_type == id_PLL_O || (!src_is_outpin))) {
             bool dst_is_spine = dst_name.str(ctx).rfind("SPINE", 0) == 0;
             res = src_valid && dst_is_spine;
         } else {

--- a/himbaechel/uarch/gowin/globals.cc
+++ b/himbaechel/uarch/gowin/globals.cc
@@ -65,11 +65,11 @@ struct GowinGlobalRouter
         bool not_dcs_pip = dst_name != id_CLKOUT;
         IdString src_type = ctx->getWireType(src);
         IdString dst_type = ctx->getWireType(dst);
-        bool src_valid = not_dcs_pip && src_type.in(id_GLOBAL_CLK, id_IO_O, id_PLL_O, id_HCLK, id_DLLDLY);
+        bool src_valid = not_dcs_pip && src_type.in(id_GLOBAL_CLK, id_IO_O, id_PLL_O, id_HCLK, id_DLLDLY, id_OSCOUT);
         bool dst_valid = not_dcs_pip && dst_type.in(id_GLOBAL_CLK, id_TILE_CLK, id_PLL_I, id_IO_I, id_HCLK);
 
         bool res;
-        if (src == src_wire && (!src_type.in(id_IO_O, id_HCLK, id_DLLDLY_O))) {
+        if (src == src_wire && (!src_type.in(id_IO_O, id_HCLK, id_DLLDLY_O, id_OSCOUT))) {
             bool dst_is_spine = dst_name.str(ctx).rfind("SPINE", 0) == 0;
             res = src_valid && dst_is_spine;
         } else {

--- a/himbaechel/uarch/gowin/gowin_utils.cc
+++ b/himbaechel/uarch/gowin/gowin_utils.cc
@@ -34,6 +34,19 @@ bool GowinUtils::driver_is_clksrc(const PortRef &driver)
             }
         }
     }
+    // OSC outputs
+    if (driver.cell->type.in(id_OSC, id_OSCA, id_OSCZ, id_OSCH, id_OSCF, id_OSCW, id_OSCO)) {
+        if (driver.port == id_OSCOUT) {
+            if (ctx->debug) {
+                if (driver.cell->bel != BelId()) {
+                    log_info("OSC out bel:%s:%s\n", ctx->nameOfBel(driver.cell->bel), driver.port.c_str(ctx));
+                } else {
+                    log_info("OSC out:%s:%s\n", ctx->nameOf(driver.cell), driver.port.c_str(ctx));
+                }
+            }
+            return true;
+        }
+    }
     // PLL outputs
     if (driver.cell->type.in(id_rPLL, id_PLLVR)) {
         if (driver.port.in(id_CLKOUT, id_CLKOUTD, id_CLKOUTD3, id_CLKOUTP)) {


### PR DESCRIPTION
A programmable on-chip crystal oscillator has been implemented for the GW5A series.

A critical innovation in this series was the change in the nature of the OSC output pin—it now belongs to the clock wires, and therefore the routes must be made with a special global router, as there is no possibility of using routing through general-purpose PIPs.

At the same time, we are transferring the outputs of all previous generations of OSC to potential clock wires. At the moment, this will not affect the way they are routed - they will still end up as segments as before, but in the future we may optimize the mechanism.