### PR TITLE
gatemate: cleanup of PLL and BUFG

### DIFF
--- a/himbaechel/uarch/gatemate/ccf.cc
+++ b/himbaechel/uarch/gatemate/ccf.cc
@@ -94,6 +94,11 @@ struct GateMateCCFReader
                         count[i]--;
                 }
                 uarch->available_pads.erase(ctx->id(value));
+                // Erase aliases as well
+                if (value == "SER_CLK")
+                    uarch->available_pads.erase(ctx->id("SER_CLK_N"));
+                if (value == "SER_CLK_N")
+                    uarch->available_pads.erase(ctx->id("SER_CLK"));
             } else if (name == "SCHMITT_TRIGGER" || name == "PULLUP" || name == "PULLDOWN" || name == "KEEPER" ||
                        name == "FF_IBF" || name == "FF_OBF" || name == "LVDS_BOOST" || name == "LVDS_RTERM") {
                 if (value == "1")

--- a/himbaechel/uarch/gatemate/cells.cc
+++ b/himbaechel/uarch/gatemate/cells.cc
@@ -127,6 +127,9 @@ CellInfo *GateMatePacker::create_cell_ptr(IdString type, IdString name)
         add_port(id_I, PORT_IN);
     } else if (type.in(id_PLL)) {
         add_port(id_CLK_REF, PORT_IN);
+        add_port(id_USR_CLK_REF, PORT_IN);
+        add_port(id_USR_SEL_A_B, PORT_IN);
+        add_port(id_CLK_FEEDBACK, PORT_IN);
         add_port(id_CLK0, PORT_OUT);
         add_port(id_CLK90, PORT_OUT);
         add_port(id_CLK180, PORT_OUT);

--- a/himbaechel/uarch/gatemate/cells.cc
+++ b/himbaechel/uarch/gatemate/cells.cc
@@ -122,6 +122,18 @@ CellInfo *GateMatePacker::create_cell_ptr(IdString type, IdString name)
         add_port(id_CLOCK2, PORT_IN);
         add_port(id_CLOCK3, PORT_IN);
         add_port(id_CLOCK4, PORT_IN);
+    } else if (type.in(id_CPE_IBUF)) {
+        add_port(id_Y, PORT_OUT);
+        add_port(id_I, PORT_IN);
+    } else if (type.in(id_PLL)) {
+        add_port(id_CLK_REF, PORT_IN);
+        add_port(id_CLK0, PORT_OUT);
+        add_port(id_CLK90, PORT_OUT);
+        add_port(id_CLK180, PORT_OUT);
+        add_port(id_CLK270, PORT_OUT);
+        add_port(id_USR_PLL_LOCKED, PORT_OUT);
+        add_port(id_USR_PLL_LOCKED_STDY, PORT_OUT);
+        add_port(id_USR_LOCKED_STDY_RST, PORT_IN);
     } else {
         log_error("Trying to create unknown cell type %s\n", type.c_str(ctx));
     }

--- a/himbaechel/uarch/gatemate/constids.inc
+++ b/himbaechel/uarch/gatemate/constids.inc
@@ -2468,6 +2468,12 @@ X(MULT_INVERT)
 X(RAM_HALF)
 X(RAM_HALF_DUMMY)
 
+// Dies
+X(1A)
+X(1B)
+X(2A)
+X(2B)
+
 // Timing
 X(timing_ADDF2x_IN5_8_comb2)
 X(timing_CIN_C_CINI)

--- a/himbaechel/uarch/gatemate/extra_data.h
+++ b/himbaechel/uarch/gatemate/extra_data.h
@@ -69,6 +69,16 @@ NPNR_PACKED_STRUCT(struct GateMateTimingExtraDataPOD {
 
 NPNR_PACKED_STRUCT(struct GateMateSpeedGradeExtraDataPOD { RelSlice<GateMateTimingExtraDataPOD> timings; });
 
+NPNR_PACKED_STRUCT(struct GateMateDieRegionPOD {
+    int32_t name;
+    uint16_t x1;
+    uint16_t y1;
+    uint16_t x2;
+    uint16_t y2;
+});
+
+NPNR_PACKED_STRUCT(struct GateMateChipExtraDataPOD { RelSlice<GateMateDieRegionPOD> dies; });
+
 enum MuxFlags
 {
     MUX_INVERT = 1,

--- a/himbaechel/uarch/gatemate/gatemate.cc
+++ b/himbaechel/uarch/gatemate/gatemate.cc
@@ -151,6 +151,11 @@ void GateMateImpl::init(Context *ctx)
             ram_signal_clk.emplace(ctx->idf("DOB[%d]", i + num * 20), num + 2);
         }
     }
+
+    const GateMateChipExtraDataPOD *extra =
+            reinterpret_cast<const GateMateChipExtraDataPOD *>(ctx->chip_info->extra_data.get());
+    for (auto &die : extra->dies)
+        ctx->createRectangularRegion(IdString(die.name), die.x1, die.y1, die.x2, die.y2);
 }
 
 bool GateMateImpl::isBelLocationValid(BelId bel, bool explain_invalid) const

--- a/himbaechel/uarch/gatemate/gatemate.cc
+++ b/himbaechel/uarch/gatemate/gatemate.cc
@@ -98,6 +98,7 @@ void GateMateImpl::init_database(Arch *arch)
                                             : timing_mode == 3 ? "SPEED"
                                                                : "");
     arch->set_speed_grade(speed_grade);
+    force_die = args.options.count("force_die") != 0;
 }
 
 void GateMateImpl::init(Context *ctx)
@@ -159,8 +160,8 @@ bool GateMateImpl::isBelLocationValid(BelId bel, bool explain_invalid) const
         return true;
     }
 
-    // TODO: remove when placemente per die is better handled
-    if (cell->belStrength != PlaceStrength::STRENGTH_FIXED && tile_extra_data(bel.tile)->die != preferred_die)
+    if (force_die && cell->belStrength != PlaceStrength::STRENGTH_FIXED &&
+        tile_extra_data(bel.tile)->die != preferred_die)
         return false;
 
     if (getBelBucketForBel(bel) == id_CPE_FF) {

--- a/himbaechel/uarch/gatemate/gatemate.h
+++ b/himbaechel/uarch/gatemate/gatemate.h
@@ -90,6 +90,9 @@ struct GateMateImpl : HimbaechelAPI
     std::vector<bool> used_cpes;
     int fpga_mode;
     int timing_mode;
+    std::map<NetInfo *, int> global_signals;
+    std::vector<CellInfo *> clkin;
+    std::vector<CellInfo *> glbout;
 
   private:
     bool getChildPlacement(const BaseClusterInfo *cluster, Loc root_loc,

--- a/himbaechel/uarch/gatemate/gatemate.h
+++ b/himbaechel/uarch/gatemate/gatemate.h
@@ -90,7 +90,7 @@ struct GateMateImpl : HimbaechelAPI
     std::vector<bool> used_cpes;
     int fpga_mode;
     int timing_mode;
-    std::map<NetInfo *, int> global_signals;
+    std::map<const NetInfo *, int> global_signals;
     std::vector<CellInfo *> clkin;
     std::vector<CellInfo *> glbout;
     std::vector<CellInfo *> pll;
@@ -126,6 +126,7 @@ struct GateMateImpl : HimbaechelAPI
     std::map<BelId, std::map<IdString, const GateMateBelPinConstraintPOD *>> pin_to_constr;
     std::map<IdString, const GateMateTimingExtraDataPOD *> timing;
     dict<IdString, int> ram_signal_clk;
+    bool force_die;
 };
 
 NEXTPNR_NAMESPACE_END

--- a/himbaechel/uarch/gatemate/gatemate.h
+++ b/himbaechel/uarch/gatemate/gatemate.h
@@ -126,7 +126,8 @@ struct GateMateImpl : HimbaechelAPI
     std::map<BelId, std::map<IdString, const GateMateBelPinConstraintPOD *>> pin_to_constr;
     std::map<IdString, const GateMateTimingExtraDataPOD *> timing;
     dict<IdString, int> ram_signal_clk;
-    bool force_die;
+    IdString forced_die;
+    dict<IdString, int> die_to_index;
 };
 
 NEXTPNR_NAMESPACE_END

