### PR TITLE
Avoid throwing out_of_range in log_fmax when related clocks lack Fmax entries

### DIFF
--- a/common/kernel/timing_log.cc
+++ b/common/kernel/timing_log.cc
@@ -300,8 +300,14 @@ static void log_fmax(Context *ctx, TimingResult &result, bool warn_on_failure)
                 target = clock_fmax.at(clock_a).constraint;
             } else if (!clock_fmax.count(clock_a) && clock_fmax.count(clock_b)) {
                 target = clock_fmax.at(clock_b).constraint;
+            } else if (clock_fmax.count(clock_a) && clock_fmax.count(clock_b)) {
+                target = std::min(clock_fmax.at(clock_a).constraint, clock_fmax.at(clock_b).constraint);              
             } else {
-                target = std::min(clock_fmax.at(clock_a).constraint, clock_fmax.at(clock_b).constraint);
+                // Neither clock has an Fmax entry; just skip or fall back
+                log_warning("No Fmax for related clocks '%s' and '%s', skipping.\n",
+                            ctx->nameOf(clock_a),
+                            ctx->nameOf(clock_b));
+                continue; 
             }
 
             bool passed = target < fmax;


### PR DESCRIPTION
When two "related clocks" have no entries in result.clock_fmax, log_fmax() wrongly assumes that both have entries and
calls clock_fmax.at() for both and then throws std::out_of_range.

This patch:

- explicitly checks the has_a && has_b and else-case is then !has_a && !has_b case
- skips the "both missing" case and logs a warning instead

This fixes a crash I hit on ECP5 when a reset-like net and a derived FF clock
were treated as related clocks but had no computed Fmax.