### PR TITLE
himbaechel/xilinx: fix LUTRAM initialisation (INIT_A..INIT_D)

### DIFF
--- a/himbaechel/uarch/xilinx/pack_dram.cc
+++ b/himbaechel/uarch/xilinx/pack_dram.cc
@@ -495,8 +495,8 @@ void XilinxPacker::pack_dram()
                                                      dout, zoffset + i);
                     if (base == nullptr)
                         base = dram;
-                    if (ci->params.count(ctx->idf("INIT%c", 'A' + i)))
-                        dram->params[id_INIT] = ci->params[ctx->idf("INIT%c", 'A' + i)];
+                    if (ci->params.count(ctx->idf("INIT_%c", 'A' + i)))
+                        dram->params[id_INIT] = ci->params[ctx->idf("INIT_%c", 'A' + i)];
                 } else {
                     for (int j = 0; j < dbits; j++) {
                         NetInfo *di = ci->getPort(ctx->idf("DI%c[%d]", 'A' + i, j));
@@ -507,13 +507,19 @@ void XilinxPacker::pack_dram()
                                                            address, di, dout, (j == 0), zoffset + i);
                         if (base == nullptr)
                             base = dram;
-                        if (ci->params.count(ctx->idf("INIT%c", 'A' + i))) {
-                            auto orig_init = ci->params.at(ctx->idf("INIT%c", 'A' + i)).extract(0, 64).as_bits();
-                            std::string init;
-                            for (int k = 0; k < 32; k++) {
-                                init.push_back(orig_init.at(k * 2 + j));
-                            }
-                            dram->params[id_INIT] = Property::from_string(init);
+                        if (ci->params.count(ctx->idf("INIT_%c", 'A' + i))) {
+                            // De-interleave the 64-bit INIT (bit k*2+j is bit j
+                            // of entry k) into this RAMD32's 32 bits. Slice the
+                            // canonical bit string ('0'/'1' chars, LSB first) -
+                            // as_bits() gives raw bools, which are not valid
+                            // Property string characters.
+                            Property orig_init = ci->params.at(ctx->idf("INIT_%c", 'A' + i)).extract(0, 64);
+                            Property init;
+                            init.is_string = false;
+                            for (int k = 0; k < 32; k++)
+                                init.str.push_back(orig_init.str.at(k * 2 + j));
+                            init.update_intval();
+                            dram->params[id_INIT] = init;
                         }
                     }
                 }


### PR DESCRIPTION
**A note on authorship**: the change in this PR and its commit message were written by an AI assistant (Claude), working in an interactive debugging session that I directed. I followed the analysis and have verified the results on hardware (a MEGA65 core port that boots to BASIC on a QMTech Wukong xc7a100t), but I am not deeply familiar with this codebase — please review accordingly rather than assuming expert authorship. Happy to answer questions, re-test on hardware, or provide additional evidence.

## Symptom

All distributed RAM (RAM32M/RAM64M etc.) is configured with INIT=0 regardless of the design's initial contents.

## Root cause and fix

The primitives carry per-port initialisation in parameters named `INIT_A..INIT_D`, but `pack_dram` looked up `INITA..INITD` — the lookup never matched (one-character fix). Fixing the name exposed a second, previously unreachable bug in the wide (dbits>1) path: the 64-bit INIT slice was converted with `as_bits()`, which yields raw bool values rather than the '0'/'1' characters a `Property` string requires, producing a corrupt property. The commit de-interleaves the canonical bit string directly and rebuilds the Property with `update_intval()`.

## Repro

A RAM64M/RAM32M with nonzero `INIT_A..D` and its outputs on LEDs (WE driven by a live net, held low). Before: all outputs read 0; after: the INIT contents.

## Evidence

Hardware-verified on xc7a100t: the repro above, plus LUTRAM-based tables in a MEGA65 core port that boots to BASIC.