### PR TITLE
himbaechel/gatemate: fix multiplier-routing double-bind (w2n_entry assert) on dense designs

### DIFF
--- a/himbaechel/uarch/gatemate/gatemate.cc
+++ b/himbaechel/uarch/gatemate/gatemate.cc
@@ -208,6 +208,47 @@ bool GateMateImpl::isBelLocationValid(BelId bel, bool explain_invalid) const
         return true;
     }
 
+    // Multiplier clusters lay down dedicated, hand-picked LOCKED routing in
+    // preRoute (route_mult) that reaches into a halo of tiles around the placed
+    // cluster body. Nothing reserves those wires during placement and there is no
+    // spacing rule between clusters, so if two multiplier clusters are packed close
+    // enough their halos overlap and route_mult double-binds a shared wire (the
+    // base_arch.h bindPip assertion). Forbid any placement where the halo of this
+    // cell's multiplier cluster would overlap another placed multiplier cluster's
+    // halo. Placed first so it triggers for every cluster cell type (incl. the
+    // packed P-register FFs), not just the CPE_LT/L2T4 cells below.
+    if (!mult_cluster_roots.empty() && cell->cluster != ClusterId()) {
+        CellInfo *root = get_cluster_root(ctx, cell->cluster);
+        bool is_mult_cluster = false;
+        for (auto *r : mult_cluster_roots) {
+            if (r == root) {
+                is_mult_cluster = true;
+                break;
+            }
+        }
+        if (is_mult_cluster) {
+            int ax0, ay0, ax1, ay1;
+            if (get_mult_cluster_halo(root, ax0, ay0, ax1, ay1)) {
+                for (auto *other : mult_cluster_roots) {
+                    if (other == root)
+                        continue;
+                    int bx0, by0, bx1, by1;
+                    // Skip clusters not (fully) placed yet.
+                    if (!get_mult_cluster_halo(other, bx0, by0, bx1, by1))
+                        continue;
+                    bool disjoint = ax1 < bx0 || bx1 < ax0 || ay1 < by0 || by1 < ay0;
+                    if (!disjoint) {
+                        if (explain_invalid)
+                            log_info("Bel '%s' invalid: multiplier cluster halo overlaps another "
+                                     "multiplier cluster.\n",
+                                     ctx->nameOfBel(bel));
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+
     if (getBelBucketForBel(bel) == id_CPE_FF) {
         Loc loc = ctx->getBelLocation(bel);
         const CellInfo *adj_half = ctx->getBoundBelCell(
@@ -312,6 +353,51 @@ bool GateMateImpl::getClusterPlacement(ClusterId cluster, BelId root_bel,
     }
     placement.emplace_back(root_cell, root_bel);
     return getChildPlacement(root_cell, root_loc, placement);
+}
+
+bool GateMateImpl::get_mult_cluster_halo(CellInfo *root, int &x0, int &y0, int &x1, int &y1) const
+{
+    // Walk root + constr_children (recursively, like getChildPlacement) and take
+    // the bounding box of every placed cell. This naturally includes the zero
+    // driver and A passthrough cells, which are ordinary constr_children.
+    bool found = false;
+    std::vector<CellInfo *> stack;
+    stack.push_back(root);
+    while (!stack.empty()) {
+        CellInfo *c = stack.back();
+        stack.pop_back();
+        if (c->bel != BelId()) {
+            Loc loc = ctx->getBelLocation(c->bel);
+            if (!found) {
+                x0 = x1 = loc.x;
+                y0 = y1 = loc.y;
+                found = true;
+            } else {
+                x0 = std::min(x0, loc.x);
+                x1 = std::max(x1, loc.x);
+                y0 = std::min(y0, loc.y);
+                y1 = std::max(y1, loc.y);
+            }
+        }
+        for (auto child : c->constr_children)
+            stack.push_back(child);
+    }
+    if (!found)
+        return false;
+
+    // route_mult originates its dedicated routing from the A passthrough cells
+    // (at root.x - 1) and the zero driver, reaching wires at loc.x-1..loc.x+3 and
+    // loc.y-1..loc.y+1 (plus diagonal hops that terminate on in-cluster mult
+    // cells), and the SB switchboxes it uses can span a further tile. Relative to
+    // the all-cells bounding box the excess is ~1-2 tiles per side; a margin of 3
+    // covers that with cushion. A slightly generous margin only costs fabric
+    // spacing; too tight lets the double-bind crash persist.
+    const int margin = 3;
+    x0 -= margin;
+    y0 -= margin;
+    x1 += margin;
+    y1 += margin;
+    return true;
 }
 
 void GateMateImpl::prePlace() { assign_cell_info(); }
@@ -1125,6 +1211,32 @@ void GateMateImpl::assign_cell_info()
             fc.used = true;
         }
     }
+
+    // Cache the root cell of every multiplier cluster so isBelLocationValid can
+    // check halo overlap without an O(all cells) scan per call. Each multiplier
+    // cluster has exactly one zero driver, and its members (zero driver, A
+    // passthroughs) all point at the same cluster root; dedup by root name.
+    mult_cluster_roots.clear();
+    pool<IdString> seen_roots;
+    auto record_root = [&](IdString member_name) {
+        auto it = ctx->cells.find(member_name);
+        if (it == ctx->cells.end())
+            return;
+        CellInfo *member = it->second.get();
+        if (member->cluster == ClusterId())
+            return;
+        CellInfo *root = get_cluster_root(ctx, member->cluster);
+        if (root == nullptr || seen_roots.count(root->name))
+            return;
+        seen_roots.insert(root->name);
+        mult_cluster_roots.push_back(root);
+    };
+    for (auto &n : multiplier_zero_drivers)
+        record_root(n);
+    for (auto &n : multiplier_a_passthru_lowers)
+        record_root(n);
+    for (auto &n : multiplier_a_passthru_uppers)
+        record_root(n);
 }
 
 // Bel bucket functions

--- a/himbaechel/uarch/gatemate/gatemate.h
+++ b/himbaechel/uarch/gatemate/gatemate.h
@@ -102,6 +102,10 @@ struct GateMateImpl : HimbaechelAPI
     pool<IdString> multiplier_a_passthru_lowers;
     pool<IdString> multiplier_a_passthru_uppers;
     pool<IdString> multiplier_zero_drivers;
+    // Cached root cells of every multiplier cluster, populated once at placement
+    // start (assign_cell_info). Used by isBelLocationValid to keep two multiplier
+    // clusters' route_mult halos from overlapping.
+    std::vector<CellInfo *> mult_cluster_roots;
     std::vector<bool> used_cpes;
     std::vector<uint32_t> pip_data;
     std::vector<uint32_t> pip_mask;
@@ -124,6 +128,11 @@ struct GateMateImpl : HimbaechelAPI
   private:
     bool getChildPlacement(const BaseClusterInfo *cluster, Loc root_loc,
                            std::vector<std::pair<CellInfo *, BelId>> &placement) const;
+
+    // Bounding box (in tile coords) of a multiplier cluster's currently-placed
+    // cells, expanded by a margin covering the route_mult routing halo. Returns
+    // false if none of the cluster's cells are placed yet.
+    bool get_mult_cluster_halo(CellInfo *root, int &x0, int &y0, int &x1, int &y1) const;
 
     void write_bitstream(const std::string &device, const std::string &filename);
 

--- a/himbaechel/uarch/gatemate/route_mult.cc
+++ b/himbaechel/uarch/gatemate/route_mult.cc
@@ -39,6 +39,22 @@ void find_and_bind_downhill_pip(Context *ctx, WireId from, WireId to, NetInfo *n
 {
     NPNR_ASSERT(from != WireId());
     NPNR_ASSERT(to != WireId());
+
+    // Multiplier routes are hand-bound with STRENGTH_LOCKED. If this exact
+    // destination wire is already part of THIS net's route, re-binding it would
+    // trip the bindPip double-bind assertion (base_arch.h) -- it is just a
+    // revisit of a shared start wire, so treat it as a no-op.
+    if (ctx->getBoundWireNet(to) == net)
+        return;
+    // If the wire is held by a DIFFERENT net, two multiplier clusters were placed
+    // close enough that their dedicated (locked, hand-picked) routing overlaps.
+    // Fail with an actionable message instead of the opaque bindPip assertion, and
+    // never silently drop the connection (that would mis-route the product).
+    if (ctx->getBoundWireNet(to) != nullptr)
+        log_error("Multiplier routing conflict on wire %s: needed by net '%s' but already held by "
+                  "net '%s' -- two multiplier clusters are placed too close.\n",
+                  ctx->nameOfWire(to), net->name.c_str(ctx), ctx->getBoundWireNet(to)->name.c_str(ctx));
+
     for (auto pip : ctx->getPipsDownhill(from)) {
         if (ctx->getPipDstWire(pip) == to) {
             if (ctx->debug)


### PR DESCRIPTION
## Problem

On the Himbächel GateMate uarch, `nextpnr-himbaechel` aborts during the **"Routing multipliers"** pass with:

```
Assertion failure: w2n_entry == nullptr (common/kernel/base_arch.h:259)
```

i.e. `bindPip` is asked to bind a pip whose destination wire is already bound to another net. It is **seed-dependent** and shows up on **denser designs that use several `CC_MULT` blocks**; small designs (and a single multiplier in isolation) route fine, which is why it's easy to miss.

## Root cause

`himbaechel/uarch/gatemate/route_mult.cc` routes each multiplier by binding a **dedicated, hand-picked, `STRENGTH_LOCKED`** chain of pips whose wires are computed purely from the multiplier's placed `loc`. Some of those wires form a "halo" that reaches **outside the cluster body** — e.g. the A-passthrough column sits at `root.x - 1` and its switch-box routes (`SB_BIG/SB_SML.P0x…`) reach a tile or two further, and the `x4y1/x4y2` variants reach `loc.x + 3`.

Nothing reserves those halo wires during placement, and there is **no spacing rule between multiplier clusters**. So once the placer packs two multiplier clusters close enough that their halos overlap, the second cluster's `find_and_bind_downhill_pip` tries to bind a wire the first cluster already owns → the `bindPip` assertion.

Concretely, I reproduced a double-bind on wire `X24Y64/SB_SML.P05.Y1_int` between the `a_passthru_lower` routes of **two different** multiplier clusters.

## Fix

Two commits:

**1. `gatemate: prevent multiplier clusters from overlapping route_mult halos`** — the actual fix.
Add a placement-legality rule in `GateMateImpl::isBelLocationValid`: compute a multiplier cluster's halo bounding box (its placed cells' bbox, expanded by a margin that covers `route_mult`'s reach) and reject a placement whose halo overlaps another multiplier cluster's halo. The multiplier-cluster roots are cached once in `assign_cell_info` (via the existing `multiplier_*` pools) so the check stays cheap. This guarantees `route_mult`'s hand-routes are disjoint by construction — the same routes that already work for an isolated multiplier.

**2. `gatemate: diagnose multiplier routing conflicts instead of asserting`** — hardening.
Make `find_and_bind_downhill_pip` a no-op when the destination wire is already part of *this* net's route (a harmless revisit of a shared start wire, previously able to trip the same assert), and, if a *different* net holds the wire, emit an actionable `log_error` naming the wire and both nets instead of the opaque `NPNR_ASSERT`. This never silently drops a connection, and turns any residual/unforeseen collision into a diagnosable message.

## Verification

On a design (raycore compute core + monitor + UDP stack on a ULX5M-GS / CCGM1A1) that reproducibly hit the assert:

- Seeds that previously aborted in "Routing multipliers" (e.g. seed 4, seed 8) now **place and route** cleanly (core clock 26–28 MHz, timing met).
- A seed that already routed still routes — the rule is **not over-constraining** the placement.
- No seed hits the assert or the new `log_error` any more.

## Notes / open questions for maintainers

- The halo margin is a small fixed value (3 tiles), chosen conservatively to cover the reaches I could see in `route_mult.cc`. It could instead be derived exactly from each `route_mult_*` variant's reach if you'd prefer a tighter bound; I kept it simple and slightly generous (a too-large margin only costs a little fabric, a too-small one would let the crash slip through). Happy to adjust.
- The check recomputes cluster bboxes per call rather than caching positions (cells move during placement); multiplier clusters are few so this is cheap, but I can memoize if you'd like.

Found and fixed while bringing up a design on hardware; happy to iterate on the approach.
