### PR TITLE
Remove Wasm exception handling workarounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,13 +108,6 @@ endif()
 
 if (WASI)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lwasi-emulated-mman")
-    add_definitions(
-        -DBOOST_EXCEPTION_DISABLE
-        -DBOOST_NO_EXCEPTIONS
-    )
-    if (NOT Threads_FOUND)
-        add_definitions(-DBOOST_NO_CXX11_HDR_MUTEX)
-    endif()
 endif()
 
 if (STATIC_BUILD)

--- a/common/kernel/command.cc
+++ b/common/kernel/command.cc
@@ -748,7 +748,7 @@ int CommandHandler::exec()
 {
     try {
         if (!parseOptions())
-            return -1;
+            return 125;
 
         if (executeBeforeContext())
             return 0;
@@ -764,7 +764,7 @@ int CommandHandler::exec()
         return rc;
     } catch (log_execution_error_exception) {
         printFooter();
-        return -1;
+        return 125;
     }
 }
 

--- a/common/kernel/nextpnr.cc
+++ b/common/kernel/nextpnr.cc
@@ -16,20 +16,3 @@
  *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  */
-
-#if defined(__wasm)
-#include <exception>
-#include <typeinfo>
-#include "log.h"
-
-extern "C" {
-// FIXME: WASI does not currently support exceptions.
-void *__cxa_allocate_exception(size_t thrown_size) throw() { return malloc(thrown_size); }
-bool __cxa_uncaught_exception() throw();
-void __cxa_throw(void *thrown_exception, struct std::type_info *tinfo, void (*dest)(void *)) { std::terminate(); }
-}
-
-namespace boost {
-void throw_exception(std::exception const &e) { NEXTPNR_NAMESPACE::log_error("boost::exception(): %s\n", e.what()); }
-} // namespace boost
-#endif


### PR DESCRIPTION
This is no longer required as very recent Wasm SDK and runtime properly supports exception handling. While this will break builds with older SDKs I don't think it's worth it adding a layer of conditional compilation over `__has_feature(cxx_exceptions)`.