### PR TITLE
Update README to add section for mistral (cyclonev) backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,19 @@ sudo make install
 
 Nexus support is currently experimental, and has only been tested with engineering sample silicon.
 
+### nextpnr-mistral
+
+For Cyclone V support, clone [Mistral](https://github.com/Ravenslofty/mistral/tree/nextpnr-latest) to `$HOME/mistral` or another location and pass this path as `-DMISTRAL_ROOT=$HOME/mistral` to CMake. Then build and install `nextpnr-mistral` using the following commands:
+
+```
+mkdir -p build && cd build
+cmake .. -DARCH=mistral -DMISTRAL_ROOT=$HOME/mistral
+make -j$(nproc)
+sudo make install
+```
+
+Cyclone V support is currently experimental and has limited testing. The backend is undergoing active API refactoring, and its structure, build requirements, and integration points may change between versions.
+
 ### nextpnr-generic
 
 The generic target allows running placement and routing for arbitrary custom architectures.


### PR DESCRIPTION
Adds a short, clearly marked section to README.md documenting how to build and use the experimental nextpnr-mistral backend. At the moment this backend exists in the codebase but is not mentioned alongside the other architectures, which has caused confusion for users and contributors trying to experiment with Cyclone V support.

The added section follows the established style of the other architecture entries and explains how to point nextpnr at a local Mistral source tree using the MISTRAL_ROOT CMake variable. It also notes the experimental status and ongoing API refactoring so expectations are clear.

This documentation should make it easier for new developers to build, test, and contribute to the Mistral backend, and it addresses confusion raised in the following issues:

nextpnr: #1604

mistral: Ravenslofty/mistral#16