### PR TITLE
himbaechel/xilinx: do not set OUT_DIFF for TMDS_33 outputs

### DIFF
--- a/himbaechel/uarch/xilinx/fasm.cc
+++ b/himbaechel/uarch/xilinx/fasm.cc
@@ -1004,7 +1004,11 @@ struct FasmBackend
         else
             inv = uarch->get_site_bel(pad_bel_site, ctx->id("IOB33S.O_ININV"));
 
-        if (inv != BelId() && ctx->getBoundBelCell(inv) != nullptr)
+        // TMDS_33 outputs are driven by the Y0 current-mode driver alone
+        // (TMDS_33.OUT + DRIVE.I_FIXED, Y1 IN_ONLY); Vivado does not set
+        // OUT_DIFF for them and setting it disables the driver stage
+        // (hardware-verified: monitor reports "no transmitter present").
+        if (inv != BelId() && ctx->getBoundBelCell(inv) != nullptr && !is_tmds33)
             write_bit("OUT_DIFF");
 
         if (is_stepdown && !is_sing)


### PR DESCRIPTION
**A note on authorship**: the change in this PR and its commit message were written by an AI assistant (Claude), working in an interactive debugging session that I directed. I followed the analysis and have verified the results on hardware (a MEGA65 core port that boots to BASIC on a QMTech Wukong xc7a100t), but I am not deeply familiar with this codebase — please review accordingly rather than assuming expert authorship. Happy to answer questions, re-test on hardware, or provide additional evidence.

## Symptom

HDMI/DVI output via TMDS_33 differential pairs is completely dead; the attached monitor reports "no transmitter present".

## Root cause and fix

TMDS_33 outputs use the Y0 current-mode driver alone (`TMDS_33.OUT` plus `DRIVE.I_FIXED`, with the Y1 pad set IN_ONLY). Vivado bitstreams for the same design do not set the tile-level `OUT_DIFF` feature for TMDS pairs, and setting it disables the driver stage entirely. The fasm backend set `OUT_DIFF` for every differential output; guard it so TMDS_33 is excluded (other diff standards, e.g. LVDS_25, keep it).

## Evidence

A/B on a 640x480 DVI design for the QMTech Wukong (xc7a100t): without the fix the emitted fasm contains `OUT_DIFF` on all four TMDS tiles and the screen stays dark; with it, no `OUT_DIFF` (matching Vivado) and the monitor shows a perfect test card. Also exercised by the HDMI path of a MEGA65 core port on the same board.