### PR TITLE
Fix windows.h being included from within a namespace, which is UB.

### DIFF
--- a/gui/application.cc
+++ b/gui/application.cc
@@ -35,8 +35,6 @@
 #endif
 #endif
 
-NEXTPNR_NAMESPACE_BEGIN
-
 #ifdef _WIN32
 #define NOMINMAX
 #include <windows.h>
@@ -47,6 +45,8 @@ BOOL WINAPI WinHandler(DWORD dwCtrlType)
     return TRUE;
 }
 #endif
+
+NEXTPNR_NAMESPACE_BEGIN
 
 namespace {
 #ifdef __linux__


### PR DESCRIPTION
While trying to compile `nextpnr-ice40` for the first time in a while, I got the following error:

```sh
[68/100] Building CXX object ice40/gui/CMakeFiles/nextpnr-ice40-gui.dir/application.cc.obj
FAILED: [code=1] ice40/gui/CMakeFiles/nextpnr-ice40-gui.dir/application.cc.obj
sccache C:\msys64\mingw64\bin\c++.exe -DARCHNAME=ice40 -DARCH_ICE40 -DBOOST_ATOMIC_NO_LIB -DBOOST_ATOMIC_STATIC_LINK -DBOOST_CHRONO_NO_
LIB -DBOOST_CHRONO_STATIC_LINK -DBOOST_CONTAINER_NO_LIB -DBOOST_CONTAINER_STATIC_LINK -DBOOST_DATE_TIME_NO_LIB -DBOOST_DATE_TIME_STATIC
_LINK -DBOOST_IOSTREAMS_NO_LIB -DBOOST_IOSTREAMS_STATIC_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_PROGRAM_OPTIONS_STATIC_LINK -DBOOST
_RANDOM_NO_LIB -DBOOST_RANDOM_STATIC_LINK -DBOOST_THREAD_NO_LIB -DBOOST_THREAD_STATIC_LINK -DBOOST_THREAD_USE_LIB -DMINGW_HAS_SECURE_AP
I=1 -DNEXTPNR_NAMESPACE=nextpnr_ice40 -DNO_RUST -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NO_DEBUG -DQT_NO_KEYWORDS -DQT_OPENGLWIDGETS_LIB -DQT_O
PENGL_LIB -DQT_WIDGETS_LIB -DWIN32 -DWIN64 -DWINVER=0x0A00 -D_ENABLE_EXTENDED_ALIGNED_STORAGE -D_WIN32_WINNT=0x0A00 -D_WIN64 -IC:/msys6
4/home/William/Projects/FPGA/nextpnr/build-ice40/ice40/gui -IC:/msys64/home/William/Projects/FPGA/nextpnr/gui -IC:/msys64/home/William/
Projects/FPGA/nextpnr/build-ice40/ice40/gui/nextpnr-ice40-gui_autogen/include -IC:/msys64/mingw64/include/python3.14 -IC:/msys64/home/W
illiam/Projects/FPGA/nextpnr/gui/ice40 -IC:/msys64/home/William/Projects/FPGA/nextpnr/frontend -IC:/msys64/home/William/Projects/FPGA/n
extpnr/json -IC:/msys64/home/William/Projects/FPGA/nextpnr/3rdparty/QtPropertyBrowser/src -IC:/msys64/home/William/Projects/FPGA/nextpn
r/3rdparty/imgui -IC:/msys64/home/William/Projects/FPGA/nextpnr/3rdparty/qtimgui -IC:/msys64/home/William/Projects/FPGA/nextpnr/gui/Boo
st::headers -IC:/msys64/home/William/Projects/FPGA/nextpnr/gui/../3rdparty/python-console -IC:/msys64/home/William/Projects/FPGA/nextpn
r/gui/../3rdparty/python-console/modified -IC:/msys64/home/William/Projects/FPGA/nextpnr/common/kernel -IC:/msys64/home/William/Project
s/FPGA/nextpnr/ice40 -IC:/msys64/home/William/Projects/FPGA/nextpnr/build-ice40/common -isystem C:/msys64/mingw64/include/qt6/QtWidgets
 -isystem C:/msys64/mingw64/include/qt6 -isystem C:/msys64/mingw64/include/qt6/QtCore -isystem C:/msys64/mingw64/share/qt6/mkspecs/win3
2-g++ -isystem C:/msys64/mingw64/include/qt6/QtGui -isystem C:/msys64/mingw64/include/qt6/QtOpenGL -isystem C:/msys64/mingw64/include/q
t6/QtOpenGLWidgets -isystem C:/msys64/home/William/Projects/FPGA/nextpnr/3rdparty/pybind11/include -Wall -Wextra -Wno-unused-parameter
-Wno-missing-field-initializers -Wno-array-bounds -Wno-format-truncation -fPIC -O3 -g -pipe -std=gnu++17 -MD -MT ice40/gui/CMakeFiles/n
extpnr-ice40-gui.dir/application.cc.obj -MF ice40\gui\CMakeFiles\nextpnr-ice40-gui.dir\application.cc.obj.d -o ice40/gui/CMakeFiles/nex
tpnr-ice40-gui.dir/application.cc.obj -c C:/msys64/home/William/Projects/FPGA/nextpnr/gui/application.cc
C:/msys64/home/William/Projects/FPGA/nextpnr/gui/application.cc:27:9: warning: 'NOMINMAX' redefined
   27 | #define NOMINMAX
      |         ^~~~~~~~
In file included from C:/msys64/mingw64/include/c++/16.1.0/x86_64-w64-mingw32/bits/c++config.h:733,
                 from C:/msys64/mingw64/include/c++/16.1.0/type_traits:40,
                 from C:/msys64/mingw64/include/qt6/QtCore/qglobal.h:13,
                 from C:/msys64/mingw64/include/qt6/QtGui/qtguiglobal.h:7,
                 from C:/msys64/mingw64/include/qt6/QtWidgets/qtwidgetsglobal.h:8,
                 from C:/msys64/mingw64/include/qt6/QtWidgets/qapplication.h:8,
                 from C:/msys64/mingw64/include/qt6/QtWidgets/QApplication:1,
                 from C:/msys64/home/William/Projects/FPGA/nextpnr/gui/application.h:24,
                 from C:/msys64/home/William/Projects/FPGA/nextpnr/gui/application.cc:22:
C:/msys64/mingw64/include/c++/16.1.0/x86_64-w64-mingw32/bits/os_defines.h:45:9: note: this is the location of the previous definition
   45 | #define NOMINMAX 1
      |         ^~~~~~~~
In file included from C:/msys64/mingw64/include/windows.h:70,
                 from C:/msys64/home/William/Projects/FPGA/nextpnr/gui/application.cc:28:
C:/msys64/mingw64/include/winbase.h: In function 'unsigned int nextpnr_ice40::_InterlockedIncrement(volatile unsigned int*)':
C:/msys64/mingw64/include/winbase.h:3539:45: error: invalid conversion from 'volatile long int*' to 'volatile unsigned int*' [-fpermissive]
 3539 |     return (unsigned) InterlockedIncrement ((volatile __LONG32 *) Addend);
      |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                             |
      |                                             volatile long int*
C:/msys64/mingw64/include/winbase.h:3538:65: note: initializing argument 1 of 'unsigned int nextpnr_ice40::_InterlockedIncrement(volatile unsigned int*)'
 3538 |   FORCEINLINE unsigned InterlockedIncrement (unsigned volatile *Addend) {
      |                                              ~~~~~~~~~~~~~~~~~~~^~~~~~
C:/msys64/mingw64/include/winbase.h: In function 'long unsigned int nextpnr_ice40::_InterlockedIncrement(volatile long unsigned int*)':

C:/msys64/mingw64/include/winbase.h:3544:53: error: no matching function for call to '_InterlockedIncrement(volatile long int*)'
 3544 |     return (unsigned __LONG32) InterlockedIncrement ((volatile __LONG32 *) Addend);
      |                                                     ^
  • there are 2 candidates
    • candidate 1: 'unsigned int nextpnr_ice40::_InterlockedIncrement(volatile unsigned int*)' (near match)
      C:/msys64/mingw64/include/winbase.h:3538:24:
       3538 |   FORCEINLINE unsigned InterlockedIncrement (unsigned volatile *Addend) {
            |                        ^~~~~~~~~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
      • error: invalid conversion from 'volatile long int*' to 'volatile unsigned int*' [-fpermissive]
        C:/msys64/mingw64/include/winbase.h:3544:54:
         3544 |     return (unsigned __LONG32) InterlockedIncrement ((volatile __LONG32 *) Addend);
              |                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
              |                                                      |
              |                                                      volatile long int*
    • candidate 2: 'long unsigned int nextpnr_ice40::_InterlockedIncrement(volatile long unsigned int*)' (near match)
      C:/msys64/mingw64/include/winbase.h:3542:29:
       3542 |   FORCEINLINE unsigned long InterlockedIncrement (unsigned long volatile *Addend) {
            |                             ^~~~~~~~~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
      • error: invalid conversion from 'volatile long int*' to 'volatile long unsigned int*' [-fpermissive]
        C:/msys64/mingw64/include/winbase.h:3544:54:
         3544 |     return (unsigned __LONG32) InterlockedIncrement ((volatile __LONG32 *) Addend);
              |                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
              |                                                      |
              |                                                      volatile long int*
C:/msys64/mingw64/include/winbase.h: In function 'unsigned int nextpnr_ice40::_InterlockedDecrement(volatile unsigned int*)':
C:/msys64/mingw64/include/winbase.h:3557:45: error: invalid conversion from 'volatile long int*' to 'volatile unsigned int*' [-fpermissive]
 3557 |     return (unsigned) InterlockedDecrement ((volatile __LONG32 *) Addend);
      |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                             |
      |                                             volatile long int*
C:/msys64/mingw64/include/winbase.h:3556:65: note: initializing argument 1 of 'unsigned int nextpnr_ice40::_InterlockedDecrement(volatile unsigned int*)'
 3556 |   FORCEINLINE unsigned InterlockedDecrement (unsigned volatile *Addend) {
      |                                              ~~~~~~~~~~~~~~~~~~~^~~~~~
C:/msys64/mingw64/include/winbase.h: In function 'long unsigned int nextpnr_ice40::_InterlockedDecrement(volatile long unsigned int*)':

C:/msys64/mingw64/include/winbase.h:3562:53: error: no matching function for call to '_InterlockedDecrement(volatile long int*)'
 3562 |     return (unsigned __LONG32) InterlockedDecrement ((volatile __LONG32 *) Addend);
      |                                                     ^
  • there are 2 candidates
    • candidate 1: 'unsigned int nextpnr_ice40::_InterlockedDecrement(volatile unsigned int*)' (near match)
      C:/msys64/mingw64/include/winbase.h:3556:24:
       3556 |   FORCEINLINE unsigned InterlockedDecrement (unsigned volatile *Addend) {
            |                        ^~~~~~~~~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
      • error: invalid conversion from 'volatile long int*' to 'volatile unsigned int*' [-fpermissive]
        C:/msys64/mingw64/include/winbase.h:3562:54:
         3562 |     return (unsigned __LONG32) InterlockedDecrement ((volatile __LONG32 *) Addend);
              |                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
              |                                                      |
              |                                                      volatile long int*
    • candidate 2: 'long unsigned int nextpnr_ice40::_InterlockedDecrement(volatile long unsigned int*)' (near match)
      C:/msys64/mingw64/include/winbase.h:3560:29:
       3560 |   FORCEINLINE unsigned long InterlockedDecrement (unsigned long volatile *Addend) {
            |                             ^~~~~~~~~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
      • error: invalid conversion from 'volatile long int*' to 'volatile long unsigned int*' [-fpermissive]
        C:/msys64/mingw64/include/winbase.h:3562:54:
         3562 |     return (unsigned __LONG32) InterlockedDecrement ((volatile __LONG32 *) Addend);
              |                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
              |                                                      |
              |                                                      volatile long int*
C:/msys64/mingw64/include/winbase.h: In function 'unsigned int nextpnr_ice40::_InterlockedExchange(volatile unsigned int*, unsigned int)':
C:/msys64/mingw64/include/winbase.h:3575:44: error: invalid conversion from 'volatile long int*' to 'volatile unsigned int*' [-fpermissive]
 3575 |     return (unsigned) InterlockedExchange ((volatile __LONG32 *) Target,(__LONG32) Value);
      |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                            |
      |                                            volatile long int*
C:/msys64/mingw64/include/winbase.h:3574:64: note: initializing argument 1 of 'unsigned int nextpnr_ice40::_InterlockedExchange(volatile unsigned int*, unsigned int)'
 3574 |   FORCEINLINE unsigned InterlockedExchange (unsigned volatile *Target, unsigned Value) {
      |                                             ~~~~~~~~~~~~~~~~~~~^~~~~~
C:/msys64/mingw64/include/winbase.h: In function 'long unsigned int nextpnr_ice40::_InterlockedExchange(volatile long unsigned int*, long unsigned int)':
C:/msys64/mingw64/include/winbase.h:3580:52: error: no matching function for call to '_InterlockedExchange(volatile long int*, long int)'
 3580 |     return (unsigned __LONG32) InterlockedExchange ((volatile __LONG32 *) Target,(__LONG32) Value);
      |                                                    ^
  • there are 2 candidates
    • candidate 1: 'unsigned int nextpnr_ice40::_InterlockedExchange(volatile unsigned int*, unsigned int)' (near match)
      C:/msys64/mingw64/include/winbase.h:3574:24:
       3574 |   FORCEINLINE unsigned InterlockedExchange (unsigned volatile *Target, unsigned Value) {
            |                        ^~~~~~~~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
      • error: invalid conversion from 'volatile long int*' to 'volatile unsigned int*' [-fpermissive]
        C:/msys64/mingw64/include/winbase.h:3580:53:
         3580 |     return (unsigned __LONG32) InterlockedExchange ((volatile __LONG32 *) Target,(__LONG32) Value);
              |                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
              |                                                     |
              |                                                     volatile long int*
    • candidate 2: 'long unsigned int nextpnr_ice40::_InterlockedExchange(volatile long unsigned int*, long unsigned int)' (near match)

      C:/msys64/mingw64/include/winbase.h:3578:29:
       3578 |   FORCEINLINE unsigned long InterlockedExchange (unsigned long volatile *Target, unsigned long Value) {
            |                             ^~~~~~~~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
      • error: invalid conversion from 'volatile long int*' to 'volatile long unsigned int*' [-fpermissive]
        C:/msys64/mingw64/include/winbase.h:3580:53:
         3580 |     return (unsigned __LONG32) InterlockedExchange ((volatile __LONG32 *) Target,(__LONG32) Value);
              |                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
              |                                                     |
              |                                                     volatile long int*
C:/msys64/mingw64/include/winbase.h: In function 'unsigned int nextpnr_ice40::_InterlockedExchangeAdd(volatile unsigned int*, unsigned int)':
C:/msys64/mingw64/include/winbase.h:3593:47: error: invalid conversion from 'volatile long int*' to 'volatile unsigned int*' [-fpermissive]
 3593 |     return (unsigned) InterlockedExchangeAdd ((volatile __LONG32 *) Addend,(__LONG32) Value);
      |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                               |
      |                                               volatile long int*
C:/msys64/mingw64/include/winbase.h:3592:67: note: initializing argument 1 of 'unsigned int nextpnr_ice40::_InterlockedExchangeAdd(volatile unsigned int*, unsigned int)'
 3592 |   FORCEINLINE unsigned InterlockedExchangeAdd (unsigned volatile *Addend, unsigned Value) {
      |                                                ~~~~~~~~~~~~~~~~~~~^~~~~~
C:/msys64/mingw64/include/winbase.h: In function 'unsigned int nextpnr_ice40::InterlockedExchangeSubtract(volatile unsigned int*, unsigned int)':
C:/msys64/mingw64/include/winbase.h:3597:47: error: invalid conversion from 'volatile long int*' to 'volatile unsigned int*' [-fpermissive]
 3597 |     return (unsigned) InterlockedExchangeAdd ((volatile __LONG32 *) Addend,- (__LONG32) Value);
      |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                               |
      |                                               volatile long int*
C:/msys64/mingw64/include/winbase.h:3592:67: note: initializing argument 1 of 'unsigned int nextpnr_ice40::_InterlockedExchangeAdd(volatile unsigned int*, unsigned int)'
 3592 |   FORCEINLINE unsigned InterlockedExchangeAdd (unsigned volatile *Addend, unsigned Value) {
      |                                                ~~~~~~~~~~~~~~~~~~~^~~~~~
C:/msys64/mingw64/include/winbase.h: In function 'long unsigned int nextpnr_ice40::_InterlockedExchangeAdd(volatile long unsigned int*, long unsigned int)':
C:/msys64/mingw64/include/winbase.h:3602:55: error: no matching function for call to '_InterlockedExchangeAdd(volatile long int*, long int)'
 3602 |     return (unsigned __LONG32) InterlockedExchangeAdd ((volatile __LONG32 *) Addend,(__LONG32) Value);
      |                                                       ^
  • there are 2 candidates
    • candidate 1: 'unsigned int nextpnr_ice40::_InterlockedExchangeAdd(volatile unsigned int*, unsigned int)' (near match)
      C:/msys64/mingw64/include/winbase.h:3592:24:
       3592 |   FORCEINLINE unsigned InterlockedExchangeAdd (unsigned volatile *Addend, unsigned Value) {
            |                        ^~~~~~~~~~~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
      • error: invalid conversion from 'volatile long int*' to 'volatile unsigned int*' [-fpermissive]
        C:/msys64/mingw64/include/winbase.h:3602:56:
         3602 |     return (unsigned __LONG32) InterlockedExchangeAdd ((volatile __LONG32 *) Addend,(__LONG32) Value);
              |                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
              |                                                        |
              |                                                        volatile long int*
    • candidate 2: 'long unsigned int nextpnr_ice40::_InterlockedExchangeAdd(volatile long unsigned int*, long unsigned int)' (near match)
      C:/msys64/mingw64/include/winbase.h:3600:29:
       3600 |   FORCEINLINE unsigned long InterlockedExchangeAdd (unsigned long volatile *Addend, unsigned long Value) {
            |                             ^~~~~~~~~~~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
      • error: invalid conversion from 'volatile long int*' to 'volatile long unsigned int*' [-fpermissive]
        C:/msys64/mingw64/include/winbase.h:3602:56:
         3602 |     return (unsigned __LONG32) InterlockedExchangeAdd ((volatile __LONG32 *) Addend,(__LONG32) Value);
              |                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
              |                                                        |
              |                                                        volatile long int*
C:/msys64/mingw64/include/winbase.h: In function 'long unsigned int nextpnr_ice40::InterlockedExchangeSubtract(volatile long unsigned int*, long unsigned int)':
C:/msys64/mingw64/include/winbase.h:3610:55: error: no matching function for call to '_InterlockedExchangeAdd(volatile long int*, long int)'
 3610 |     return (unsigned __LONG32) InterlockedExchangeAdd ((volatile __LONG32 *) Addend,- (__LONG32) Value);
      |                                                       ^
  • there are 2 candidates
    • candidate 1: 'unsigned int nextpnr_ice40::_InterlockedExchangeAdd(volatile unsigned int*, unsigned int)' (near match)
      C:/msys64/mingw64/include/winbase.h:3592:24:
       3592 |   FORCEINLINE unsigned InterlockedExchangeAdd (unsigned volatile *Addend, unsigned Value) {
            |                        ^~~~~~~~~~~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
      • error: invalid conversion from 'volatile long int*' to 'volatile unsigned int*' [-fpermissive]
        C:/msys64/mingw64/include/winbase.h:3610:56:
         3610 |     return (unsigned __LONG32) InterlockedExchangeAdd ((volatile __LONG32 *) Addend,- (__LONG32) Value);
              |                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
              |                                                        |
              |                                                        volatile long int*
    • candidate 2: 'long unsigned int nextpnr_ice40::_InterlockedExchangeAdd(volatile long unsigned int*, long unsigned int)' (near match)
      C:/msys64/mingw64/include/winbase.h:3600:29:
       3600 |   FORCEINLINE unsigned long InterlockedExchangeAdd (unsigned long volatile *Addend, unsigned long Value) {
            |                             ^~~~~~~~~~~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
      • error: invalid conversion from 'volatile long int*' to 'volatile long unsigned int*' [-fpermissive]
        C:/msys64/mingw64/include/winbase.h:3610:56:
         3610 |     return (unsigned __LONG32) InterlockedExchangeAdd ((volatile __LONG32 *) Addend,- (__LONG32) Value);
              |                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
              |                                                        |
              |                                                        volatile long int*
C:/msys64/mingw64/include/winbase.h: In function 'unsigned int nextpnr_ice40::_InterlockedCompareExchange(volatile unsigned int*, unsigned int, unsigned int)':
C:/msys64/mingw64/include/winbase.h:3627:51: error: invalid conversion from 'volatile long int*' to 'volatile unsigned int*' [-fpermissive]
 3627 |     return (unsigned) InterlockedCompareExchange ((volatile __LONG32 *) Destination,(__LONG32) Exchange,(__LONG32) Comperand);
      |                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                   |
      |                                                   volatile long int*
C:/msys64/mingw64/include/winbase.h:3626:71: note: initializing argument 1 of 'unsigned int nextpnr_ice40::_InterlockedCompareExchange(volatile unsigned int*, unsigned int, unsigned int)'
 3626 |   FORCEINLINE unsigned InterlockedCompareExchange (unsigned volatile *Destination, unsigned Exchange, unsigned Comperand) {
      |                                                    ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
C:/msys64/mingw64/include/winbase.h: In function 'long unsigned int nextpnr_ice40::_InterlockedCompareExchange(volatile long unsigned int*, long unsigned int, long unsigned int)':
C:/msys64/mingw64/include/winbase.h:3632:59: error: no matching function for call to '_InterlockedCompareExchange(volatile long int*, long int, long int)'
 3632 |     return (unsigned __LONG32) InterlockedCompareExchange ((volatile __LONG32 *) Destination,(__LONG32) Exchange,(__LONG32) Comperand);
      |                                                           ^
  • there are 2 candidates
    • candidate 1: 'unsigned int nextpnr_ice40::_InterlockedCompareExchange(volatile unsigned int*, unsigned int, unsigned int)' (near match)
      C:/msys64/mingw64/include/winbase.h:3626:24:
       3626 |   FORCEINLINE unsigned InterlockedCompareExchange (unsigned volatile *Destination, unsigned Exchange, unsigned Comperand) {
            |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
      • error: invalid conversion from 'volatile long int*' to 'volatile unsigned int*' [-fpermissive]
        C:/msys64/mingw64/include/winbase.h:3632:60:
         3632 |     return (unsigned __LONG32) InterlockedCompareExchange ((volatile __LONG32 *) Destination,(__LONG32) Exchange,(__LONG32) Comperand);
              |                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
              |                                                            |
              |                                                            volatile long int*
    • candidate 2: 'long unsigned int nextpnr_ice40::_InterlockedCompareExchange(volatile long unsigned int*, long unsigned int, long unsigned int)' (near match)
      C:/msys64/mingw64/include/winbase.h:3630:29:
       3630 |   FORCEINLINE unsigned long InterlockedCompareExchange (unsigned long volatile *Destination, unsigned long Exchange, unsigned long Comperand) {
            |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
      • error: invalid conversion from 'volatile long int*' to 'volatile long unsigned int*' [-fpermissive]
        C:/msys64/mingw64/include/winbase.h:3632:60:
         3632 |     return (unsigned __LONG32) InterlockedCompareExchange ((volatile __LONG32 *) Destination,(__LONG32) Exchange,(__LONG32) Comperand);
              |                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
              |                                                            |
              |                                                            volatile long int*
```

After mulling over this for longer than I'd like, I learned that including a header within a namespace [is UB](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105707). This PR moves the inclusion of `windows.h` to before the `nextpnr` namespace, which fixes the compilation error I'm seeing.

```
William@DESKTOP-3H1DSBV MINGW64 ~/Projects/FPGA/nextpnr/build-ice40
$ gcc --version
gcc.exe (Rev5, Built by MSYS2 project) 16.1.0
Copyright (C) 2026 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


William@DESKTOP-3H1DSBV MINGW64 ~/Projects/FPGA/nextpnr/build-ice40
$ uname -a
MINGW64_NT-10.0-19045 DESKTOP-3H1DSBV 3.6.9-aa532e7b.x86_64 2026-04-21 17:18 UTC x86_64 Msys
```