### PR TITLE
Fix Qt6 Compatibility on Windows

### DIFF
--- a/common/kernel/command.cc
+++ b/common/kernel/command.cc
@@ -138,10 +138,10 @@ std::string proc_self_dirname()
     WCHAR longpath[MAX_PATH + 1];
     TCHAR shortpath[MAX_PATH + 1];
 #endif
-    if (!GetModuleFileName(0, longpath, MAX_PATH + 1))
-        log_error("GetModuleFileName() failed.\n");
-    if (!GetShortPathName(longpath, shortpath, MAX_PATH + 1))
-        log_error("GetShortPathName() failed.\n");
+    if (!GetModuleFileNameA(0, longpath, MAX_PATH + 1))
+        log_error("GetModuleFileNameA() failed.\n");
+    if (!GetShortPathNameA(longpath, shortpath, MAX_PATH + 1))
+        log_error("GetShortPathNameA() failed.\n");
     while (shortpath[i] != 0)
         i++;
     while (i > 0 && shortpath[i - 1] != '/' && shortpath[i - 1] != '\\')


### PR DESCRIPTION
_Please merge #1726 before this PR._

Qt6 [changed](https://doc.qt.io/qt-6/cmake-qt5-and-qt6-compatibility.html#unicode-support-in-windows) compiler flags for Windows, such that `UNICODE` and `_UNICODE` are now defined by default. These [changes](https://learn.microsoft.com/en-us/windows/win32/learnwin32/working-with-strings) the macro expansion of certain Windows API functions so that they're UTF-16/`wchar`- incompatible with `char` or C strings. I've found one spot in `nextpnr` where this matters:

```
[7/7] Building CXX object ice40/CMakeFiles/nextpnr-ice40.dir/__/common/kernel/command.cc.obj
FAILED: [code=1] ice40/CMakeFiles/nextpnr-ice40.dir/__/common/kernel/command.cc.obj 
sccache C:\msys64\mingw64\bin\c++.exe -DARCHNAME=ice40 -DARCH_ICE40 -DBOOST_ATOMIC_NO_LIB -DBOOST_ATOMIC_STATIC_LINK -DBOOST_CHRONO_NO_LIB -DBOOST_CHRONO_STATIC_LINK -DBOOST_CONTAINER_NO_LIB -DBOOST_CONTAINER_STATIC_LINK -DBOOST_DATE_TIME_NO_LIB -DBOOST_DATE_TIME_STATIC_LINK -DBOOST_IOSTREAMS_NO_LIB -DBOOST_IOSTREAMS_STATIC_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_PROGRAM_OPTIONS_STATIC_LINK -DBOOST_RANDOM_NO_LIB -DBOOST_RANDOM_STATIC_LINK -DBOOST_THREAD_NO_LIB -DBOOST_THREAD_STATIC_LINK -DBOOST_THREAD_USE_LIB -DMINGW_HAS_SECURE_API=1 -DNEXTPNR_NAMESPACE=nextpnr_ice40 -DNO_RUST -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NO_DEBUG -DQT_NO_KEYWORDS -DQT_WIDGETS_LIB -DUNICODE -DWIN32 -DWIN64 -DWINVER=0x0A00 -D_ENABLE_EXTENDED_ALIGNED_STORAGE -D_UNICODE -D_WIN32_WINNT=0x0A00 -D_WIN64 -Dnextpnr_ice40_EXPORTS -IC:/msys64/mingw64/include/python3.14 -IC:/msys64/home/William/Projects/FPGA/nextpnr/common/kernel -IC:/msys64/home/William/Projects/FPGA/nextpnr/ice40 -IC:/msys64/home/William/Projects/FPGA/nextpnr/common/kernel/. -IC:/msys64/home/William/Projects/FPGA/nextpnr/build-ice40/common -IC:/msys64/home/William/Projects/FPGA/nextpnr/frontend/. -IC:/msys64/home/William/Projects/FPGA/nextpnr/json/. -IC:/msys64/home/William/Projects/FPGA/nextpnr/rust/. -IC:/msys64/home/William/Projects/FPGA/nextpnr/3rdparty/json11/. -IC:/msys64/home/William/Projects/FPGA/nextpnr/common/place/. -IC:/msys64/home/William/Projects/FPGA/nextpnr/common/route/. -IC:/msys64/home/William/Projects/FPGA/nextpnr/3rdparty/oourafft/. -IC:/msys64/home/William/Projects/FPGA/nextpnr/gui/ice40 -IC:/msys64/home/William/Projects/FPGA/nextpnr/gui -isystem C:/msys64/home/William/Projects/FPGA/nextpnr/3rdparty/pybind11/include -isystem C:/msys64/mingw64/include/eigen3 -isystem C:/msys64/mingw64/include/qt6/QtWidgets -isystem C:/msys64/mingw64/include/qt6 -isystem C:/msys64/mingw64/include/qt6/QtCore -isystem C:/msys64/mingw64/share/qt6/mkspecs/win32-g++ -isystem C:/msys64/mingw64/include/qt6/QtGui -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-array-bounds -Wno-format-truncation -fPIC -O3 -g -pipe -std=gnu++17 -MD -MT ice40/CMakeFiles/nextpnr-ice40.dir/__/common/kernel/command.cc.obj -MF ice40\CMakeFiles\nextpnr-ice40.dir\__\common\kernel\command.cc.obj.d -o ice40/CMakeFiles/nextpnr-ice40.dir/__/common/kernel/command.cc.obj -c C:/msys64/home/William/Projects/FPGA/nextpnr/common/kernel/command.cc
C:/msys64/home/William/Projects/FPGA/nextpnr/common/kernel/command.cc:50:9: warning: 'NOMINMAX' redefined
   50 | #define NOMINMAX
      |         ^~~~~~~~
In file included from C:/msys64/mingw64/include/c++/16.1.0/x86_64-w64-mingw32/bits/c++config.h:733,
                 from C:/msys64/mingw64/include/c++/16.1.0/type_traits:40,
                 from C:/msys64/mingw64/include/qt6/QtCore/qglobal.h:13,
                 from C:/msys64/mingw64/include/qt6/QtGui/qtguiglobal.h:7,
                 from C:/msys64/mingw64/include/qt6/QtWidgets/qtwidgetsglobal.h:8,
                 from C:/msys64/mingw64/include/qt6/QtWidgets/qapplication.h:8,
                 from C:/msys64/mingw64/include/qt6/QtWidgets/QApplication:1,
                 from C:/msys64/home/William/Projects/FPGA/nextpnr/gui/application.h:24,
                 from C:/msys64/home/William/Projects/FPGA/nextpnr/common/kernel/command.cc:22:
C:/msys64/mingw64/include/c++/16.1.0/x86_64-w64-mingw32/bits/os_defines.h:45:9: note: this is the location of the previous definition
   45 | #define NOMINMAX 1
      |         ^~~~~~~~
C:/msys64/home/William/Projects/FPGA/nextpnr/common/kernel/command.cc: In function 'std::string nextpnr_ice40::proc_self_dirname()':
C:/msys64/home/William/Projects/FPGA/nextpnr/common/kernel/command.cc:141:31: error: cannot convert 'char*' to 'LPWSTR' {aka 'wchar_t*'}
  141 |     if (!GetModuleFileName(0, longpath, MAX_PATH + 1))
      |                               ^~~~~~~~
      |                               |
      |                               char*
In file included from C:/msys64/mingw64/include/winbase.h:24,
                 from C:/msys64/mingw64/include/windows.h:70,
                 from C:/msys64/home/William/Projects/FPGA/nextpnr/common/kernel/command.cc:51:
C:/msys64/mingw64/include/libloaderapi.h:114:71: note: initializing argument 2 of 'DWORD GetModuleFileNameW(HMODULE, LPWSTR, DWORD)'
  114 |   WINBASEAPI DWORD WINAPI GetModuleFileNameW (HMODULE hModule, LPWSTR lpFilename, DWORD nSize);
      |                                                                ~~~~~~~^~~~~~~~~~
C:/msys64/home/William/Projects/FPGA/nextpnr/common/kernel/command.cc:143:27: error: cannot convert 'char*' to 'LPCWSTR' {aka 'const wchar_t*'}
  143 |     if (!GetShortPathName(longpath, shortpath, MAX_PATH + 1))
      |                           ^~~~~~~~
      |                           |
      |                           char*
In file included from C:/msys64/mingw64/include/winbase.h:18:
C:/msys64/mingw64/include/fileapi.h:104:54: note: initializing argument 1 of 'DWORD GetShortPathNameW(LPCWSTR, LPWSTR, DWORD)'
  104 |   WINBASEAPI DWORD WINAPI GetShortPathNameW (LPCWSTR lpszLongPath, LPWSTR lpszShortPath, DWORD cchBuffer);
      |                                              ~~~~~~~~^~~~~~~~~~~~
ninja: build stopped: subcommand failed.
```

This PR fixes the compiler error by suppressing the suppressing Qt's Unicode defines, so that the current `char`-based strings can be sent to the Windows API.

Now, I've noticed that there is [dead code](https://github.com/YosysHQ/nextpnr/blob/48c70978b3074dab0d534ce20aed442744e68438/common/kernel/command.cc#L134-L140) to use `wchar` strings in `proc_self_dirname()`. These should work fine with the `UNICODE` and `_UNICODE` defines. However, I figured that code is dead for a reason, so I just made the change that retains the current behavior. I'm open to switching to UTF-16, however.