--- a/himbaechel/uarch/gatemate/gatemate.h
+++ b/himbaechel/uarch/gatemate/gatemate.h
@@ -93,6 +93,7 @@ struct GateMateImpl : HimbaechelAPI
     std::map<NetInfo *, int> global_signals;
     std::vector<CellInfo *> clkin;
     std::vector<CellInfo *> glbout;
+    std::vector<CellInfo *> pll;
 
   private:
     bool getChildPlacement(const BaseClusterInfo *cluster, Loc root_loc,

--- a/himbaechel/uarch/gatemate/pack.cc
+++ b/himbaechel/uarch/gatemate/pack.cc
@@ -401,7 +401,6 @@ void GateMateImpl::pack()
     packer.pack_addf();
     packer.pack_cpe();
     packer.remove_constants();
-    packer.remove_clocking();
 }
 
 void GateMateImpl::repack()
@@ -409,6 +408,7 @@ void GateMateImpl::repack()
     GateMatePacker packer(ctx, this);
     packer.repack_ram();
     packer.repack_cpe();
+    packer.remove_clocking();
 }
 
 NEXTPNR_NAMESPACE_END

--- a/himbaechel/uarch/gatemate/pack.cc
+++ b/himbaechel/uarch/gatemate/pack.cc
@@ -390,7 +390,6 @@ void GateMateImpl::pack()
     packer.cleanup();
     packer.pack_io();
     packer.insert_clocking();
-    packer.sort_bufg();
     packer.pack_pll();
     packer.pack_bufg();
     packer.pack_io_sel(); // merge in FF and DDR

--- a/himbaechel/uarch/gatemate/pack.cc
+++ b/himbaechel/uarch/gatemate/pack.cc
@@ -385,6 +385,9 @@ void GateMateImpl::pack()
         parse_ccf(args.options.at("ccf"));
     }
 
+    if (forced_die != IdString())
+        preferred_die = die_to_index[forced_die];
+
     GateMatePacker packer(ctx, this);
     packer.pack_constants();
     packer.cleanup();
@@ -401,6 +404,13 @@ void GateMateImpl::pack()
     packer.pack_cpe();
     packer.copy_clocks();
     packer.remove_constants();
+
+    if (forced_die != IdString()) {
+        for (auto &cell : ctx->cells) {
+            if (cell.second->belStrength != PlaceStrength::STRENGTH_FIXED)
+                ctx->constrainCellToRegion(cell.second->name, forced_die);
+        }
+    }
 }
 
 void GateMateImpl::repack()

--- a/himbaechel/uarch/gatemate/pack.cc
+++ b/himbaechel/uarch/gatemate/pack.cc
@@ -98,7 +98,7 @@ void GateMatePacker::disconnect_not_used()
     }
 }
 
-void GateMatePacker::copy_constraint(NetInfo *in_net, NetInfo *out_net)
+void GateMatePacker::copy_constraint(const NetInfo *in_net, NetInfo *out_net)
 {
     if (!in_net || !out_net)
         return;
@@ -399,6 +399,7 @@ void GateMateImpl::pack()
     packer.pack_mult();
     packer.pack_addf();
     packer.pack_cpe();
+    packer.copy_clocks();
     packer.remove_constants();
 }
 
@@ -407,6 +408,7 @@ void GateMateImpl::repack()
     GateMatePacker packer(ctx, this);
     packer.repack_ram();
     packer.repack_cpe();
+    packer.reassign_clocks();
     packer.remove_clocking();
 }
 

--- a/himbaechel/uarch/gatemate/pack.h
+++ b/himbaechel/uarch/gatemate/pack.h
@@ -117,6 +117,7 @@ struct GateMatePacker
     HimbaechelHelpers h;
     NetInfo *net_PACKER_VCC;
     NetInfo *net_PACKER_GND;
+    NetInfo *net_SER_CLK;
     int count;
     std::map<IdString, int> count_per_type;
 };

--- a/himbaechel/uarch/gatemate/pack.h
+++ b/himbaechel/uarch/gatemate/pack.h
@@ -68,6 +68,8 @@ struct GateMatePacker
     void cleanup();
     void repack_cpe();
     void repack_ram();
+    void reassign_clocks();
+    void copy_clocks();
 
   private:
     void rename_param(CellInfo *cell, IdString name, IdString new_name, int width);
@@ -104,7 +106,7 @@ struct GateMatePacker
     CellInfo *create_cell_ptr(IdString type, IdString name);
     void flush_cells();
     void pack_ram_cell(CellInfo &ci, CellInfo *cell, bool is_split);
-    void copy_constraint(NetInfo *in_net, NetInfo *out_net);
+    void copy_constraint(const NetInfo *in_net, NetInfo *out_net);
 
     pool<IdString> packed_cells;
 

--- a/himbaechel/uarch/gatemate/pack.h
+++ b/himbaechel/uarch/gatemate/pack.h
@@ -107,9 +107,6 @@ struct GateMatePacker
     void copy_constraint(NetInfo *in_net, NetInfo *out_net);
 
     pool<IdString> packed_cells;
-    std::map<NetInfo *, int> global_signals;
-    std::vector<CellInfo *> clkin;
-    std::vector<CellInfo *> glbout;
 
     Context *ctx;
     GateMateImpl *uarch;

--- a/himbaechel/uarch/gatemate/pack.h
+++ b/himbaechel/uarch/gatemate/pack.h
@@ -77,6 +77,7 @@ struct GateMatePacker
     void dff_update_params();
     void disconnect_if_gnd(CellInfo *cell, IdString input);
     void pll_out(CellInfo *cell, IdString origPort, Loc fixed);
+    void rewire_ram_o(CellInfo *first, IdString port, CellInfo *second);
 
     void disconnect_not_used();
     void optimize_lut();

