### PR TITLE
gatemate: Fix DFF pin names when packing mult p registers

### DIFF
--- a/himbaechel/uarch/gatemate/pack_mult.cc
+++ b/himbaechel/uarch/gatemate/pack_mult.cc
@@ -994,6 +994,8 @@ void GateMatePacker::pack_mult()
             // Reconfigure the flop.
             sink->renamePort(id_D, id_DIN);
             sink->renamePort(id_Q, id_DOUT);
+            sink->renamePort(id_CLK, id_CLK_INT);
+            sink->renamePort(id_EN, id_EN_INT);
             sink->type = id_CPE_FF;
 
             // Connect the passthrough.


### PR DESCRIPTION
This fixes a bug similar to #1617.
My understanding is that b8a6559 switched `CLK` to `CLK_INT` and `EN` to `EN_INT` but missed the output register packing in `pack_mult.cc`. This results in the timing analyzer missing the paths to those FFs.