### PR TITLE
gatemate: Place CC_MULT packed P register in same row

### DIFF
--- a/himbaechel/uarch/gatemate/pack_mult.cc
+++ b/himbaechel/uarch/gatemate/pack_mult.cc
@@ -1026,7 +1026,7 @@ void GateMatePacker::pack_mult()
                 auto *sink = cpe_half_cpout_user.cell;
                 NPNR_ASSERT(sink != nullptr);
                 if (sink->type == id_CC_DFF && should_pack_register) {
-                    create_p_register(cpe_half, sink, b_width / 2, b_width / 2 + p / 2, p % 2 == 1, p);
+                    create_p_register(cpe_half, sink, b_width / 2, 4 + p / 2, p % 2 == 1, p);
                 }
             }
         }
@@ -1043,8 +1043,8 @@ void GateMatePacker::pack_mult()
                 auto *sink = cpe_half_cpout_user.cell;
                 NPNR_ASSERT(sink != nullptr);
                 if (sink->type == id_CC_DFF && should_pack_register) {
-                    create_p_register(cpe_half, sink, b_width / 2, b_width / 2 + diagonal_p_width / 2 + p / 2,
-                                      p % 2 == 1, p + diagonal_p_width);
+                    create_p_register(cpe_half, sink, b_width / 2, 4 + diagonal_p_width / 2 + p / 2, p % 2 == 1,
+                                      p + diagonal_p_width);
                 }
             }
         }


### PR DESCRIPTION
This places the merged output registers for CC_MULT in the same row as the CPE_MULT generating them (as was probably intended). The current implementation shifts the registers upward depending on the `b_width` parameter.

Without this change the following Verilog code:
```verilog
module test(CLK, A, B, P);
    
    input CLK;
    input[31:0] A;
    input[31:0] B;
    output[63:0] P;

    reg[31:0] A_reg;
    reg[31:0] B_reg;
    reg[31:0] P_reg;

    wire[31:0] P_int;

    always @(posedge CLK) begin
        A_reg <= A;
        B_reg <= B;
        P_reg <= P_int;
    end

    CC_MULT #(
        .A_WIDTH(32),
        .B_WIDTH(32),
        .P_WIDTH(64)
    ) mult_inst (
        .A(A_reg),
        .B(B_reg),
        .P(P_int)
    );

    assign P = P_reg;

endmodule
```

Synthesized and implemented via:
```bash
yosys -p "read_verilog test.v; synth_gatemate -luttree -nomx8 -json synth.json" -l synth.log

nextpnr-himbaechel --device CCGM1A1 --json synth.json --write impl.json -o allow-unconstrained --log impl.log
```

Show the following log:
```
Info: Critical path report for clock '$iopadmap$CLK' (posedge -> posedge):
Info:       type curr  total name
...
Info:    routing  2.52  26.33 Net P_int[31] (76,59) -> (78,72)
Info:                          Sink mult_inst$col16$row0$mult_upper$p[31]_passthru.IN1
Info:                          Defined in:
Info:                               test.v:12.16-12.21
Info:      logic  0.61  26.93 Source mult_inst$col16$row0$mult_upper$p[31]_passthru.OUT
Info:    routing  0.00  26.93 Net mult_inst$col16$row0$mult_upper$p[31]_passthru$p (78,72) -> (78,72)
Info:                          Sink $auto$ff.cc:337:slice$193.DIN
Info:      setup  0.10  27.03 Source $auto$ff.cc:337:slice$193.DIN
Info: 16.89 ns logic, 10.14 ns routing
```

I.e. we route from the CPE_MULT at `(76,59)` to the register at `(78,72)`.

With the change we instead get the following:
```
Info: Critical path report for clock '$iopadmap$CLK' (posedge -> posedge):
Info:       type curr  total name
...
Info:    routing  1.79  25.58 Net P_int[30] (76,59) -> (78,59)
Info:                          Sink mult_inst$col16$row0$mult_lower$p[30]_passthru.IN1
Info:                          Defined in:
Info:                               test.v:12.16-12.21
Info:      logic  0.55  26.13 Source mult_inst$col16$row0$mult_lower$p[30]_passthru.OUT
Info:    routing  0.00  26.13 Net mult_inst$col16$row0$mult_lower$p[30]_passthru$p (78,59) -> (78,59)
Info:                          Sink $auto$ff.cc:337:slice$192.DIN
Info:      setup  0.10  26.23 Source $auto$ff.cc:337:slice$192.DIN
Info: 16.85 ns logic, 9.38 ns routing
```
Where both CPE are placed in the same row `(76,59) -> (78,59)`.

[test.zip](https://github.com/user-attachments/files/30752393/test.zip)