--- a/himbaechel/uarch/gatemate/pack_bram.cc
+++ b/himbaechel/uarch/gatemate/pack_bram.cc
@@ -348,6 +348,7 @@ void GateMatePacker::pack_ram()
             cell->constr_y = +8;
             cell->constr_z = RAM_HALF_L_Z;
             cell->cluster = ci.cluster;
+            cell->region = ci.region;
             cell->params[id_RAM_cfg_ecc_enable] = Property(b_ecc_en << 1 | a_ecc_en, 2);
             cell->params[id_RAM_cfg_sram_mode] = Property(ram_mode << 1 | split, 2);
         }

--- a/himbaechel/uarch/gatemate/pack_bram.cc
+++ b/himbaechel/uarch/gatemate/pack_bram.cc
@@ -47,10 +47,10 @@ uint8_t GateMatePacker::ram_ctrl_signal(CellInfo *cell, IdString port, bool alt)
 uint8_t GateMatePacker::ram_clk_signal(CellInfo *cell, IdString port)
 {
     NetInfo *clk_net = cell->getPort(port);
-    if (!global_signals.count(clk_net)) {
+    if (!uarch->global_signals.count(clk_net)) {
         return 0b00000000;
     } else {
-        int index = global_signals[clk_net];
+        int index = uarch->global_signals[clk_net];
         uint8_t val = 0;
         switch (index) {
         case 0:

--- a/himbaechel/uarch/gatemate/pack_bram.cc
+++ b/himbaechel/uarch/gatemate/pack_bram.cc
@@ -395,7 +395,7 @@ void GateMatePacker::pack_ram()
                     ci.renamePort(ctx->idf("F_ALMOST_EMPTY_OFFSET[%d]", i), ctx->idf("WEA[%d]", i));
                     // WEA[34:20] = F_ALMOST_FULL_OFFSET
                     ci.disconnectPort(ctx->idf("WEA[%d]", 20 + i));
-                    ci.renamePort(ctx->idf("F_ALMOST_FULL_OFFSET[%d]", i),  ctx->idf("WEA[%d]", 20 + i));
+                    ci.renamePort(ctx->idf("F_ALMOST_FULL_OFFSET[%d]", i), ctx->idf("WEA[%d]", 20 + i));
                 }
             }
         }

--- a/himbaechel/uarch/gatemate/pack_clocking.cc
+++ b/himbaechel/uarch/gatemate/pack_clocking.cc
@@ -64,7 +64,7 @@ void GateMatePacker::sort_bufg()
     }
 
     if (count > (uarch->dies * 4)) {
-        //log_error("More than %d BUFG used. Unable to place them.\n", uarch->dies * 4);
+        // log_error("More than %d BUFG used. Unable to place them.\n", uarch->dies * 4);
         log_warning("More than 4 BUFG used. Those with highest fan-out will be used.\n");
         std::sort(bufg.begin(), bufg.end(), [](const ItemBufG &a, const ItemBufG &b) { return a.fan_out > b.fan_out; });
         for (size_t i = (uarch->dies * 4); i < bufg.size(); i++) {
@@ -119,7 +119,8 @@ void GateMatePacker::pack_bufg()
     unsigned max_plls = 4;
     // Index vector for permutation
     std::vector<unsigned> indexes(max_plls);
-    for (unsigned i = 0; i < max_plls; ++i) indexes[i] = i;
+    for (unsigned i = 0; i < max_plls; ++i)
+        indexes[i] = i;
 
     CellInfo *bufg[4] = {nullptr};
 
@@ -191,7 +192,8 @@ void GateMatePacker::pack_bufg()
                         int index = pad_info->flags - 1;
                         die = uarch->tile_extra_data(in_net->driver.cell->bel.tile)->die;
                         if (!uarch->clkin[die]->getPort(ctx->idf("CLK%d", index))) {
-                            uarch->clkin[die]->connectPort(ctx->idf("CLK%d", index), in_net->driver.cell->getPort(id_Y));
+                            uarch->clkin[die]->connectPort(ctx->idf("CLK%d", index),
+                                                           in_net->driver.cell->getPort(id_Y));
                         }
                     }
                 }
@@ -229,7 +231,8 @@ void GateMatePacker::pack_bufg()
                         die = uarch->tile_extra_data(in_net->driver.cell->bel.tile)->die;
                         uarch->clkin[die]->params[ctx->idf("REF%d", i)] = Property(pad_info->flags - 1, 3);
                         uarch->clkin[die]->params[ctx->idf("REF%d_INV", i)] = Property(Property::State::S0);
-                        uarch->clkin[die]->connectPorts(ctx->idf("CLK_REF%d", i), uarch->glbout[die], ctx->idf("CLK_REF_OUT%d", i));
+                        uarch->clkin[die]->connectPorts(ctx->idf("CLK_REF%d", i), uarch->glbout[die],
+                                                        ctx->idf("CLK_REF_OUT%d", i));
                         user_glb = false;
                     }
                 }
@@ -248,19 +251,22 @@ void GateMatePacker::pack_bufg()
                     else
                         log_error("Uknown connecton on BUFG to PLL.\n");
                     glb_mux = glb_mux_mapping[i * 16 + pll_index * 4 + pll_out];
-                    ci.movePortTo(id_I, uarch->glbout[die], ctx->idf("%s_%d", in_net->driver.port.c_str(ctx), pll_index));
+                    ci.movePortTo(id_I, uarch->glbout[die],
+                                  ctx->idf("%s_%d", in_net->driver.port.c_str(ctx), pll_index));
                     user_glb = false;
                 }
                 if (user_glb) {
                     ci.movePortTo(id_I, uarch->glbout[die], ctx->idf("USR_GLB%d", i));
-                    move_ram_o_fixed(uarch->glbout[die], ctx->idf("USR_GLB%d", i), ctx->getBelLocation(uarch->glbout[die]->bel));
+                    move_ram_o_fixed(uarch->glbout[die], ctx->idf("USR_GLB%d", i),
+                                     ctx->getBelLocation(uarch->glbout[die]->bel));
                     uarch->glbout[die]->params[ctx->idf("USR_GLB%d_EN", i)] = Property(Property::State::S1);
                 }
             } else {
                 // SER_CLK
                 uarch->clkin[die]->params[ctx->idf("REF%d", i)] = Property(0b100, 3);
                 uarch->clkin[die]->params[ctx->idf("REF%d_INV", i)] = Property(Property::State::S0);
-                uarch->clkin[die]->connectPorts(ctx->idf("CLK_REF%d", i), uarch->glbout[die], ctx->idf("CLK_REF_OUT%d", i));
+                uarch->clkin[die]->connectPorts(ctx->idf("CLK_REF%d", i), uarch->glbout[die],
+                                                ctx->idf("CLK_REF_OUT%d", i));
             }
 
             ci.movePortTo(id_O, uarch->glbout[die], ctx->idf("GLB%d", i));
@@ -269,7 +275,6 @@ void GateMatePacker::pack_bufg()
             packed_cells.emplace(ci.name);
         }
     }
