### PR TITLE
himbaechel/xilinx: don't pair FFs with SRL/LUTRAM on a different clock

### DIFF
--- a/himbaechel/uarch/xilinx/pack.cc
+++ b/himbaechel/uarch/xilinx/pack.cc
@@ -310,6 +310,14 @@ void XilinxPacker::pack_lutffs()
                 ci->constr_z = lut->constr_z + (BEL_FF - BEL_6LUT);
                 ++pairs;
             } else {
+                // don't pair an FF with an SRL/LUTRAM unless it shares the
+                // slice clock (same net and polarity)
+                NetInfo *lut_clk = lut->getPort(id_CLK);
+                if (lut_clk != nullptr &&
+                    (ci->getPort(id_CK) != lut_clk ||
+                     bool_or_default(ci->params, id_IS_CLK_INVERTED, false) !=
+                             bool_or_default(lut->params, id_IS_CLK_INVERTED, false)))
+                    continue;
                 lut->constr_children.push_back(ci);
                 lut->cluster = lut->name;
                 ci->cluster = lut->name;

--- a/himbaechel/uarch/xilinx/pack.cc
+++ b/himbaechel/uarch/xilinx/pack.cc
@@ -310,6 +310,17 @@ void XilinxPacker::pack_lutffs()
                 ci->constr_z = lut->constr_z + (BEL_FF - BEL_6LUT);
                 ++pairs;
             } else {
+                // For SRL/LUTRAM drivers the slice write clock is the slice
+                // CLK, which the FF must share (same net, same polarity) —
+                // otherwise the cluster is unplaceable (xc7_logic_tile_valid
+                // FF-clk-vs-wclk check rejects it at every bel and
+                // legalisation spins forever).
+                NetInfo *lut_clk = lut->getPort(id_CLK);
+                if (lut_clk != nullptr &&
+                    (ci->getPort(id_CK) != lut_clk ||
+                     bool_or_default(ci->params, id_IS_CLK_INVERTED, false) !=
+                             bool_or_default(lut->params, id_IS_CLK_INVERTED, false)))
+                    continue;
                 lut->constr_children.push_back(ci);
                 lut->cluster = lut->name;
                 ci->cluster = lut->name;


### PR DESCRIPTION
**A note on authorship**: the change in this PR and its commit message were written by an AI assistant (Claude), working in an interactive debugging session that I directed. I followed the analysis and have verified the results on hardware (a MEGA65 core port that boots to BASIC on a QMTech Wukong xc7a100t), but I am not deeply familiar with this codebase — please review accordingly rather than assuming expert authorship. Happy to answer questions, re-test on hardware, or provide additional evidence.

## Symptom

The placer silently hangs (strict legalisation spins forever) on designs where an SRL or LUTRAM output feeds a flip-flop clocked by a different clock (or opposite polarity).

## Root cause and fix

`pack_lutffs` constrains an FF into the same slice position as the LUT driving its D input. When that driver is an SRL/LUTRAM cell, the slice write clock is the slice CLK, which the FF must share — the validity check (`xc7_logic_tile_valid`) correctly rejects any slice where they differ. Pairing such an FF creates a cluster that is invalid at every bel on the device, and the static placer's strict legalisation loop has no termination path for a never-valid cell, so it spins forever. The fix: only pair the FF when the driving cell has no CLK or shares the FF's clock net and `IS_CLK_INVERTED` polarity.

(The missing termination path in `legalise_placement_strict` is a separate latent issue — any never-placeable cell hangs the placer silently instead of erroring out. I can file it separately if useful.)

## Evidence

Hardware-verified on xc7a100t as part of a MEGA65 core port that previously hung in placement and now places, routes, and boots to BASIC.