### PR TITLE
gatemate: Fix GPIO output-enable inversion when CC_LUT1 drives T input

### DIFF
--- a/himbaechel/uarch/gatemate/pack_io.cc
+++ b/himbaechel/uarch/gatemate/pack_io.cc
@@ -602,8 +602,11 @@ void GateMatePacker::pack_io_sel()
         Loc root_loc = ctx->getBelLocation(ci.bel);
         for (int i = 0; i < 4; i++) {
             CellInfo *cpe = move_ram_o_fixed(&ci, ctx->idf("OUT%d", i + 1), root_loc).first;
-            if (cpe && is_inverted[i])
-                cpe->params[id_INIT_L10] = Property(LUT_INV_D0, 4);
+            if (cpe && is_inverted[i]) {
+                uint8_t existing = int_or_default(cpe->params, id_INIT_L10, 0);
+                uint8_t inverted = (existing ^ 0xF);
+                cpe->params[id_INIT_L10] = Property(inverted, 4);
+            }
         }
     }
     flush_cells();


### PR DESCRIPTION
In `pack_io_sel()`, the `is_inverted[2]` flag unconditionally overwrites `INIT_L10` with `LUT_INV_D0`, discarding any logic from an absorbed CC_LUT1 that drives the T (output-enable) port.

Fixes #1713.