### PR TITLE
Update CI and README for Qt6

### DIFF
--- a/.github/workflows/arch_ci.yml
+++ b/.github/workflows/arch_ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install
       run: |
         sudo apt-get update
-        sudo apt-get install git make cmake libboost-all-dev python3-dev pypy3 libeigen3-dev tcl-dev lzma-dev libftdi-dev clang bison flex swig qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools iverilog libreadline-dev liblzma-dev cargo rustc
+        sudo apt-get install git make cmake libboost-all-dev python3-dev pypy3 libeigen3-dev tcl-dev lzma-dev libftdi-dev clang bison flex swig qt6-base-dev iverilog libreadline-dev liblzma-dev cargo rustc
 
     - name: Cache yosys installation
       uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -185,9 +185,16 @@ sudo make install
 
 ### GUI
 
-The nextpnr GUI is not built by default, to reduce the number of dependencies for a standard headless build. To enable it, add `-DBUILD_GUI=ON` to the CMake command line and ensure that Qt5 and OpenGL are available:
+The nextpnr GUI is not built by default, to reduce the number of dependencies for a standard headless build. To enable it, add `-DBUILD_GUI=ON` to the CMake command line and ensure that Qt5/Qt6 and OpenGL are available:
 
- - On Ubuntu 22.04 LTS, install `qtcreator qtbase5-dev qt5-qmake`
+For Qt6:
+ - On Ubuntu 22.04 LTS or later, install `qt6-base-dev`
+ - For MSVC vcpkg, install `qt-base` (32-bit) or `qt-base:x64-windows` (64-bit)
+ - For Homebrew, install `qt6` and add qt6 in path: `echo 'export PATH="/usr/local/opt/qt/bin:$PATH"' >> ~/.bash_profile`
+` - this change is effective in next terminal session, so please re-open terminal window before building
+
+For Qt5:
+ - On Ubuntu 22.04 LTS, install `qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools`
  - On other Ubuntu versions, install `qt5-default`
  - For MSVC vcpkg, install `qt5-base` (32-bit) or `qt5-base:x64-windows` (64-bit)
  - For Homebrew, install `qt5` and add qt5 in path: `echo 'export PATH="/usr/local/opt/qt/bin:$PATH"' >> ~/.bash_profile`

--- a/machxo2/README.md
+++ b/machxo2/README.md
@@ -38,7 +38,7 @@ The following commands are known to work on a near-fresh Linux Mint system
 
 ```
 sudo apt install cmake clang-format libboost-all-dev build-essential
-qt5-default libeigen3-dev build-essential clang bison flex libreadline-dev
+qt6-base-dev libeigen3-dev build-essential clang bison flex libreadline-dev
 gawk tcl-dev libffi-dev git graphviz xdot pkg-config python3
 libboost-system-dev libboost-python-dev libboost-filesystem-dev zlib1g-dev
 python3-setuptools python3-serial

--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@ in pkgs.mkShell {
     boostPython
     pythonPkgs.python
     pythonPkgs.apycula
-    libsForQt5.qt5.qtbase
+    pkgs.qt6.qtbase
     llvmPackages.openmp
     icestorm
     trellis
@@ -25,6 +25,6 @@ in pkgs.mkShell {
   shellHook = ''
     export TRELLIS_INSTALL_PREFIX=${pkgs.trellis}
     export ICESTORM_INSTALL_PREFIX=${pkgs.icestorm}
-    export QT_QPA_PLATFORM_PLUGIN_PATH="${pkgs.libsForQt5.qt5.qtbase.bin}/lib/qt-${pkgs.libsForQt5.qt5.qtbase.version}/plugins";
+    export QT_QPA_PLATFORM_PLUGIN_PATH="${pkgs.qt6.qtbase.bin}/lib/qt-${pkgs.qt6.qtbase.version}/plugins";
   '';
 }


### PR DESCRIPTION
This PR takes CI updates and README changes in https://github.com/YosysHQ/nextpnr/pull/1514 
Have altered it a bit to have Qt5 and Qt6 both paths explained.

If this is merged we should close #1514 