### PR TITLE
Minor UX improvements to the generic example code

### DIFF
--- a/generic/examples/simple.py
+++ b/generic/examples/simple.py
@@ -3,6 +3,8 @@ from simple_config import *
 def is_io(x, y):
 	return x == 0 or x == X-1 or y == 0 or y == Y-1
 
+ctx.setLutK(K)
+
 for x in range(X):
 	for y in range(Y):
 		# Bel port wires

--- a/generic/examples/simple.sh
+++ b/generic/examples/simple.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -ex
+export PYTHONPATH=$(dirname $0)
 yosys -p "tcl ../synth/synth_generic.tcl 4 blinky.json" blinky.v
 ${NEXTPNR:-../../nextpnr-generic} --pre-pack simple.py --pre-place simple_timing.py --json blinky.json --post-route bitstream.py --write pnrblinky.json
 yosys -p "read_verilog -lib ../synth/prims.v; read_json pnrblinky.json; dump -o blinky.il; show -format png -prefix blinky"

--- a/generic/examples/simple.sh
+++ b/generic/examples/simple.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 export PYTHONPATH=$(dirname $0)
-yosys -p "tcl ../synth/synth_generic.tcl 4 blinky.json" blinky.v
+K=$(python3 -c "import simple_config; print(simple_config.K)")
+yosys -p "tcl ../synth/synth_generic.tcl $K blinky.json" blinky.v
 ${NEXTPNR:-../../nextpnr-generic} --pre-pack simple.py --pre-place simple_timing.py --json blinky.json --post-route bitstream.py --write pnrblinky.json
 yosys -p "read_verilog -lib ../synth/prims.v; read_json pnrblinky.json; dump -o blinky.il; show -format png -prefix blinky"

--- a/generic/examples/simtest.sh
+++ b/generic/examples/simtest.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -ex
+export PYTHONPATH=$(dirname $0)
 yosys -p "tcl ../synth/synth_generic.tcl 4 blinky.json" blinky.v
 ${NEXTPNR:-../../nextpnr-generic} --no-iobs --pre-pack simple.py --pre-place simple_timing.py --json blinky.json --post-route bitstream.py --write pnrblinky.json
 yosys -p "read_json pnrblinky.json; write_verilog -noattr -norename pnrblinky.v"

--- a/generic/examples/simtest.sh
+++ b/generic/examples/simtest.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -ex
 export PYTHONPATH=$(dirname $0)
-yosys -p "tcl ../synth/synth_generic.tcl 4 blinky.json" blinky.v
+K=$(python3 -c "import simple_config; print(simple_config.K)")
+yosys -p "tcl ../synth/synth_generic.tcl $K blinky.json" blinky.v
 ${NEXTPNR:-../../nextpnr-generic} --no-iobs --pre-pack simple.py --pre-place simple_timing.py --json blinky.json --post-route bitstream.py --write pnrblinky.json
 yosys -p "read_json pnrblinky.json; write_verilog -noattr -norename pnrblinky.v"
 iverilog -o blinky_simtest ../synth/prims.v blinky_tb.v pnrblinky.v


### PR DESCRIPTION


The primary thing here is adding the `ctx.setLutK` call. Without it, even changing
the relevant constants from 4 to 3 still results in 4-input LUTs being generated:

From `pnrblinky.v`:
```verilog
  GENERIC_SLICE #(
    .FF_USED(32'd0),
    .INIT(8'h88),
    .K(32'd4)
  ) \$abc$249$auto$blifparse.cc:536:parse_blif$261_LC  (
    .F(\$abc$249$auto$alumacc.cc:512:replace_alu$8.CO[5]_new ),
    .I({ \$auto$jsonparse.cc:552:json_import$8 , \$auto$jsonparse.cc:552:json_import$7 , leds[5], \$abc$249$auto$alumacc.cc:512:replace_alu$8.CO[4]_new  })
  );
```

or `pnrblinky.json`
```json
"$abc$249$auto$blifparse.cc:536:parse_blif$254_LC": {
  "hide_name": 1,
  "type": "GENERIC_SLICE",
  "parameters": {
    "FF_USED": "00000000000000000000000000000001",
    "INIT": "00010100",
    "K": "00000000000000000000000000000100"
  },
  "attributes": {
    "BEL_STRENGTH": "00000000000000000000000000000001",
    "NEXTPNR_BEL": "X6Y8_SLICE6",
    "module_not_derived": "00000000000000000000000000000001",
    "src": "/home/atx/git/nextpnr/generic/synth/cells_map.v:9.34-9.66"
  },
  "port_directions": {
    "Q": "output",
    "F": "output",
    "CLK": "input",
    "I": "input"
  },
  "connections": {
    "Q": [ 59 ],
    "F": [  ],
    "CLK": [ 23 ],
    "I": [ 25, 57, 59, 286337 ]
  }
},
```

As far as I can tell, this is purely cosmetic.  In the Verilog, the fourth input bit just gets connected to an undriven wire in the end.

On the other hand, increasing K to 5 results in a clean crash:

```
Info: Packing IOs..
Info: Packing LUT-FFs..
terminate called after throwing an instance of 'nextpnr_generic::assertion_failure'
  what():  Assertion failure: lut_k <= ctx->args.K (/home/atx/git/nextpnr/generic/cells.cc:65)
```

Both of these cases get fixed by the `setLutK` call.

The PYTHONPATH thing is up to debate I guess. Making the embedded interpreter include the cwd in sys.path is also an option, but I have no clue how stable is this API expected to be.