### PR TITLE
Gate Boost `system` component behind version check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,11 +169,18 @@ else()
     endif()
 endif()
 
-set(boost_libs filesystem program_options iostreams system)
+set(boost_libs filesystem program_options iostreams)
 if (Threads_FOUND)
     list(APPEND boost_libs thread)
 endif()
 find_package(Boost REQUIRED COMPONENTS ${boost_libs})
+
+# The `boost_system` library stubs were removed in 1.89.0, so only add them if
+# boost is older than that
+if (Boost_VERSION VERSION_LESS "1.89.0")
+    list(APPEND boost_libs system)
+    find_package(Boost REQUIRED COMPONENTS ${boost_libs})
+endif()
 
 if (BUILD_PYTHON)
     # TODO: sensible minimum Python version

--- a/bba/CMakeLists.txt
+++ b/bba/CMakeLists.txt
@@ -3,13 +3,24 @@ project(bba CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 
-find_package(Boost REQUIRED COMPONENTS
-    program_options
-    system)
+set(boost_libs program_options iostreams)
+
+find_package(Boost REQUIRED COMPONENTS ${boost_libs})
+
+if (Boost_VERSION VERSION_LESS "1.89.0")
+    list(APPEND boost_libs system)
+    find_package(Boost REQUIRED COMPONENTS ${boost_libs})
+endif()
+
 
 add_executable(bbasm
     main.cc)
-target_link_libraries(bbasm LINK_PRIVATE
-    ${Boost_PROGRAM_OPTIONS_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY})
+
+set(boost_link_libs ${Boost_PROGRAM_OPTIONS_LIBRARY})
+if(Boost_VERSION VERSION_LESS "1.89.0")
+    list(APPEND boost_link_libs ${Boost_SYSTEM_LIBRARY})
+endif()
+
+target_link_libraries(bbasm LINK_PRIVATE ${boost_link_libs})
+
 export(TARGETS bbasm FILE ${CMAKE_BINARY_DIR}/bba-export.cmake)


### PR DESCRIPTION
This PR adds a version check for the Boost `system` component to only require the stub libraries if the version of boost is older than `1.89.0`, as it was removed in that version


This closes #1588

See Also: https://github.com/YosysHQ/prjtrellis/pull/258