-
 
     for (auto &cell : uarch->pll) {
         CellInfo &ci = *cell;
@@ -295,7 +300,8 @@ void GateMatePacker::pack_bufg()
         if (feedback_net) {
             if (!uarch->global_signals.count(feedback_net)) {
                 ci.movePortTo(id_CLK_FEEDBACK, uarch->glbout[die], ctx->idf("USR_FB%d", i));
-                move_ram_o_fixed(uarch->glbout[die], ctx->idf("USR_FB%d", i), ctx->getBelLocation(uarch->glbout[die]->bel));
+                move_ram_o_fixed(uarch->glbout[die], ctx->idf("USR_FB%d", i),
+                                 ctx->getBelLocation(uarch->glbout[die]->bel));
                 uarch->glbout[die]->params[ctx->idf("USR_FB%d_EN", i)] = Property(Property::State::S1);
             } else {
                 int index = uarch->global_signals[feedback_net];

--- a/himbaechel/uarch/gatemate/pack_clocking.cc
+++ b/himbaechel/uarch/gatemate/pack_clocking.cc
@@ -757,6 +757,7 @@ void GateMatePacker::reassign_clocks()
         int index = glob.second;
         int drv_die = uarch->tile_extra_data(net->driver.cell->bel.tile)->die;
         auto users = net->users; // make a copy
+        int count = 0;
         for (auto &user : users) {
             int cell_die = uarch->tile_extra_data(user.cell->bel.tile)->die;
             if (cell_die != drv_die) {
@@ -768,8 +769,11 @@ void GateMatePacker::reassign_clocks()
                 }
                 user.cell->disconnectPort(user.port);
                 user.cell->connectPort(user.port, new_bufg[cell_die][index]);
+                count++;
             }
         }
+        if (count)
+            log_info("    reassign %d net '%s' users\n", count, net->name.c_str(ctx));
     }
 }
 

--- a/himbaechel/uarch/gatemate/pack_clocking.cc
+++ b/himbaechel/uarch/gatemate/pack_clocking.cc
@@ -174,9 +174,7 @@ void GateMatePacker::pack_bufg()
                         die = uarch->tile_extra_data(in_net->driver.cell->bel.tile)->die;
                         clkin[die]->params[ctx->idf("REF%d", i)] = Property(pad_info->flags - 1, 3);
                         clkin[die]->params[ctx->idf("REF%d_INV", i)] = Property(Property::State::S0);
-                        NetInfo *conn = ctx->createNet(ci.name);
-                        clkin[die]->connectPort(ctx->idf("CLK_REF%d", i), conn);
-                        glbout[die]->connectPort(ctx->idf("CLK_REF_OUT%d", i), conn);
+                        clkin[die]->connectPorts(ctx->idf("CLK_REF%d", i), glbout[die], ctx->idf("CLK_REF_OUT%d", i));
                         user_glb = false;
                     }
                 }
@@ -207,9 +205,7 @@ void GateMatePacker::pack_bufg()
                 // SER_CLK
                 clkin[die]->params[ctx->idf("REF%d", i)] = Property(0b100, 3);
                 clkin[die]->params[ctx->idf("REF%d_INV", i)] = Property(Property::State::S0);
-                NetInfo *conn = ctx->createNet(ci.name);
-                clkin[die]->connectPort(ctx->idf("CLK_REF%d", i), conn);
-                glbout[die]->connectPort(ctx->idf("CLK_REF_OUT%d", i), conn);
+                clkin[die]->connectPorts(ctx->idf("CLK_REF%d", i), glbout[die], ctx->idf("CLK_REF_OUT%d", i));
             }
 
             ci.movePortTo(id_O, glbout[die], ctx->idf("GLB%d", i));
@@ -233,10 +229,7 @@ void GateMatePacker::pack_bufg()
                     glbout[die]->params[ctx->idf("FB%d_CFG", i)] = Property(index, 2);
                     pll[i]->disconnectPort(id_CLK_FEEDBACK);
                 }
-                NetInfo *conn =
-                        ctx->createNet(ctx->idf("%s_%s", glbout[die]->name.c_str(ctx), feedback_net->name.c_str(ctx)));
-                pll[i]->connectPort(id_CLK_FEEDBACK, conn);
-                glbout[die]->connectPort(ctx->idf("CLK_FB%d", i), conn);
+                pll[i]->connectPorts(id_CLK_FEEDBACK, glbout[die], ctx->idf("CLK_FB%d", i));
             }
         }
     }
@@ -389,9 +382,7 @@ void GateMatePacker::pack_pll()
             }
             if (clk->clkconstr)
                 period = clk->clkconstr->period.minDelay();
-            NetInfo *conn = ctx->createNet(ctx->idf("%s_CLK_REF", ci.name.c_str(ctx)));
-            clkin[die]->connectPort(ctx->idf("CLK_REF%d", pll_index[die]), conn);
-            ci.connectPort(id_CLK_REF, conn);
+            clkin[die]->connectPorts(ctx->idf("CLK_REF%d", pll_index[die]), &ci, id_CLK_REF);
         }
 
         clk = ci.getPort(id_USR_CLK_REF);

--- a/himbaechel/uarch/gatemate/pack_clocking.cc
+++ b/himbaechel/uarch/gatemate/pack_clocking.cc
@@ -770,6 +770,7 @@ void GateMatePacker::copy_clocks()
                     move_ram_o_fixed(pll_new, id_USR_LOCKED_STDY_RST, new_loc);
                     move_ram_o_fixed(pll_new, id_USR_CLK_REF, new_loc);
                     move_ram_o_fixed(pll_new, id_USR_SEL_A_B, new_loc);
+                    // TODO: AND outputs of all USR_LOCKED_STDY_RST and use that signal to drive logic
                 }
             }
             // Copy GLBOUT inputs

--- a/himbaechel/uarch/gatemate/pack_clocking.cc
+++ b/himbaechel/uarch/gatemate/pack_clocking.cc
@@ -270,7 +270,11 @@ void GateMatePacker::pack_bufg()
                 auto pad_info = uarch->bel_to_pad[clk->driver.cell->bel];
                 uarch->clkin[die]->params[ctx->idf("REF%d", i)] = Property(pad_info->flags - 1, 3);
                 uarch->clkin[die]->params[ctx->idf("REF%d_INV", i)] = Property(Property::State::S0);
