### PR TITLE
Gowin. Remove the special status of corner tiles.

### DIFF
--- a/himbaechel/uarch/gowin/gowin.h
+++ b/himbaechel/uarch/gowin/gowin.h
@@ -184,7 +184,7 @@ NPNR_PACKED_STRUCT(struct Extra_package_data_POD { RelSlice<Constraint_POD> cst;
 
 NPNR_PACKED_STRUCT(struct Extra_chip_data_POD {
     int32_t chip_flags;
-    IdString dcs_prefix;
+    int32_t dcs_prefix;
     Bottom_io_POD bottom_io;
     RelSlice<IdString> diff_io_types;
     RelSlice<Spine_bel_POD> dqce_bels;

--- a/himbaechel/uarch/gowin/gowin_utils.cc
+++ b/himbaechel/uarch/gowin/gowin_utils.cc
@@ -293,7 +293,7 @@ BelId GowinUtils::get_dhcen_bel(WireId hclkin_wire, IdString &side)
 IdString GowinUtils::get_dcs_prefix(void)
 {
     const Extra_chip_data_POD *extra = reinterpret_cast<const Extra_chip_data_POD *>(ctx->chip_info->extra_data.get());
-    return extra->dcs_prefix;
+    return IdString(extra->dcs_prefix);
 }
 
 bool GowinUtils::is_simple_io_bel(BelId bel)


### PR DESCRIPTION
Over time, it became clear that the special status of corner tiles is handled in other parts of the toolchain, and in the GW5A chip series, it began to interfere—in this series, IO can be located in the corners.

So we move the only function (creating VCC and GND) to the extra function itself, and at the same time create a mechanism for explicitly specifying the location of these sources in Apicula when necessary.