### PR TITLE
fix visual studio build

### DIFF
--- a/3rdparty/QtPropertyBrowser/src/CMakeLists.txt
+++ b/3rdparty/QtPropertyBrowser/src/CMakeLists.txt
@@ -39,7 +39,9 @@ add_library(${TARGET_NAME} STATIC
   ${_QRC_SRCS}
   )
 
-target_compile_options(${TARGET_NAME} PRIVATE -Wno-deprecated-declarations)
+if (!MSVC)
+  target_compile_options(${TARGET_NAME} PRIVATE -Wno-deprecated-declarations)
+endif()
 
 if (MSVC)
   target_compile_options(${TARGET_NAME} PRIVATE /wd4457 /wd4718)

--- a/3rdparty/QtPropertyBrowser/src/CMakeLists.txt
+++ b/3rdparty/QtPropertyBrowser/src/CMakeLists.txt
@@ -39,7 +39,7 @@ add_library(${TARGET_NAME} STATIC
   ${_QRC_SRCS}
   )
 
-if (!MSVC)
+if (NOT MSVC)
   target_compile_options(${TARGET_NAME} PRIVATE -Wno-deprecated-declarations)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ endif()
 cmake_minimum_required(VERSION 3.25)
 project(nextpnr CXX)
 
+if (MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+endif()
+
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 include(CheckCXXCompilerFlag)

--- a/common/kernel/command.cc
+++ b/common/kernel/command.cc
@@ -191,36 +191,21 @@ void init_share_dirname() { npnr_share_dirname = "/share/"; }
 void init_share_dirname()
 {
     std::string proc_self_path = proc_self_dirname();
-#if defined(_WIN32) && !defined(nextpnr_WIN32_UNIX_DIR)
-    std::string proc_share_path = proc_self_path + "share\\";
-    if (check_file_exists(proc_share_path, true)) {
-        npnr_share_dirname = proc_share_path;
-        return;
-    }
-    proc_share_path = proc_self_path + "..\\share\\" + "nextpnr\\";
-    if (check_file_exists(proc_share_path, true)) {
-        npnr_share_dirname = proc_share_path;
-        return;
-    }
-#else
-    std::string proc_share_path = proc_self_path + "share/";
-    if (check_file_exists(proc_share_path, true)) {
-        npnr_share_dirname = proc_share_path;
-        return;
-    }
-    proc_share_path = proc_self_path + "../share/" + "nextpnr/";
-    if (check_file_exists(proc_share_path, true)) {
-        npnr_share_dirname = proc_share_path;
-        return;
-    }
+
+    for (const std::string &proc_share_path : {
+        proc_self_path + "share/",
+        proc_self_path + "../share/nextpnr/",
+        proc_self_path + "../share/",
 #ifdef nextpnr_DATDIR
-    proc_share_path = nextpnr_DATDIR "/";
-    if (check_file_exists(proc_share_path, true)) {
-        npnr_share_dirname = proc_share_path;
-        return;
+          nextpnr_DATDIR "/",
+#endif
+        })
+    {
+        if (check_file_exists(proc_share_path, true)) {
+            npnr_share_dirname = proc_share_path;
+            return;
+        }
     }
-#endif
-#endif
 }
 #endif
 

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -59,6 +59,7 @@ target_include_directories(nextpnr-${target}-gui PRIVATE
     ${CMAKE_SOURCE_DIR}/3rdparty/QtPropertyBrowser/src
     ${CMAKE_SOURCE_DIR}/3rdparty/imgui
     ${CMAKE_SOURCE_DIR}/3rdparty/qtimgui
+    Boost::headers
 )
 
 if (Qt6_FOUND)
@@ -74,6 +75,7 @@ target_link_libraries(nextpnr-${target}-gui PRIVATE
     nextpnr_version
     QtPropertyBrowser
     pybind11::headers
+    ${Boost_LIBRARIES}
 )
 
 # Currently always the case when the GUI is built.

--- a/himbaechel/uarch/gatemate/pack_bram.cc
+++ b/himbaechel/uarch/gatemate/pack_bram.cc
@@ -88,26 +88,19 @@ uint8_t GateMatePacker::ram_clk_signal(CellInfo *cell, IdString port)
 
 int width_to_config(int width)
 {
-    switch (width) {
-    case 0:
-        return 0;
-    case 1:
-        return 1;
-    case 2:
-        return 2;
-    case 3 ... 5:
+    if (width < 3)
+        return width;
+    if (width < 6)
         return 3;
-    case 6 ... 10:
+    if (width < 11)
         return 4;
-    case 11 ... 20:
+    if (width < 21)
         return 5;
-    case 21 ... 40:
+    if (width < 41)
         return 6;
-    case 41 ... 80:
+    if (width < 81)
         return 7;
-    default:
-        log_error("Unsupported width '%d'.\n", width);
-    }
+    log_error("Unsupported width '%d'.\n", width);
 }
 
 static void rename_or_move(CellInfo *main, CellInfo *other, IdString port, IdString other_port)

--- a/himbaechel/uarch/gatemate/route_clock.cc
+++ b/himbaechel/uarch/gatemate/route_clock.cc
@@ -19,6 +19,7 @@
 
 #include <functional>
 #include <queue>
+#include <chrono>
 
 #include "gatemate.h"
 #include "log.h"


### PR DESCRIPTION
These changes were necessary to make nextpnr-himbaechel build with gui on windows using visual studio 2022/2026.

The only general change is the addition of proc_path + "../share" to the list of share search locations. This is the natural path where the share folder is located after build. Allowing visual studio builds to "just run" out of the box.

Note that windows does not require backslashes as folder separators. Therefore, I removed the win32 specific version.