### PR TITLE
himbaechel/xilinx: fix MMCM loop filter and power register programming

### DIFF
--- a/himbaechel/uarch/xilinx/fasm.cc
+++ b/himbaechel/uarch/xilinx/fasm.cc
@@ -1691,14 +1691,23 @@ struct FasmBackend
             filter_lookup = Xc7MMCM::filter_lookup_high;
         else
             filter_lookup = Xc7MMCM::filter_lookup_optimized;
-        write_int_vector("FILTREG1_RESERVED[11:0]", filter_lookup[clkfbout_mult - 1], 12);
+        // prjxray's TABLE[9:0] IS the 10-bit loop-filter word; putting the
+        // filter word in FILTREG1_RESERVED with a hardcoded TABLE=0x3d4
+        // (as before) yields an MMCM that never locks on hardware.
+        // Values verified against Vivado bitstreams (integer and
+        // CLKOUT0_DIVIDE_F=6.5 fractional testcases) and hardware-validated
+        // on a QMTech Wukong xc7a100t.
+        write_int_vector("FILTREG1_RESERVED[11:0]", 0x8, 12);
 
-        // 0x9900 enables fractional counters
-        // only int counters would be 0x1 << 8
-        // 0xffff enables everything, I suppose, this is what is used in xap888
-        write_int_vector("POWER_REG_POWER_REG_POWER_REG[15:0]", 0xffff, 16);
+        // POWER_REG: 0x1 << 8 for integer-only counters, 0x9900 when
+        // CLKOUT0 or CLKFBOUT use fractional divide.
+        float clkout0_divide_f = float_or_default(ci, "CLKOUT0_DIVIDE_F", 1.0);
+        float clkfbout_mult_f = float_or_default(ci, "CLKFBOUT_MULT_F", 5.000);
+        bool fractional = (clkout0_divide_f != (float)(int)clkout0_divide_f) ||
+                          (clkfbout_mult_f != (float)(int)clkfbout_mult_f);
+        write_int_vector("POWER_REG_POWER_REG_POWER_REG[15:0]", fractional ? 0x9900 : 0x0100, 16);
         write_bit("LOCKREG3_RESERVED[0]");
-        write_int_vector("TABLE[9:0]", 0x3d4, 10);
+        write_int_vector("TABLE[9:0]", filter_lookup[clkfbout_mult - 1], 10);
         pop(2);
     }
     void write_dsp_cell(CellInfo *ci)

--- a/himbaechel/uarch/xilinx/fasm.cc
+++ b/himbaechel/uarch/xilinx/fasm.cc
@@ -1691,14 +1691,15 @@ struct FasmBackend
             filter_lookup = Xc7MMCM::filter_lookup_high;
         else
             filter_lookup = Xc7MMCM::filter_lookup_optimized;
-        write_int_vector("FILTREG1_RESERVED[11:0]", filter_lookup[clkfbout_mult - 1], 12);
+        // TABLE holds the loop-filter word; FILTREG1_RESERVED is a constant 0x8 (matches Vivado)
+        write_int_vector("FILTREG1_RESERVED[11:0]", 0x8, 12);
 
         // 0x9900 enables fractional counters
         // only int counters would be 0x1 << 8
         // 0xffff enables everything, I suppose, this is what is used in xap888
         write_int_vector("POWER_REG_POWER_REG_POWER_REG[15:0]", 0xffff, 16);
         write_bit("LOCKREG3_RESERVED[0]");
-        write_int_vector("TABLE[9:0]", 0x3d4, 10);
+        write_int_vector("TABLE[9:0]", filter_lookup[clkfbout_mult - 1], 10);
         pop(2);
     }
     void write_dsp_cell(CellInfo *ci)


### PR DESCRIPTION
**A note on authorship**: the change in this PR and its commit message were written by an AI assistant (Claude), working in an interactive debugging session that I directed. I followed the analysis and have verified the results on hardware (a MEGA65 core port that boots to BASIC on a QMTech Wukong xc7a100t), but I am not deeply familiar with this codebase — please review accordingly rather than assuming expert authorship. Happy to answer questions, re-test on hardware, or provide additional evidence.

## Symptom

MMCME2_ADV never asserts LOCKED on hardware; all derived clocks stay dead. (PLLE2 was unaffected.)

## Root cause and fix

The fasm writer put the 10-bit BANDWIDTH loop-filter word into `FILTREG1_RESERVED[11:0]` and wrote a hardcoded `0x3d4` into `TABLE[9:0]`. In prjxray's MMCM model, `TABLE[9:0]` *is* the loop-filter table word; with the filter word misplaced the analog loop is misconfigured and never locks. The fix swaps them (`TABLE = filter_lookup[CLKFBOUT_MULT-1]`, `FILTREG1_RESERVED = 0x8`) and programs `POWER_REG` from the actual configuration (`0x0100` integer-only, `0x9900` when CLKOUT0/CLKFBOUT use fractional divide) instead of `0xffff` — all matching Vivado bitstreams for the same configurations (verified for integer and `CLKOUT0_DIVIDE_F=6.5` fractional testcases).

## Evidence

Hardware-validated on a QMTech Wukong (xc7a100t): an MMCM blinky that never locked before locks and blinks after; the fix also carries a 640x480 DVI design and a MEGA65 core port (both MMCM-clocked) on the same board. A/B fasm diff shows exactly the TABLE/FILTREG1_RESERVED/POWER_REG features changing, with the same 10-bit filter word moving from FILTREG1_RESERVED to TABLE.