### PR TITLE
himbaechel/xilinx: make depth-cascaded RAMB36E1 memories work

### DIFF
--- a/himbaechel/uarch/xilinx/fasm.cc
+++ b/himbaechel/uarch/xilinx/fasm.cc
@@ -1442,6 +1442,18 @@ struct FasmBackend
             write_bit("CASCOUT_ARD_ACTIVE", !used_rdaddrcasc.empty());
             write_bit("CASCOUT_BWR_ACTIVE", !used_wraddrcasc.empty());
         }
+        // A RAMB36E1 with a width-1 port needs the RAMB36-level BRAM36_*_WIDTH_*_1
+        // feature in addition to the per-half RAMB18_Yx width bits. Without it the
+        // two 16K halves (which interleave even/odd bit addresses in true 32K x 1
+        // mode) both respond at addr>>1: every write hits bit pairs 2k/2k+1 and
+        // the address LSB is ignored.
+        if (half == 0 && ci != nullptr && ci->type == id_RAMB36E1_RAMB36E1) {
+            push("RAMB36");
+            for (const char *port : {"READ_WIDTH_A", "READ_WIDTH_B", "WRITE_WIDTH_A", "WRITE_WIDTH_B"})
+                if (int_or_default(ci->params, ctx->id(port), 0) == 1)
+                    write_bit(std::string("BRAM36_") + port + "_1");
+            pop();
+        }
         pop();
     }
 

--- a/himbaechel/uarch/xilinx/fasm.cc
+++ b/himbaechel/uarch/xilinx/fasm.cc
@@ -1452,6 +1452,16 @@ struct FasmBackend
             for (const char *port : {"READ_WIDTH_A", "READ_WIDTH_B", "WRITE_WIDTH_A", "WRITE_WIDTH_B"})
                 if (int_or_default(ci->params, ctx->id(port), 0) == 1)
                     write_bit(std::string("BRAM36_") + port + "_1");
+            // Depth-cascaded pairs (64K x 1): the LOWER cell needs its
+            // RAM_EXTENSION bit set; UPPER shares the NONE encoding (bit
+            // clear), so only LOWER is written. Was never emitted, which
+            // breaks true width-1 cascaded memories.
+            for (const char *port : {"A", "B"}) {
+                std::string ext =
+                        str_or_default(ci->params, ctx->id(std::string("RAM_EXTENSION_") + port), "NONE");
+                if (ext == "LOWER")
+                    write_bit(std::string("RAM_EXTENSION_") + port + "_LOWER");
+            }
             pop();
         }
         pop();

--- a/himbaechel/uarch/xilinx/pack.cc
+++ b/himbaechel/uarch/xilinx/pack.cc
@@ -754,14 +754,19 @@ void XC7Packer::pack_bram()
                 ci->connectPort(p, ctx->nets[ctx->id("$PACKER_VCC_NET")].get());
             }
         } else if (ci->type == id_RAMB36E1_RAMB36E1) {
+            // ADDRARDADDRL15/ADDRBWRADDRL15 must be tied high in non-cascaded
+            // modes, but in a depth-cascaded pair (RAM_EXTENSION_A/B = LOWER/
+            // UPPER) they carry the address MSB that selects the half; the
+            // multixform has already wired ADDRARDADDR[15] onto them, and
+            // overriding that with VCC pins both reads and writes to the upper
+            // 32K half. Only tie when not driven.
             for (auto p : {id_ADDRARDADDRL15, id_ADDRBWRADDRL15}) {
                 if (!ci->ports.count(p)) {
                     ci->ports[p].name = p;
                     ci->ports[p].type = PORT_IN;
-                } else {
-                    ci->disconnectPort(p);
                 }
-                ci->connectPort(p, ctx->nets[ctx->id("$PACKER_VCC_NET")].get());
+                if (ci->getPort(p) == nullptr)
+                    ci->connectPort(p, ctx->nets[ctx->id("$PACKER_VCC_NET")].get());
             }
             if (int_or_default(ci->params, id_WRITE_WIDTH_A, 0) == 1) {
                 ci->disconnectPort(id_DIADI1);

--- a/himbaechel/uarch/xilinx/pack.cc
+++ b/himbaechel/uarch/xilinx/pack.cc
@@ -808,6 +808,42 @@ void XC7Packer::pack_bram()
             }
         }
     }
