### PR TITLE
Gowin. GW5A chips. Implement the DCS primitive.

### DIFF
--- a/himbaechel/uarch/gowin/gowin.h
+++ b/himbaechel/uarch/gowin/gowin.h
@@ -184,6 +184,7 @@ NPNR_PACKED_STRUCT(struct Extra_package_data_POD { RelSlice<Constraint_POD> cst;
 
 NPNR_PACKED_STRUCT(struct Extra_chip_data_POD {
     int32_t chip_flags;
+    IdString dcs_prefix;
     Bottom_io_POD bottom_io;
     RelSlice<IdString> diff_io_types;
     RelSlice<Spine_bel_POD> dqce_bels;

--- a/himbaechel/uarch/gowin/gowin_utils.cc
+++ b/himbaechel/uarch/gowin/gowin_utils.cc
@@ -290,6 +290,12 @@ BelId GowinUtils::get_dhcen_bel(WireId hclkin_wire, IdString &side)
     return BelId();
 }
 
+IdString GowinUtils::get_dcs_prefix(void)
+{
+    const Extra_chip_data_POD *extra = reinterpret_cast<const Extra_chip_data_POD *>(ctx->chip_info->extra_data.get());
+    return extra->dcs_prefix;
+}
+
 bool GowinUtils::is_simple_io_bel(BelId bel)
 {
     return chip_bel_info(ctx->chip_info, bel).flags & BelFlags::FLAG_SIMPLE_IO;

--- a/himbaechel/uarch/gowin/gowin_utils.h
+++ b/himbaechel/uarch/gowin/gowin_utils.h
@@ -49,6 +49,7 @@ struct GowinUtils
     BelId get_dcs_bel(IdString spine_name);
     BelId get_dhcen_bel(WireId hclkin_wire, IdString &side);
     BelId get_dlldly_bel(BelId io_bel);
+    IdString get_dcs_prefix(void);
 
     // Segments
     int get_segments_count(void) const;

--- a/himbaechel/uarch/gowin/pack.cc
+++ b/himbaechel/uarch/gowin/pack.cc
@@ -4141,12 +4141,7 @@ struct GowinPacker
                 if (dcs_bel != BelId()) {
                     IdString dcs_name = ctx->idf("$PACKER_DCS_SPINE%d", 8 * (i % 4) + 6 + (i >> 2));
                     CellInfo *dcs = ctx->createCell(dcs_name, id_DCS);
-                    dcs->addInput(id_SELFORCE);
-                    for (int j = 0; j < 4; ++j) {
-                        dcs->addInput(ctx->idf("CLK%d", j));
-                        dcs->addInput(ctx->idf("CLKSEL%d", j));
-                    }
-                    dcs->addOutput(id_CLKOUT);
+                    ctx->copyBelPorts(dcs_name, dcs_bel);
                     ctx->bindBel(dcs_bel, dcs, STRENGTH_LOCKED);
                 }
             }


### PR DESCRIPTION
The GW5A series is interesting—in this particular primitive, the inputs have been renamed from CLKx to CLKINx. Everything else remains the same, including functionality.

As a solution, we will store in the chip database which prefix the DCS inputs have.