### PR TITLE
Gowin. BUGFIX. Add data about gate wires.

### DIFF
--- a/himbaechel/uarch/gowin/gowin_arch_gen.py
+++ b/himbaechel/uarch/gowin/gowin_arch_gen.py
@@ -14,6 +14,9 @@ from apycula import chipdb
 # Bel flags
 BEL_FLAG_SIMPLE_IO = 0x100
 
+# Wire flags
+WIRE_FLAG_CLOCK_GATE = 0x1
+
 # Chip flags
 CHIP_HAS_SP32              = 0x1
 CHIP_NEED_SP_FIX           = 0x2
@@ -768,6 +771,14 @@ def create_extra_funcs(tt: TileType, db: chipdb, x: int, y: int):
                         tt.create_wire(wire, "PINCFG_IN")
                     tt.add_bel_pin(bel, port, wire, PinType.INPUT)
 
+def set_wire_flags(tt: TileType, tdesc: TypeDesc):
+    if tdesc.extra_func and 'clock_gates' in tdesc.extra_func:
+        for wire_name in tdesc.extra_func['clock_gates']:
+            wname_id = tt.strs.id(wire_name)
+            for wire_data in tt.wires:
+                if wire_data.name == wname_id:
+                    wire_data.flags |= WIRE_FLAG_CLOCK_GATE
+
 def create_tiletype(create_func, chip: Chip, db: chipdb, x: int, y: int, ttyp: int):
     has_extra_func = (y, x) in db.extra_func
 
@@ -817,6 +828,7 @@ def create_tiletype(create_func, chip: Chip, db: chipdb, x: int, y: int, ttyp: i
     create_extra_funcs(tt, db, x, y)
     create_hclk_switch_matrix(tt, db, x, y)
     create_switch_matrix(tt, db, x, y)
+    set_wire_flags(tt, tdesc)
     chip.set_tile_type(x, y, tdesc.tiletype)
 
 def add_port_wire(tt, bel, portmap, name, wire_type, port_type, pin_name = None):

--- a/himbaechel/uarch/gowin/gowin_utils.h
+++ b/himbaechel/uarch/gowin/gowin_utils.h
@@ -12,6 +12,10 @@ namespace BelFlags {
 static constexpr uint32_t FLAG_SIMPLE_IO = 0x100;
 }
 
+namespace WireFlags {
+static constexpr uint32_t FLAG_CLOCK_GATE = 0x1;
+}
+
 struct GowinUtils
 {
     Context *ctx;
@@ -84,6 +88,12 @@ struct GowinUtils
         return CellTypePort(driver) == CellTypePort(id_IOBUF, id_O) && driver.cell->params.count(id_MIPI_IBUF);
     }
     bool driver_is_clksrc(const PortRef &driver);
+
+    // clock nets
+    bool wire_is_clock_gate(WireId wire) const
+    {
+        return chip_wire_info(ctx->chip_info, wire).flags & WireFlags::FLAG_CLOCK_GATE;
+    }
 
     // BSRAM
     bool has_SP32(void);


### PR DESCRIPTION
Very rarely (about once a year), the dedicated clock router would malfunction, issuing an incorrect route.

The reason turned out to be the so-called gate wires to the global clock wire system from the logic. Among the PIPs for which these wires are sinks, there are PIPs where the sources are also clock wires.

This leads to the possibility of feeding the clock signal back into the gate and again into the global clock MUX.

If handled carelessly, this can lead to a complete loop.

But the loop option itself is particularly useful in the case of DCS (dynamic clock selection) - the fact is that because these primitives have four clock inputs and each of them could theoretically address all 56 clock sources, but in practice there are not enough wires and the DCS inputs cannot serve as sinks for all clock sources.

The simplest solution (and the one that currently works) is to use the gate to re-enter the clock system, but this time changing the clock source.

This commit explicitly marks wires as gates and removes the possibility of looping (however unlikely it may be) where a loop is not needed.