### PR TITLE
ice40: Initialize context pointer in tests

### DIFF
--- a/ice40/tests/hx1k.cc
+++ b/ice40/tests/hx1k.cc
@@ -37,7 +37,7 @@ class HX1KTest : public ::testing::Test
     virtual void TearDown() { delete ctx; }
 
     ArchArgs chipArgs;
-    Context *ctx;
+    Context *ctx = nullptr;
 };
 
 TEST_F(HX1KTest, bel_names)

--- a/ice40/tests/hx8k.cc
+++ b/ice40/tests/hx8k.cc
@@ -37,7 +37,7 @@ class HX8KTest : public ::testing::Test
     virtual void TearDown() { delete ctx; }
 
     ArchArgs chipArgs;
-    Context *ctx;
+    Context *ctx = nullptr;
 };
 
 TEST_F(HX8KTest, bel_names)

--- a/ice40/tests/lp1k.cc
+++ b/ice40/tests/lp1k.cc
@@ -37,7 +37,7 @@ class LP1KTest : public ::testing::Test
     virtual void TearDown() { delete ctx; }
 
     ArchArgs chipArgs;
-    Context *ctx;
+    Context *ctx = nullptr;
 };
 
 TEST_F(LP1KTest, bel_names)

--- a/ice40/tests/lp384.cc
+++ b/ice40/tests/lp384.cc
@@ -37,7 +37,7 @@ class LP384Test : public ::testing::Test
     virtual void TearDown() { delete ctx; }
 
     ArchArgs chipArgs;
-    Context *ctx;
+    Context *ctx = nullptr;
 };
 
 TEST_F(LP384Test, bel_names)

--- a/ice40/tests/lp8k.cc
+++ b/ice40/tests/lp8k.cc
@@ -37,7 +37,7 @@ class LP8KTest : public ::testing::Test
     virtual void TearDown() { delete ctx; }
 
     ArchArgs chipArgs;
-    Context *ctx;
+    Context *ctx = nullptr;
 };
 
 TEST_F(LP8KTest, bel_names)

--- a/ice40/tests/up5k.cc
+++ b/ice40/tests/up5k.cc
@@ -37,7 +37,7 @@ class UP5KTest : public ::testing::Test
     virtual void TearDown() { delete ctx; }
 
     ArchArgs chipArgs;
-    Context *ctx;
+    Context *ctx = nullptr;
 };
 
 TEST_F(UP5KTest, bel_names)


### PR DESCRIPTION
If the chipdb is not found, the Setup() call throws, but GTest still calls TearDown, which then stumbles over the uninitialized pointer.

This makes the tests fail without valgrind errors or segfaults at least.