### PR TITLE
WASI: fix thread presence detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,11 +102,25 @@ else()
 endif()
 
 find_package(Threads)
-if (NOT Threads_FOUND)
+if (CMAKE_SYSTEM_NAME STREQUAL "WASI")
+    include(CheckCXXSourceCompiles)
+
+    # On WASI, pthreads are always available but pthread_create() always fails
+    # unless the pthread-enabled triple that defines `_REENTRANT` is used.
+    check_cxx_source_compiles([[
+    #if !defined(_REENTRANT)
+    #  error "No threads"
+    #endif
+    int main(void) { return 0; }
+    ]] HAVE_REENTRANT)
+    if (NOT HAVE_REENTRANT)
+        add_definitions(-DNPNR_DISABLE_THREADS)
+    endif()
+elseif (NOT Threads_FOUND)
     add_definitions(-DNPNR_DISABLE_THREADS)
 endif()
 
-if (WASI)
+if (CMAKE_SYSTEM_NAME STREQUAL "WASI")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lwasi-emulated-mman")
 endif()
 
@@ -379,7 +393,7 @@ function(add_nextpnr_architecture target)
     add_executable(nextpnr-${target} ${arg_MAIN_SOURCE})
     set_property(TARGET nextpnr-${target} PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
     set_property(TARGET nextpnr-${target} PROPERTY OUTPUT_NAME ${PROGRAM_PREFIX}nextpnr-${target})
-    if (WASI)
+    if (CMAKE_SYSTEM_NAME STREQUAL "WASI")
         # set(CMAKE_EXECUTABLE_SUFFIX) breaks CMake tests for some reason
         set_property(TARGET nextpnr-${target} PROPERTY SUFFIX ".wasm")
     endif()


### PR DESCRIPTION
I've also fixed a few outdated checks for the WASI system, as a part of a shift towards using upstream toolchain files from WASI SDK. I will also send follow-up PRs to all the individual projects with the same fix.