### PR TITLE
gui: Fix crash when pass throws error

### DIFF
--- a/gui/application.cc
+++ b/gui/application.cc
@@ -147,12 +147,14 @@ Application::Application(int &argc, char **argv, bool noantialiasing) : QApplica
     std::set_terminate(do_error);
 }
 
+void Application::show_pass_error() { QMessageBox::critical(0, "Error", "Pass failed, see log for details!"); }
+
 bool Application::notify(QObject *receiver, QEvent *event)
 {
     try {
         return QApplication::notify(receiver, event);
     } catch (log_execution_error_exception) {
-        QMessageBox::critical(0, "Error", "Pass failed, see log for details!");
+        QMetaObject::invokeMethod(this, &Application::show_pass_error, Qt::QueuedConnection);
         return true;
     }
 }

--- a/gui/application.h
+++ b/gui/application.h
@@ -31,6 +31,8 @@ class Application : public QApplication
   public:
     Application(int &argc, char **argv, bool noantialiasing);
     bool notify(QObject *receiver, QEvent *event);
+  protected Q_SLOTS:
+    void show_pass_error();
 };
 
 NEXTPNR_NAMESPACE_END


### PR DESCRIPTION
Calling `QMessageBox` inside `Application::notify` isn't safe and causes a crash due to recursive repaints. Instead use the slots mechanism for this.