### PR TITLE
Gowin. GW5A series BSRAM fix.

### DIFF
--- a/himbaechel/uarch/gowin/gowin.h
+++ b/himbaechel/uarch/gowin/gowin.h
@@ -203,6 +203,7 @@ NPNR_PACKED_STRUCT(struct Extra_chip_data_POD {
     static constexpr int32_t HAS_PINCFG = 128;
     static constexpr int32_t HAS_DFF67 = 256;
     static constexpr int32_t HAS_CIN_MUX = 512;
+    static constexpr int32_t NEED_BSRAM_RESET_FIX = 1024;
 });
 
 } // namespace

--- a/himbaechel/uarch/gowin/gowin_arch_gen.py
+++ b/himbaechel/uarch/gowin/gowin_arch_gen.py
@@ -28,6 +28,7 @@ CHIP_HAS_CLKDIV_HCLK       = 0x40
 CHIP_HAS_PINCFG            = 0x80
 CHIP_HAS_DFF67             = 0x100
 CHIP_HAS_CIN_MUX           = 0x200
+CHIP_NEED_BSRAM_RESET_FIX  = 0x400
 
 # Tile flags
 TILE_I3C_CAPABLE_IO        = 0x1
@@ -1617,6 +1618,8 @@ def main():
             chip_flags |= CHIP_HAS_DFF67;
         if "HAS_CIN_MUX" in db.chip_flags:
             chip_flags |= CHIP_HAS_CIN_MUX;
+        if "NEED_BSRAM_RESET_FIX" in db.chip_flags:
+            chip_flags |= CHIP_NEED_BSRAM_RESET_FIX;
 
     X = db.cols;
     Y = db.rows;

--- a/himbaechel/uarch/gowin/gowin_utils.cc
+++ b/himbaechel/uarch/gowin/gowin_utils.cc
@@ -386,6 +386,12 @@ bool GowinUtils::need_BSRAM_OUTREG_fix(void)
     return extra->chip_flags & Extra_chip_data_POD::NEED_BSRAM_OUTREG_FIX;
 }
 
+bool GowinUtils::need_BSRAM_RESET_fix(void)
+{
+    const Extra_chip_data_POD *extra = reinterpret_cast<const Extra_chip_data_POD *>(ctx->chip_info->extra_data.get());
+    return extra->chip_flags & Extra_chip_data_POD::NEED_BSRAM_RESET_FIX;
+}
+
 bool GowinUtils::need_BLKSEL_fix(void)
 {
     const Extra_chip_data_POD *extra = reinterpret_cast<const Extra_chip_data_POD *>(ctx->chip_info->extra_data.get());

--- a/himbaechel/uarch/gowin/gowin_utils.h
+++ b/himbaechel/uarch/gowin/gowin_utils.h
@@ -100,6 +100,7 @@ struct GowinUtils
     bool has_SP32(void);
     bool need_SP_fix(void);
     bool need_BSRAM_OUTREG_fix(void);
+    bool need_BSRAM_RESET_fix(void);
     bool need_BLKSEL_fix(void);
     bool has_PLL_HCLK(void);
     bool has_CLKDIV_HCLK(void);

--- a/himbaechel/uarch/gowin/pack.cc
+++ b/himbaechel/uarch/gowin/pack.cc
@@ -2632,6 +2632,13 @@ struct GowinPacker
             ci->connectPort(id_WREB, vss_net);
             bsram_rename_ports(ci, bit_width, "DO[%d]", "DO%d", 18);
         }
+
+        // If misconnected RESET
+        if (gwu.need_BSRAM_RESET_fix()) {
+            ci->renamePort(id_RESET, id_RESETB);
+            ci->addInput(id_RESET);
+            ci->connectPort(id_RESET, vcc_net);
+        }
     }
 
     void pack_DPB(CellInfo *ci)


### PR DESCRIPTION
In the new series of chips, the SemiDual Port primitive has one RESET pin instead of two in previous versions - RESETA and RESETB.

Physically, the two pins are still there and both must be connected, with RESETA being constant.