### PR TITLE
gatemate: respect keep attribute and prevent crash with BEL set

### DIFF
--- a/himbaechel/uarch/gatemate/pack.h
+++ b/himbaechel/uarch/gatemate/pack.h
@@ -64,6 +64,7 @@ struct GateMatePacker
 
     void remove_constants();
     void remove_clocking();
+    void remove_double_constrained();
 
     void cleanup();
     void repack_cpe();


### PR DESCRIPTION
If BEL attribute is set and cell is part of cluster placer will crash. Prevent that for now until placer can handle this.