### PR TITLE
gatemate: add default values to vopt descriptions

### DIFF
--- a/himbaechel/uarch/gatemate/gatemate.cc
+++ b/himbaechel/uarch/gatemate/gatemate.cc
@@ -40,10 +40,10 @@ po::options_description GateMateImpl::getUArchOptions()
     specific.add_options()("out", po::value<std::string>(), "textual configuration bitstream output file");
     specific.add_options()("ccf", po::value<std::string>(), "name of constraints file");
     specific.add_options()("allow-unconstrained", "allow unconstrained IOs");
-    specific.add_options()("fpga_mode", po::value<std::string>(), "performance mode (1:lowpower, 2:economy, 3:speed)");
-    specific.add_options()("time_mode", po::value<std::string>(), "timing mode (1:best, 2:typical, 3:worst)");
+    specific.add_options()("fpga_mode", po::value<std::string>(), "performance mode (1:lowpower, 2:economy, 3:speed (default))");
+    specific.add_options()("time_mode", po::value<std::string>(), "timing mode (1:best, 2:typical, 3:worst (default))");
     specific.add_options()("strategy", po::value<std::string>(),
-                           "multi-die clock placement strategy (mirror, full or clk1)");
+                           "multi-die clock placement strategy (mirror (default), full or clk1)");
     specific.add_options()("force_die", po::value<std::string>(), "force specific die (example 1A,1B...)");
     specific.add_options()("clk-cp", "use CP lines for CLK and EN");
     specific.add_options()("no-cpe-cp", "do not use CP lines pass through CPE");


### PR DESCRIPTION
This add default values in the `nextpnr-himbaechel --device CCGM1A1 --vopt help` help of the parameter. It is based on my review of the current code.

I think these parameters will not be changed lightly, so I didn't do something with a const at the top of the file (would need STRINGIFY macro or something).

For flags without values, I didn't included a default because it's oblivous that without it's not active. For `--vopt force_die=<arg>` I suppose it's oblivous it not forced (but I don't know this parameter much).

I used `(default)` to keep short and the output is under 100 char length.

The help gives this:
```
nextpnr-himbaechel --device CCGM1A1 --vopt help
Info: Using uarch 'gatemate' for device 'CCGM1A1'
Allowed --vopt options:
  --vopt out=<arg>            textual configuration bitstream output file
  --vopt ccf=<arg>            name of constraints file
  --vopt allow-unconstrained  allow unconstrained IOs
  --vopt fpga_mode=<arg>      performance mode (1:lowpower, 2:economy, 3:speed (default))
  --vopt time_mode=<arg>      timing mode (1:best, 2:typical, 3:worst (default))
  --vopt strategy=<arg>       multi-die clock placement strategy (mirror (default), full or clk1)
  --vopt force_die=<arg>      force specific die (example 1A,1B...)
  --vopt clk-cp               use CP lines for CLK and EN
  --vopt no-cpe-cp            do not use CP lines pass through CPE
  --vopt no-bridges           do not use CPE in bridge mode
  --vopt help                 show help
```