### PR TITLE
gatemate: handle default parameters for IO

### DIFF
--- a/himbaechel/uarch/gatemate/pack_io.cc
+++ b/himbaechel/uarch/gatemate/pack_io.cc
@@ -196,12 +196,12 @@ void GateMatePacker::pack_io()
             if (ci.type.in(id_CC_TOBUF) && p.first.in(id_PULLUP, id_PULLDOWN, id_KEEPER))
                 continue;
             if (ci.type.in(id_CC_OBUF, id_CC_TOBUF, id_CC_IOBUF)) {
-                if (p.first == id_DRIVE) {
+                if (p.first.in(id_DRIVE, id_SLEW)) {
                     if (p.second.is_string && p.second.as_string() == "UNDEFINED")
                         keys.push_back(p.first);
                     continue;
                 }
-                if (p.first.in(id_SLEW, id_DELAY_OBF, id_FF_OBF))
+                if (p.first.in(id_DELAY_OBF, id_FF_OBF))
                     continue;
             }
             if (ci.type.in(id_CC_LVDS_IBUF, id_CC_LVDS_IOBUF) && p.first.in(id_LVDS_RTERM, id_DELAY_IBF, id_FF_IBF))


### PR DESCRIPTION
This is probably a VHDL specific issue.  In VHDL, there is no black-box. Primitive instantiations are done using VHDL component instantiations and the component must have been declared with all its ports and parameters (generic).  Currently the components are translated from cells_sim.v and cells_bb.v

If a user doesn't override a parameter, the default value is used instead.  As a consequence, nextpnr can have 'UNDEFINED' for DRIVER or SLEW parameters of CC_IOBUF.  I think this is a main difference with verilog, where unspecified parameters do not appear.

With this change, the UNPLACED value of PIN_NAME and UNDEFINED value of DRIVE are simply ignored.