### PR TITLE
Gowin. Take the arch arguments directly.

### DIFF
--- a/himbaechel/uarch/gowin/gowin.cc
+++ b/himbaechel/uarch/gowin/gowin.cc
@@ -179,7 +179,7 @@ void GowinImpl::init(Context *ctx)
 
     gwu.init(ctx);
 
-    const ArchArgs &args = ctx->getArchArgs();
+    const ArchArgs &args = ctx->args;
 
     // package and speed class
     std::regex speedre = std::regex("(.*)(C[0-9]/I[0-9])$");

--- a/himbaechel/uarch/gowin/pack.cc
+++ b/himbaechel/uarch/gowin/pack.cc
@@ -2696,7 +2696,7 @@ struct GowinPacker
                 divide_sdp(ci, new_cells);
             } else {
                 log_error("The fix for SDP when ports A and B have different bit widths has not yet been implemented. "
-                          "Cell'%s'\n",
+                          "Cell: '%s'\n",
                           ci->type.c_str(ctx));
             }
         }
@@ -3934,7 +3934,7 @@ struct GowinPacker
             pincfg_cell->connectPort(port, ctx->nets.at(ctx->id("$PACKER_VCC")).get());
         }
 
-        const ArchArgs &args = ctx->getArchArgs();
+        const ArchArgs &args = ctx->args;
 
         pincfg_cell->addInput(id_SSPI);
         if (args.options.count("sspi_as_gpio")) {


### PR DESCRIPTION
Since ctx->getArchArgs() no longer returns architecture-specific arguments, we read the args field directly.