+
+    // Cluster cascaded RAMB36 pairs: CASCADEOUT->CASCADEIN are dedicated
+    // wires that only reach the vertically adjacent RAMB36 site, so the
+    // pair must be placed together (cf. carry chains). BRAM tiles are 5
+    // grid rows apart within a column.
+    int cascade_pairs = 0;
+    for (auto &cell : ctx->cells) {
+        CellInfo *lower = cell.second.get();
+        if (lower->type != id_RAMB36E1_RAMB36E1)
+            continue;
+        for (auto pn : {ctx->id("CASCADEOUTA"), ctx->id("CASCADEOUTB")}) {
+            NetInfo *cn = lower->getPort(pn);
+            if (cn == nullptr)
+                continue;
+            for (auto &usr : cn->users) {
+                CellInfo *upper = usr.cell;
+                if (upper == lower || upper->type != id_RAMB36E1_RAMB36E1)
+                    continue;
+                if (upper->cluster != ClusterId())
+                    continue; // already clustered (e.g. via the A cascade)
+                if (lower->cluster == ClusterId())
+                    lower->cluster = lower->name;
+                else if (lower->cluster != lower->name)
+                    continue; // lower is a child of another cluster; unsupported
+                upper->cluster = lower->name;
+                lower->constr_children.push_back(upper);
+                upper->constr_x = 0;
+                upper->constr_y = 5;
+                upper->constr_z = 0;
+                upper->constr_abs_z = false;
+                ++cascade_pairs;
+            }
+        }
+    }
+    if (cascade_pairs > 0)
+        log_info("    Clustered %d cascaded BRAM pairs\n", cascade_pairs);
 }
 
 void XilinxPacker::pack_inverters()

--- a/himbaechel/uarch/xilinx/pack.cc
+++ b/himbaechel/uarch/xilinx/pack.cc
@@ -808,6 +808,50 @@ void XC7Packer::pack_bram()
             }
         }
     }
+
+    // Cluster cascaded RAMB36 pairs: CASCADEOUT->CASCADEIN are dedicated
+    // wires that only reach the vertically adjacent RAMB36 site, so the
+    // pair must be placed together (cf. carry chains). BRAM tiles are 5
+    // grid rows apart within a column.
+    int cascade_pairs = 0;
+    for (auto &cell : ctx->cells) {
+        CellInfo *lower = cell.second.get();
+        if (lower->type != id_RAMB36E1_RAMB36E1)
+            continue;
+        for (auto pn : {ctx->id("CASCADEOUTA"), ctx->id("CASCADEOUTB")}) {
+            NetInfo *cn = lower->getPort(pn);
+            if (cn == nullptr || cn->users.empty())
+                continue;
+            // the only legal load on CASCADEOUT is the corresponding
+            // CASCADEIN of one other RAMB36
+            IdString in_port = (pn == ctx->id("CASCADEOUTA")) ? ctx->id("CASCADEINA") : ctx->id("CASCADEINB");
+            if (cn->users.entries() != 1)
+                log_error("%s.%s (net '%s') must drive exactly one load, found %d\n", ctx->nameOf(lower),
+                          pn.c_str(ctx), ctx->nameOf(cn), int(cn->users.entries()));
+            auto &usr = *cn->users.begin();
+            CellInfo *upper = usr.cell;
+            if (upper == lower || upper->type != id_RAMB36E1_RAMB36E1 || usr.port != in_port)
+                log_error("%s.%s (net '%s') may only drive %s of another RAMB36E1, found %s.%s\n",
+                          ctx->nameOf(lower), pn.c_str(ctx), ctx->nameOf(cn), in_port.c_str(ctx),
+                          ctx->nameOf(upper), usr.port.c_str(ctx));
+            if (upper->cluster == lower->name)
+                continue; // pair already clustered via the other cascade port
+            if (upper->cluster != ClusterId() || lower->cluster != ClusterId())
+                log_error("unsupported RAMB36E1 cascade topology at '%s' -> '%s' (chains deeper than two "
+                          "are not possible on xc7)\n",
+                          ctx->nameOf(lower), ctx->nameOf(upper));
+            lower->cluster = lower->name;
+            upper->cluster = lower->name;
+            lower->constr_children.push_back(upper);
+            upper->constr_x = 0;
+            upper->constr_y = 5;
+            upper->constr_z = 0;
+            upper->constr_abs_z = false;
+            ++cascade_pairs;
+        }
+    }
+    if (cascade_pairs > 0)
+        log_info("    Clustered %d cascaded BRAM pairs\n", cascade_pairs);
 }
 
 void XilinxPacker::pack_inverters()

