### PR TITLE
router2: fix no-op ripup of constant-net arcs

### DIFF
--- a/common/route/router2.cc
+++ b/common/route/router2.cc
@@ -447,10 +447,19 @@ struct Router2
             return;
         WireId src = nets.at(net->udata).src_wire;
         WireId cursor = ad.sink_wire;
-        while (cursor != src &&
-               (net->constant_value == IdString() || ctx->getWireConstantValue(cursor) == net->constant_value)) {
+        while (cursor != src) {
             PipId pip = nd.wires.at(cursor).first;
             unbind_pip_internal(nd, user, cursor);
+            // Constant nets have no global source; each arc's tree roots at a
+            // tap wire carrying the right constant value, bound with a null
+            // pip (see the const_mode midpoint bind in route_arc). The old
+            // condition here tested the const value on every wire from the
+            // sink up - false for all general routing - so the walk stopped
+            // immediately and ripup never unbound anything: rebinding the
+            // same path each iteration leaked one refcount per iteration and
+            // congestion on contested taps could never resolve.
+            if (pip == PipId())
+                break;
             cursor = ctx->getPipSrcWire(pip);
         }
         ad.routed = false;


### PR DESCRIPTION
**A note on authorship**: the change in this PR and its commit message were written by an AI assistant (Claude), working in an interactive debugging session that I directed. I followed the analysis and have verified the results on hardware (a MEGA65 core port that boots to BASIC on a QMTech Wukong xc7a100t), but I am not deeply familiar with this codebase — please review accordingly rather than assuming expert authorship. Happy to answer questions, re-test on hardware, or provide additional evidence.

## Symptom

On congested designs that use constant-net routing (himbaechel/xilinx routes GND/VCC this way), router2 livelocks: a handful of wires stay overused forever, with the same arcs ripped up and re-routed every iteration for thousands of iterations.

## Root cause

`ripup_arc` walks from the sink wire back to the net source, unbinding pips as it goes. For nets with `constant_value` set, the walk condition required every wire on the path to itself carry that constant value (`getWireConstantValue(cursor) == net->constant_value`). This is false for general-purpose routing wires, so the walk terminated at the sink immediately: ripup never unbound anything, re-routing rebound the same path on top of itself (leaking one wire refcount per cycle), and congestion on contested constant tap wires could never resolve.

## Fix

Constant-net arc trees root at a tap wire bound with a null pip (the const-mode midpoint bind in `route_arc`), so terminate the backwards walk there instead: walk toward the net source as usual and stop at the first null-pip binding.

## Evidence

Hardware-verified on xc7a100t: a MEGA65 core port (~34k LCs) that previously livelocked (>3000 iterations with 6 wires pinned overused) now routes to 0 overused wires in 23 iterations, and the resulting bitstream boots to BASIC. I don't have a small repro for this one — it needs enough congestion pressure on const taps to show — but the inverted walk condition is visible by inspection.

This affects every arch that uses constant-net mode in router2 (himbaechel/xilinx and gowin at least). It is one of a series of fixes from porting the MEGA65 core to the Wukong board with the open toolchain; the other PRs in the series are independent of this one.