-                ci.movePortTo(id_CLK_REF, uarch->clkin[die], ctx->idf("CLK%d", pad_info->flags - 1));
+                int index = pad_info->flags - 1;
+                if (!uarch->clkin[die]->getPort(ctx->idf("CLK%d", index)))
+                    ci.movePortTo(id_CLK_REF, uarch->clkin[die], ctx->idf("CLK%d", index));
+                else
+                    ci.disconnectPort(id_CLK_REF);
             } else {
                 // SER_CLK
                 uarch->clkin[die]->params[ctx->idf("REF%d", i)] = Property(0b100, 3);

--- a/himbaechel/uarch/gatemate/pack_clocking.cc
+++ b/himbaechel/uarch/gatemate/pack_clocking.cc
@@ -772,13 +772,18 @@ void GateMatePacker::copy_clocks()
             }
             // Copy GLBOUT inputs
             for (int i = 0; i < 4; i++) {
+                Loc new_loc = uarch->locations[std::make_pair(id_GLBOUT, new_die)];
                 // Plain copy of user signals
                 NetInfo *net = uarch->glbout[0]->getPort(ctx->idf("USR_GLB%d", i));
                 if (net)
-                    uarch->glbout[new_die]->connectPort(ctx->idf("USR_GLB%d", i), net);
+                    rewire_ram_o(uarch->glbout[0], ctx->idf("USR_GLB%d", i), uarch->glbout[new_die]);
+
                 net = uarch->glbout[0]->getPort(ctx->idf("USR_FB%d", i));
                 if (net)
-                    uarch->glbout[new_die]->connectPort(ctx->idf("USR_FB%d", i), net);
+                    rewire_ram_o(uarch->glbout[0], ctx->idf("USR_FB%d", i), uarch->glbout[new_die]);
+
+                move_ram_o_fixed(uarch->glbout[new_die], ctx->idf("USR_GLB%d", i), new_loc);
+                move_ram_o_fixed(uarch->glbout[new_die], ctx->idf("USR_FB%d", i), new_loc);
 
                 if (uarch->glbout[0]->getPort(ctx->idf("CLK_REF_OUT%d", i)))
                     uarch->clkin[new_die]->connectPorts(ctx->idf("CLK_REF%d", i), uarch->glbout[new_die],

--- a/himbaechel/uarch/gatemate/pack_clocking.cc
+++ b/himbaechel/uarch/gatemate/pack_clocking.cc
@@ -41,7 +41,6 @@ void GateMatePacker::sort_bufg()
 
     log_info("Sort BUFGs..\n");
     std::vector<ItemBufG> bufg;
-    int count = 0;
     for (auto &cell : ctx->cells) {
         CellInfo &ci = *cell.second;
         if (!ci.type.in(id_CC_BUFG))
@@ -59,12 +58,11 @@ void GateMatePacker::sort_bufg()
             packed_cells.emplace(ci.name); // Remove if no output
             continue;
         }
-        count++;
         bufg.push_back(ItemBufG(&ci, o_net->users.entries()));
     }
 
-    if (count > 4) { // uarch->dies * 4
-        log_warning("More than %d BUFG used. Those with highest fan-out will be used.\n", 4);
+    if (bufg.size() > 4) {
+        log_warning("More than 4 BUFG used. Those with highest fan-out will be used.\n");
         std::sort(bufg.begin(), bufg.end(), [](const ItemBufG &a, const ItemBufG &b) { return a.fan_out > b.fan_out; });
         for (size_t i = 4; i < bufg.size(); i++) {
             log_warning("Removing BUFG cell %s.\n", bufg.at(i).cell->name.c_str(ctx));

--- a/himbaechel/uarch/gatemate/pack_clocking.cc
+++ b/himbaechel/uarch/gatemate/pack_clocking.cc
@@ -393,10 +393,12 @@ void GateMatePacker::pack_pll()
             log_error("Used more than available PLLs.\n");
 
         if (ci.getPort(id_CLK_REF) == nullptr && ci.getPort(id_USR_CLK_REF) == nullptr)
-            log_error("At least one reference clock (CLK_REF or USR_CLK_REF) must be set.\n");
+            log_error("At least one reference clock (CLK_REF or USR_CLK_REF) must be set for cell '%s'.\n",
+                      ci.name.c_str(ctx));
 
         if (ci.getPort(id_CLK_REF) != nullptr && ci.getPort(id_USR_CLK_REF) != nullptr)
-            log_error("CLK_REF and USR_CLK_REF are not allowed to be set in same time.\n");
+            log_error("CLK_REF and USR_CLK_REF are not allowed to be set in same time for cell '%s'.\n",
+                      ci.name.c_str(ctx));
 
         NetInfo *clk = ci.getPort(id_CLK_REF);
         delay_t period = ctx->getDelayFromNS(1.0e9 / ctx->setting<float>("target_freq"));
@@ -409,14 +411,14 @@ void GateMatePacker::pack_pll()
                     clk = in;
                 }
                 if (ctx->getBelBucketForCellType(clk->driver.cell->type) != id_IOSEL)
-                    log_error("CLK_REF must be driven with GPIO pin.\n");
+                    log_error("CLK_REF must be driven with GPIO pin for cell '%s'.\n", ci.name.c_str(ctx));
                 auto pad_info = uarch->bel_to_pad[clk->driver.cell->bel];
                 if (pad_info->flags == 0)
-                    log_error("CLK_REF must be driven with CLK dedicated pin.\n");
+                    log_error("CLK_REF must be driven with CLK dedicated pin for cell '%s'.\n", ci.name.c_str(ctx));
             } else {
                 // SER_CLK
                 if (clk != net_SER_CLK)
-                    log_error("CLK_REF connected to uknown pin.\n");
+                    log_error("CLK_REF connected to uknown pin for cell '%s'.\n", ci.name.c_str(ctx));
             }
             if (clk->clkconstr)
                 period = clk->clkconstr->period.minDelay();
@@ -438,7 +440,7 @@ void GateMatePacker::pack_pll()
         }
 
         if (ci.getPort(id_CLK_REF_OUT))
-            log_error("Output CLK_REF_OUT cannot be used if PLL is used.\n");
+            log_error("Output CLK_REF_OUT cannot be used if PLL '%s' is used.\n", ci.name.c_str(ctx));
 
         double out_clk_max = 0;
         int clk270_doub = 0;
@@ -478,18 +480,18 @@ void GateMatePacker::pack_pll()
 
             double ref_clk = double_or_default(ci.params, id_REF_CLK, 0.0);
             if (ref_clk <= 0 || ref_clk > 125)
-                log_error("REF_CLK parameter is out of range (0,125.00].\n");
+                log_error("REF_CLK parameter is out of range (0,125.00] for '%s'.\n", ci.name.c_str(ctx));
 
             double out_clk = double_or_default(ci.params, id_OUT_CLK, 0.0);
             if (out_clk <= 0 || out_clk > max_freq)
-                log_error("OUT_CLK parameter is out of range (0,%.2lf].\n", max_freq);
+                log_error("OUT_CLK parameter is out of range (0,%.2lf] for '%s'.\n", max_freq, ci.name.c_str(ctx));
 
             if ((ci_const < 1) || (ci_const > 31)) {
-                log_warning("CI const out of range. Set to default CI = 2\n");
+                log_warning("CI const out of range. Set to default CI = 2 for '%s'\n", ci.name.c_str(ctx));
                 ci_const = 2;
             }
             if ((cp_const < 1) || (cp_const > 31)) {
-                log_warning("CP const out of range. Set to default CP = 4\n");
+                log_warning("CP const out of range. Set to default CP = 4 for '%s'\n", ci.name.c_str(ctx));
                 cp_const = 4;
             }
             // PLL_cfg_val_800_1400  PLL values from 11.08.2021

--- a/himbaechel/uarch/gatemate/pack_clocking.cc
+++ b/himbaechel/uarch/gatemate/pack_clocking.cc
@@ -381,6 +381,8 @@ void GateMatePacker::pack_pll()
                 ci.movePortTo(id_CLK_REF, clkin[die], ctx->idf("CLK%d", pad_info->flags - 1));
             } else {
                 // SER_CLK
+                if (clk != net_SER_CLK)
+                    log_error("CLK_REF connected to uknown pin.\n");
                 clkin[die]->params[ctx->idf("REF%d", pll_index[die])] = Property(0b100, 3);
                 clkin[die]->params[ctx->idf("REF%d_INV", pll_index[die])] = Property(Property::State::S0);
                 ci.movePortTo(id_CLK_REF, clkin[die], id_SER_CLK);

--- a/himbaechel/uarch/gatemate/pack_cpe.cc
+++ b/himbaechel/uarch/gatemate/pack_cpe.cc
@@ -173,6 +173,7 @@ void GateMatePacker::pack_cpe()
 
     auto merge_dff = [&](CellInfo &ci, CellInfo *dff) {
         dff->cluster = ci.name;
+        dff->region = ci.region;
         dff->constr_abs_z = false;
         dff->constr_z = +2;
         ci.cluster = ci.name;
@@ -253,6 +254,7 @@ void GateMatePacker::pack_cpe()
                     CellInfo *lower = create_cell_ptr(id_CPE_L2T4, ctx->idf("%s$lower", ci.name.c_str(ctx)));
                     ci.constr_children.push_back(lower);
                     lower->cluster = ci.name;
+                    lower->region = ci.region;
                     lower->constr_abs_z = true;
                     lower->constr_z = CPE_LT_L_Z;
                     lower->params[id_INIT_L20] = Property(LUT_D0, 4);
@@ -280,6 +282,7 @@ void GateMatePacker::pack_cpe()
     for (auto ci : l2t5_list) {
         CellInfo *upper = create_cell_ptr(id_CPE_L2T4, ctx->idf("%s$upper", ci->name.c_str(ctx)));
         upper->cluster = ci->name;
+        upper->region = ci->region;
         upper->constr_abs_z = true;
         upper->constr_z = CPE_LT_U_Z;
         ci->movePortTo(id_I4, upper, id_IN1);
@@ -334,6 +337,7 @@ void GateMatePacker::pack_cpe()
 
         CellInfo *upper = create_cell_ptr(id_CPE_LT_U, ctx->idf("%s$upper", ci.name.c_str(ctx)));
         upper->cluster = ci.name;
+        upper->region = ci.region;
         upper->constr_abs_z = false;
         upper->constr_z = -1;
         upper->params[id_INIT_L10] = Property(select, 4); // Selection bits
@@ -365,6 +369,7 @@ void GateMatePacker::pack_cpe()
         CellInfo &ci = *cell;
         CellInfo *lt = create_cell_ptr(id_CPE_L2T4, ctx->idf("%s$lt", ci.name.c_str(ctx)));
         lt->cluster = ci.name;
+        lt->region = ci.region;
         lt->constr_abs_z = false;
         lt->constr_z = -2;
         ci.cluster = ci.name;
@@ -515,6 +520,7 @@ void GateMatePacker::pack_addf()
             CellInfo *dff = net_only_drives(ctx, o, is_dff, id_D, true);
             if (dff && are_ffs_compatible(dff, other)) {
                 dff->cluster = cell->cluster;
+                dff->region = cell->region;
                 dff->constr_abs_z = false;
                 dff->constr_z = +2;
                 cell->constr_children.push_back(dff);
@@ -534,6 +540,7 @@ void GateMatePacker::pack_addf()
         CellInfo *ci_upper = create_cell_ptr(id_CPE_DUMMY, ctx->idf("%s$ci_upper", root->name.c_str(ctx)));
         root->constr_children.push_back(ci_upper);
         ci_upper->cluster = root->name;
+        ci_upper->region = root->region;
         ci_upper->constr_abs_z = false;
         ci_upper->constr_z = -1;
         ci_upper->constr_y = -1;
@@ -541,6 +548,7 @@ void GateMatePacker::pack_addf()
         CellInfo *ci_lower = create_cell_ptr(id_CPE_L2T4, ctx->idf("%s$ci", root->name.c_str(ctx)));
         root->constr_children.push_back(ci_lower);
         ci_lower->cluster = root->name;
+        ci_lower->region = root->region;
         ci_lower->constr_abs_z = false;
         ci_lower->constr_y = -1;
         ci_lower->params[id_INIT_L00] = Property(LUT_ZERO, 4);
@@ -551,6 +559,7 @@ void GateMatePacker::pack_addf()
         ci_cplines->params[id_C_CY1_I] = Property(1, 1);
         root->constr_children.push_back(ci_cplines);
         ci_cplines->cluster = root->name;
+        ci_cplines->region = root->region;
         ci_cplines->constr_abs_z = true;
         ci_cplines->constr_y = -1;
         ci_cplines->constr_z = CPE_CPLINES_Z;
@@ -580,6 +589,7 @@ void GateMatePacker::pack_addf()
             CellInfo *cy = grp.at(i);
             if (i != 0) {
                 cy->cluster = root->name;
+                cy->region = root->region;
                 root->constr_children.push_back(cy);
                 cy->constr_abs_z = false;
                 cy->constr_y = +i;
@@ -602,6 +612,7 @@ void GateMatePacker::pack_addf()
 
             CellInfo *upper = create_cell_ptr(id_CPE_LT_U, ctx->idf("%s$upper", cy->name.c_str(ctx)));
             upper->cluster = root->name;
+            upper->region = root->region;
             root->constr_children.push_back(upper);
             upper->constr_abs_z = false;
             upper->constr_y = +i;
@@ -625,12 +636,14 @@ void GateMatePacker::pack_addf()
                     break;
                 CellInfo *co_upper = create_cell_ptr(id_CPE_DUMMY, ctx->idf("%s$co_upper", cy->name.c_str(ctx)));
                 co_upper->cluster = root->name;
+                co_upper->region = root->region;
                 root->constr_children.push_back(co_upper);
                 co_upper->constr_abs_z = false;
                 co_upper->constr_z = -1;
                 co_upper->constr_y = +i + 1;
                 CellInfo *co_lower = create_cell_ptr(id_CPE_L2T4, ctx->idf("%s$co", cy->name.c_str(ctx)));
                 co_lower->cluster = root->name;
+                co_lower->region = root->region;
                 root->constr_children.push_back(co_lower);
                 co_lower->constr_abs_z = false;
                 co_lower->constr_y = +i + 1;
@@ -720,6 +733,7 @@ std::pair<CellInfo *, CellInfo *> GateMatePacker::move_ram_i(CellInfo *cell, IdS
         if (place) {
             cell->constr_children.push_back(cpe_ramio);
             cpe_ramio->cluster = cell->cluster;
+            cpe_ramio->region = cell->region;
             cpe_ramio->constr_abs_z = false;
             cpe_ramio->constr_z = PLACE_DB_CONSTR + origPort.index;
         } else {
@@ -731,6 +745,7 @@ std::pair<CellInfo *, CellInfo *> GateMatePacker::move_ram_i(CellInfo *cell, IdS
         if (place) {
             cpe_ramio->constr_children.push_back(cpe_half);
             cpe_half->cluster = cell->cluster;
+            cpe_half->region = cell->region;
             cpe_half->constr_abs_z = false;
             cpe_half->constr_z = -4;
         } else {
@@ -758,6 +773,7 @@ std::pair<CellInfo *, CellInfo *> GateMatePacker::move_ram_o(CellInfo *cell, IdS
         if (place) {
             cell->constr_children.push_back(cpe_ramio);
             cpe_ramio->cluster = cell->cluster;
+            cpe_ramio->region = cell->region;
             cpe_ramio->constr_abs_z = false;
             cpe_ramio->constr_z = PLACE_DB_CONSTR + origPort.index;
         } else {
@@ -768,6 +784,7 @@ std::pair<CellInfo *, CellInfo *> GateMatePacker::move_ram_o(CellInfo *cell, IdS
         if (place) {
             cpe_ramio->constr_children.push_back(cpe_half);
             cpe_half->cluster = cell->cluster;
+            cpe_half->region = cell->region;
             cpe_half->constr_abs_z = false;
             cpe_half->constr_z = -4;
         } else {
@@ -816,6 +833,7 @@ std::pair<CellInfo *, CellInfo *> GateMatePacker::move_ram_io(CellInfo *cell, Id
     if (place) {
         cell->constr_children.push_back(cpe_ramio);
         cpe_ramio->cluster = cell->cluster;
+        cpe_ramio->region = cell->region;
         cpe_ramio->constr_abs_z = false;
         cpe_ramio->constr_z = PLACE_DB_CONSTR + oPort.index;
     } else {
@@ -827,6 +845,7 @@ std::pair<CellInfo *, CellInfo *> GateMatePacker::move_ram_io(CellInfo *cell, Id
     if (place) {
         cpe_ramio->constr_children.push_back(cpe_half);
         cpe_half->cluster = cell->cluster;
+        cpe_half->region = cell->region;
         cpe_half->constr_abs_z = false;
         cpe_half->constr_z = -4;
     } else {

--- a/himbaechel/uarch/gatemate/pack_cpe.cc
+++ b/himbaechel/uarch/gatemate/pack_cpe.cc
@@ -678,6 +678,7 @@ void GateMatePacker::pack_constants()
     h.replace_constants(CellTypePort(id_CPE_L2T4, id_OUT), CellTypePort(id_CPE_L2T4, id_OUT), vcc_params, gnd_params);
     net_PACKER_VCC = ctx->nets.at(ctx->id("$PACKER_VCC")).get();
     net_PACKER_GND = ctx->nets.at(ctx->id("$PACKER_GND")).get();
+    net_SER_CLK = nullptr;
 }
 
 void GateMatePacker::remove_constants()

--- a/himbaechel/uarch/gatemate/pack_io.cc
+++ b/himbaechel/uarch/gatemate/pack_io.cc
@@ -371,12 +371,12 @@ void GateMatePacker::pack_io_sel()
             } else if (clk_net == net_PACKER_VCC) {
                 cell->disconnectPort(id_CLK);
             } else {
-                if (!global_signals.count(clk_net)) {
+                if (!uarch->global_signals.count(clk_net)) {
                     cell->movePortTo(id_CLK, target, id_OUT4);
                     target->params[id_SEL_OUT_CLOCK] = Property(Property::State::S1);
                     return true;
                 } else {
-                    int index = global_signals[clk_net];
+                    int index = uarch->global_signals[clk_net];
                     cell->movePortTo(id_CLK, target, ctx->idf("CLOCK%d", index + 1));
                     target->params[id_OUT_CLOCK] = Property(index, 2);
                 }
@@ -392,11 +392,11 @@ void GateMatePacker::pack_io_sel()
             } else if (clk_net == net_PACKER_VCC) {
                 cell->disconnectPort(id_CLK);
             } else {
-                if (!global_signals.count(clk_net)) {
+                if (!uarch->global_signals.count(clk_net)) {
                     cell->movePortTo(id_CLK, target, id_OUT4);
                     target->params[id_SEL_IN_CLOCK] = Property(Property::State::S1);
                 } else {
-                    int index = global_signals[clk_net];
+                    int index = uarch->global_signals[clk_net];
                     cell->movePortTo(id_CLK, target, ctx->idf("CLOCK%d", index + 1));
                     target->params[id_IN_CLOCK] = Property(index, 2);
                 }
@@ -407,7 +407,7 @@ void GateMatePacker::pack_io_sel()
     auto merge_ibf = [&](NetInfo *di_net, CellInfo &ci, bool use_custom_clock) -> bool {
         CellInfo *dff = (*di_net->users.begin()).cell;
         if (is_gpio_valid_dff(dff)) {
-            if (!global_signals.count(ci.getPort(id_CLK)) && use_custom_clock) {
+            if (!uarch->global_signals.count(ci.getPort(id_CLK)) && use_custom_clock) {
                 log_warning("Found DFF %s cell, but not enough CLK signals.\n", dff->name.c_str(ctx));
                 return false;
             }
@@ -432,7 +432,7 @@ void GateMatePacker::pack_io_sel()
 
     auto merge_iddr = [&](NetInfo *di_net, CellInfo &ci, bool use_custom_clock) -> bool {
         CellInfo *iddr = (*di_net->users.begin()).cell;
-        if (!global_signals.count(ci.getPort(id_CLK)) && use_custom_clock) {
+        if (!uarch->global_signals.count(ci.getPort(id_CLK)) && use_custom_clock) {
             log_warning("Found IDDR %s cell, but not enough CLK signals.\n", iddr->name.c_str(ctx));
             return false;
         }

--- a/himbaechel/uarch/gatemate/pack_io.cc
+++ b/himbaechel/uarch/gatemate/pack_io.cc
@@ -142,6 +142,7 @@ void GateMatePacker::pack_io()
                     s.cell->disconnectPort(s.port);
                     s.cell->connectPort(s.port, ser_clk);
                 }
+                net_SER_CLK = ser_clk;
                 ci.disconnectPort(id_I);
                 packed_cells.emplace(ci.name);
                 continue;

--- a/himbaechel/uarch/gatemate/pack_io.cc
+++ b/himbaechel/uarch/gatemate/pack_io.cc
@@ -303,7 +303,6 @@ void GateMatePacker::pack_io()
             uarch->available_pads.erase(id);
             loc = id.c_str(ctx);
         }
-        ci.params[id_LOC] = Property(loc);
 
         BelId bel;
         if (uarch->locations.count(std::make_pair(ctx->id(loc), uarch->preferred_die)))
@@ -471,8 +470,6 @@ void GateMatePacker::pack_io_sel()
         }
 
         ci.cluster = ci.name;
-        std::string loc = str_or_default(ci.params, id_LOC, "UNPLACED");
-        ci.unsetParam(id_LOC);
 
         NetInfo *do_net = ci.getPort(id_A);
         bool use_custom_clock = false;
@@ -526,7 +523,7 @@ void GateMatePacker::pack_io_sel()
                     ci.disconnectPort(id_A);
                     oddr->movePortTo(id_D0, &ci, id_OUT2);
                     oddr->movePortTo(id_D1, &ci, id_OUT1);
-                    const auto &pad = ctx->get_package_pin(ctx->id(loc));
+                    const auto &pad = uarch->bel_to_pad[ci.bel];
                     int die = uarch->tile_extra_data(ci.bel.tile)->die;
                     auto [cpe_half, cpe_ramio] = ddr[die][pad->pad_bank];
                     if (cpe_half) {

--- a/himbaechel/uarch/gatemate/pack_mult.cc
+++ b/himbaechel/uarch/gatemate/pack_mult.cc
@@ -573,6 +573,7 @@ void GateMatePacker::pack_mult()
         // we also constrain it to proper Z location
         auto *root = m.cols[0].b_passthru.upper;
         root->cluster = root->name;
+        root->region = mult->region;
         root->constr_abs_z = true;
         root->constr_z = CPE_LT_U_Z;
 
@@ -581,6 +582,7 @@ void GateMatePacker::pack_mult()
                 return;
             root->constr_children.push_back(cell);
             cell->cluster = root->name;
+            cell->region = root->region;
             cell->constr_abs_z = true;
             cell->constr_x = x_offset;
             cell->constr_y = y_offset;

--- a/himbaechel/uarch/gatemate/tests/lut.cc
+++ b/himbaechel/uarch/gatemate/tests/lut.cc
@@ -49,11 +49,11 @@ TEST_F(GateMateTest, remove_lut1_zero)
 
     CellInfo *obuf = create_cell_ptr(id_CC_OBUF, "obuf");
 
-    lut1->connectPorts(id_O, obuf, id_A);
+    direct_connect(lut1, id_O, obuf, id_A);
 
     ASSERT_EQ(ctx->cells.size(), 2LU);
     ctx->uarch->pack();
-    ASSERT_EQ(ctx->cells.size(), 1LU);
+    ASSERT_EQ(ctx->cells.size(), 4LU);
 }
 
 TEST_F(GateMateTest, remove_lut1_one)
@@ -63,11 +63,11 @@ TEST_F(GateMateTest, remove_lut1_one)
 
     CellInfo *obuf = create_cell_ptr(id_CC_OBUF, "obuf");
 
-    lut1->connectPorts(id_O, obuf, id_A);
+    direct_connect(lut1, id_O, obuf, id_A);
 
     ASSERT_EQ(ctx->cells.size(), 2LU);
     ctx->uarch->pack();
-    ASSERT_EQ(ctx->cells.size(), 1LU);
+    ASSERT_EQ(ctx->cells.size(), 4LU);
 }
 
 TEST_F(GateMateTest, remove_lut1_pass)
@@ -78,14 +78,14 @@ TEST_F(GateMateTest, remove_lut1_pass)
     CellInfo *obuf = create_cell_ptr(id_CC_OBUF, "obuf");
     CellInfo *ibuf = create_cell_ptr(id_CC_IBUF, "ibuf");
 
-    ibuf->connectPorts(id_Y, lut1, id_I0);
-    lut1->connectPorts(id_O, obuf, id_A);
+    direct_connect(ibuf, id_Y, lut1, id_I0);
+    direct_connect(lut1, id_O, obuf, id_A);
 
     ASSERT_EQ(ctx->cells.size(), 3LU);
     ctx->uarch->pack();
     // Expect IBUF -> CPE -> OBUF
     // LUT removed, but CPE for driving OBUF added
-    ASSERT_EQ(ctx->cells.size(), 4LU);
+    ASSERT_EQ(ctx->cells.size(), 8LU);
 }
 
 TEST_F(GateMateTest, remove_lut1_inv)
@@ -96,14 +96,14 @@ TEST_F(GateMateTest, remove_lut1_inv)
     CellInfo *obuf = create_cell_ptr(id_CC_OBUF, "obuf");
     CellInfo *ibuf = create_cell_ptr(id_CC_IBUF, "ibuf");
 
-    ibuf->connectPorts(id_Y, lut1, id_I0);
-    lut1->connectPorts(id_O, obuf, id_A);
+    direct_connect(ibuf, id_Y, lut1, id_I0);
+    direct_connect(lut1, id_O, obuf, id_A);
 
     ASSERT_EQ(ctx->cells.size(), 3LU);
     ctx->uarch->pack();
     // Expect IBUF -> CPE -> OBUF
     // LUT merged, but CPE for driving OBUF added
-    ASSERT_EQ(ctx->cells.size(), 5LU);
+    ASSERT_EQ(ctx->cells.size(), 9LU);
 }
 
 TEST_F(GateMateTest, remove_lut1_not_driven)
@@ -123,5 +123,5 @@ TEST_F(GateMateTest, remove_lut1_not_driven)
     ctx->uarch->pack();
     // Expect IBUF -> CPE -> OBUF
     // LUT1 removed as not used, but CPE for driving OBUF added
-    ASSERT_EQ(ctx->cells.size(), 4LU);
+    ASSERT_EQ(ctx->cells.size(), 8LU);
 }

--- a/himbaechel/uarch/gatemate/tests/testing.cc
+++ b/himbaechel/uarch/gatemate/tests/testing.cc
@@ -201,4 +201,11 @@ CellInfo *GateMateTest::create_cell_ptr(IdString type, std::string name)
     return cell;
 }
 
+void GateMateTest::direct_connect(CellInfo *o_cell, IdString o_port, CellInfo *i_cell, IdString i_port)
+{
+    NetInfo *net = ctx->createNet(ctx->idf("%s_%s", o_cell->name.c_str(ctx), o_port.c_str(ctx)));
+    o_cell->connectPort(o_port, net);
+    i_cell->connectPort(i_port, net);
+}
+
 NEXTPNR_NAMESPACE_END

--- a/himbaechel/uarch/gatemate/tests/testing.h
+++ b/himbaechel/uarch/gatemate/tests/testing.h
@@ -34,6 +34,7 @@ class GateMateTest : public ::testing::Test
     virtual void TearDown() override;
 
     CellInfo *create_cell_ptr(IdString type, std::string name);
+    void direct_connect(CellInfo *o_cell, IdString o_port, CellInfo *i_cell, IdString i_port);
 
     ArchArgs chipArgs;
     Context *ctx;


### PR DESCRIPTION
This one search for better PLL/BUFG assignment when that is possible.

Currently limiting number to 4 PLLs and BUFGs independently of number of dies, this makes copy of all clocks possible, so they become available in all dies in same order, this makes use of A2 and A4 for lower clock number.

Also it fixes special case where CC_ODDR is having inverter on output, by moving that inverter to both inputs. 

Separate dies are now defined as regions, and cells can be assigned to be in desired one.  force_die option now sets region for all non-pre-placed cells to a given one. We are also making sure that pack procedure preserves region information ( for future use).