--- a/himbaechel/uarch/xilinx/xilinx.cc
+++ b/himbaechel/uarch/xilinx/xilinx.cc
@@ -440,7 +440,7 @@ void XilinxImpl::configurePlacerStatic(PlacerStaticCfg &cfg)
         comb.cell_area[id_RAMB18E1_RAMB18E1] = StaticRect(1.0f, 3.0f);
         comb.bel_area[id_RAMB18E1_RAMB18E1] = StaticRect(1.0f, 3.0f);
         comb.cell_area[id_RAMB36E1_RAMB36E1] = StaticRect(1.0f, 6.0f);
-        comb.bel_area[id_RAMB36E1_RAMB36E1] = StaticRect(0.0f, 0.0f);
+        comb.bel_area[id_RAMB36E1_RAMB36E1] = StaticRect(1.0f, 6.0f);
         comb.spacer_rect = StaticRect(1.0f, 3.0f);
     }
     {

--- a/himbaechel/uarch/xilinx/xilinx.cc
+++ b/himbaechel/uarch/xilinx/xilinx.cc
@@ -101,6 +101,49 @@ void XilinxImpl::init(Context *ctx)
         auto extra_data = tile_extra_data(i);
         tile_status.at(i).site_variant.resize(extra_data->sites.ssize());
     }
+
+    // Build the next-RAMB36-up-the-column map for cascade placement
+    std::map<int, std::map<int, BelId>> bram36_by_col; // x -> y -> bel
+    for (BelId bel : ctx->getBels()) {
+        if (ctx->getBelType(bel) != id_RAMB36E1_RAMB36E1)
+            continue;
+        Loc l = ctx->getBelLocation(bel);
+        bram36_by_col[l.x][l.y] = bel;
+    }
+    for (auto &col : bram36_by_col) {
+        BelId prev;
+        int prev_y = 0;
+        for (auto &entry : col.second) {
+            if (prev != BelId() && (entry.first - prev_y) <= 6)
+                next_bram36_up[entry.second] = prev; // grid Y increases downwards: 'up' = smaller y
+            prev = entry.second;
+            prev_y = entry.first;
+        }
+    }
+}
+
+bool XilinxImpl::getClusterPlacement(ClusterId cluster, BelId root_bel,
+                                     std::vector<std::pair<CellInfo *, BelId>> &placement) const
+{
+    CellInfo *root_cell = ctx->getClusterRootCell(cluster);
+    if (root_cell->type == id_RAMB36E1_RAMB36E1) {
+        if (ctx->getBelType(root_bel) != id_RAMB36E1_RAMB36E1)
+            return false;
+        placement.clear();
+        placement.emplace_back(root_cell, root_bel);
+        BelId cursor = root_bel;
+        for (auto child : root_cell->constr_children) {
+            auto fnd = next_bram36_up.find(cursor);
+            if (fnd == next_bram36_up.end())
+                return false;
+            cursor = fnd->second;
+            if (ctx->getBelType(cursor) != id_RAMB36E1_RAMB36E1)
+                return false;
+            placement.emplace_back(child, cursor);
+        }
+        return true;
+    }
+    return HimbaechelAPI::getClusterPlacement(cluster, root_bel, placement);
 }
 
 SiteIndex XilinxImpl::get_bel_site(BelId bel) const

