### PR TITLE
Gowin. Implement ADC.

### DIFF
--- a/himbaechel/uarch/gowin/constids.inc
+++ b/himbaechel/uarch/gowin/constids.inc
@@ -1038,6 +1038,9 @@ X(RPLLA)
 X(PLLVR)
 X(PLLA)
 
+// ADC
+X(ADC)
+
 // primitive attributes
 X(INIT)
 X(FF_USED)

--- a/himbaechel/uarch/gowin/gowin.h
+++ b/himbaechel/uarch/gowin/gowin.h
@@ -100,6 +100,10 @@ inline bool is_userflash(const CellInfo *cell) { return type_is_userflash(cell->
 inline bool type_is_pll(IdString cell_type) { return cell_type.in(id_rPLL, id_PLLVR); }
 inline bool is_pll(const CellInfo *cell) { return type_is_pll(cell->type); }
 
+// Return true if a cell is a ADC
+inline bool type_is_adc(IdString cell_type) { return cell_type.in(id_ADC); }
+inline bool is_adc(const CellInfo *cell) { return type_is_adc(cell->type); }
+
 // Return true if a cell is a EMCU
 inline bool type_is_emcu(IdString cell_type) { return cell_type == id_EMCU; }
 inline bool is_emcu(const CellInfo *cell) { return type_is_emcu(cell->type); }
@@ -253,6 +257,8 @@ enum
     DLLDLY_Z = 303, // : 305 reserve for 2 DLLDLYs
 
     PINCFG_Z = 400,
+
+    ADC_Z = 401,
 
     // The two least significant bits encode Z for 9-bit adders and
     // multipliers, if they are equal to 0, then we get Z of their common

--- a/himbaechel/uarch/gowin/gowin_arch_gen.py
+++ b/himbaechel/uarch/gowin/gowin_arch_gen.py
@@ -75,7 +75,8 @@ MIPIIBUF_Z  = 302
 
 DLLDLY_Z    = 303 # : 305 reserve for 2 DLLDLYs
 
-PINCFG_Z    = 400 #
+PINCFG_Z    = 400
+ADC_Z       = 401
 
 DSP_Z          = 509
 
@@ -463,7 +464,7 @@ def create_nodes(chip: Chip, db: chipdb):
                 for i in range(5):
                     nodes.append([NodeWire(x, y, f'COUT{i}'),
                                   NodeWire(x, y, f'CIN{i + 1}')]);
-                # gobal carry chain
+                # global carry chain
                 if x > 1 and chip.tile_type_at(x - 1, y).extra_data.tile_class == chip.strs.id('LOGIC'):
                     nodes.append([NodeWire(x, y, f'CIN0'),
                                   NodeWire(x - 1, y, f'COUT5')])
@@ -787,6 +788,17 @@ def create_extra_funcs(tt: TileType, db: chipdb, x: int, y: int):
                     tt.add_bel_pin(pll, pin, wire, PinType.OUTPUT)
                 for pin, wire in desc['inputs'].items():
                     tt.create_wire(wire, "PLL_I")
+                    tt.add_bel_pin(pll, pin, wire, PinType.INPUT)
+        elif func == 'adc':
+                pll = tt.create_bel("ADC", "ADC", z = ADC_Z)
+                for pin, wire in desc['outputs'].items():
+                    tt.create_wire(wire, "ADC_O")
+                    tt.add_bel_pin(pll, pin, wire, PinType.OUTPUT)
+                for pin, wire in desc['inputs'].items():
+                    if pin == 'CLK' or pin == 'MDRP_CLK':
+                        tt.create_wire(wire, "TILE_CLK")
+                    else:
+                        tt.create_wire(wire, "ADC_I")
                     tt.add_bel_pin(pll, pin, wire, PinType.INPUT)
         elif func == 'gnd_source':
                 # GND is the logic low level generator

--- a/himbaechel/uarch/gowin/pack.cc
+++ b/himbaechel/uarch/gowin/pack.cc
@@ -4074,6 +4074,34 @@ struct GowinPacker
     }
 
     // ===================================
+    // ADC
+    // ===================================
+    void pack_adc(void)
+    {
+        log_info("Pack ADC...\n");
+
+        for (auto &cell : ctx->cells) {
+            auto &ci = *cell.second;
+
+            if (is_adc(&ci)) {
+                for (int i = 0; i < 14; ++i) {
+                    if (i < 2) {
+                        ci.renamePort(ctx->idf("MDRP_OPCODE[%d]", i), ctx->idf("MDRP_OPCODE%d", i));
+                    }
+                    if (i < 3) {
+                        ci.renamePort(ctx->idf("VSENCTL[%d]", i), ctx->idf("VSENCTL%d", i));
+                    }
+                    if (i < 8) {
+                        ci.renamePort(ctx->idf("MDRP_WDATA[%d]", i), ctx->idf("MDRP_WDATA%d", i));
+                        ci.renamePort(ctx->idf("MDRP_RDATA[%d]", i), ctx->idf("MDRP_RDATA%d", i));
+                    }
+                    ci.renamePort(ctx->idf("ADCVALUE[%d]", i), ctx->idf("ADCVALUE%d", i));
+                }
+            }
+        }
+    }
+
+    // ===================================
     // HCLK -- CLKDIV and CLKDIV2 for now
     // ===================================
     void pack_hclk(void)
@@ -4555,6 +4583,9 @@ struct GowinPacker
         ctx->check();
 
         pack_pll();
+        ctx->check();
+
+        pack_adc();
         ctx->check();
 
         pack_bsram();


### PR DESCRIPTION
ADC support for GW5A-25 chips has been added.

The inputs of this primitive are fixed and do not require routing, although they can be switched dynamically.

The .CST file also specifies the pins used as signal sources for the bus0 and bus1 ADC buses.