### PR TITLE
gatemate: improve PLL->BUFG error message

### DIFF
--- a/himbaechel/uarch/gatemate/pack_clocking.cc
+++ b/himbaechel/uarch/gatemate/pack_clocking.cc
@@ -319,7 +319,12 @@ void GateMatePacker::pll_out(CellInfo *cell, IdString origPort, Loc fixed)
     }
     if (bufg) {
         if (net->users.entries() != 1) {
-            log_error("Not handled BUFG.\n");
+            std::string msg = stringf("A PLL output (here %s of %s) connected to a BUFG could only connect to it, not %d ports:\n",
+                                      origPort.c_str(ctx), ctx->nameOf(cell), net->users.entries());
+            for (auto &usr : net->users) {
+                msg += stringf("    %s.%s\n", ctx->nameOf(usr.cell), ctx->nameOf(usr.port));
+            }
+            log_error("%s", msg.c_str());
         }
     } else {
         move_ram_i_fixed(cell, origPort, fixed);


### PR DESCRIPTION
When a PLL output is connected to a BUFG, it can only be connected to it.

The message is improved in mentioning it and listing all ports connected and the PLL name.

This simplify debug.

It gives this kind of output on my design:

```
Info: Packing BUFGs..
ERROR: A PLL output (here CLK0 of socCtrl_pll) connected to a BUFG could only connect to it, not 3 nets:
    $auto$ff.cc:337:slice$11978.CLK
    $auto$ff.cc:337:slice$11979.CLK
    socCtrl_resetGenerationArea_bufClk.I
0 warnings, 1 error
```

I don't know if the term are exact. The message also gives the impression it's a limitation of the gatemate hardware. If it's a current limitation of nextpnr, perhaps we should change the phrasing.

I reviewed if the code can create a crash in the crash, but I think it's not possible.