--- a/himbaechel/uarch/xilinx/xilinx.h
+++ b/himbaechel/uarch/xilinx/xilinx.h
@@ -123,6 +123,14 @@ struct XilinxImpl : HimbaechelAPI
     bool isBelLocationValid(BelId bel, bool explain_invalid = false) const override;
     bool xc7_logic_tile_valid(IdString tileType, const LogicTileStatus &lts) const;
 
+    // BRAM cascade support: CASCADEOUT->CASCADEIN only reaches the next
+    // RAMB36 site up the column; bel z indices are not uniform across BRAM
+    // tiles, so relative (x,y,z) constraints cannot express this. Precompute
+    // the next-RAMB36-in-column map and use it in getClusterPlacement.
+    dict<BelId, BelId> next_bram36_up;
+    bool getClusterPlacement(ClusterId cluster, BelId root_bel,
+                             std::vector<std::pair<CellInfo *, BelId>> &placement) const override;
+
     // Pips
     bool is_pip_unavail(PipId pip) const;
     bool checkPipAvail(PipId pip) const override { return !is_pip_unavail(pip); }


### PR DESCRIPTION
**A note on authorship**: the changes in this PR and their commit messages were written by an AI assistant (Claude), working in an interactive debugging session that I directed. I followed the analysis and have verified the results on hardware (a MEGA65 core port that boots to BASIC on a QMTech Wukong xc7a100t), but I am not deeply familiar with this codebase — please review accordingly rather than assuming expert authorship. Happy to answer questions, re-test on hardware, or provide additional evidence.

## Summary

Deep, narrow inferred memories (e.g. 64K x 1, which yosys maps to a depth-cascaded pair of RAMB36E1s, and 32K x 1 single-cell mode) were broken in several independent ways. This PR fixes them in five self-contained commits:

1. **fasm: emit `BRAM36_{READ,WRITE}_WIDTH_{A,B}_1`** — width-1 ports need the RAMB36-level feature in addition to the per-half RAMB18 bits; without it the two 16K halves alias (address LSB ignored).
2. **fasm: emit `RAM_EXTENSION_{A,B}_LOWER`** — the cascade configuration of the LOWER cell was never written (UPPER shares the NONE encoding, so only LOWER needs a bit).
3. **pack: don't override driven `ADDRARDADDRL15`/`ADDRBWRADDRL15`** — these were unconditionally tied to VCC, but in a cascaded pair they carry the address MSB selecting the half; tying them pinned all accesses to the upper 32K. Tie only when undriven.
4. **pack/arch: place cascade pairs as clusters** — CASCADEOUT→CASCADEIN are dedicated wires reaching only the vertically adjacent RAMB36 site. Bel z indices are not uniform across BRAM tiles, so relative (x,y,z) constraints can't express "next RAMB36 up the column"; a precomputed next-in-column map plus a `getClusterPlacement` override does.
5. **arch: give RAMB36 bels a nonzero area in the static placer** — `bel_area` was 0x0 while cells claim 1x6, so BRAM-heavy designs couldn't converge to a legalisable placement.

## Repro

Infer a 64K x 1 (cascaded pair) or 32K x 1 (single cell, commits 1-2) memory, e.g. `reg mem[0:65535]` with registered read, initialised with a known pattern; read it back. Before this PR: placement may fail outright (commit 4), and the read data aliases or comes from the wrong half.

## Evidence

Verified against Vivado bitstreams for the same configurations, and on xc7a100t hardware: a 128K ROM built from cascaded RAMB36E1 pairs passes a full content fingerprint check (32/32), as part of a MEGA65 core port (93% BRAM utilisation) that boots to BASIC.