### PR TITLE
himbaechel/gui: Fix segfault when using "Open json" in gui

### DIFF
--- a/frontend/frontend_base.h
+++ b/frontend/frontend_base.h
@@ -132,6 +132,9 @@ template <typename FrontendType> struct GenericFrontend
         m.is_toplevel = true;
         m.prefix = "";
         m.path = top;
+
+        std::lock_guard<std::mutex> lock(ctx->mutex);
+
         ctx->top_module = top;
         // Do the actual import, starting from the top level module
         import_module(m, top.str(ctx), top.str(ctx), mod_refs.at(top.str(ctx)));

--- a/gui/basewindow.cc
+++ b/gui/basewindow.cc
@@ -370,6 +370,11 @@ void BaseMainWindow::open_json()
         if (ctx->settings.find(ctx->id("synth")) == ctx->settings.end()) {
             ArchArgs chipArgs = ctx->args;
             ctx = std::unique_ptr<Context>(new Context(chipArgs));
+#ifdef ARCH_HIMBAECHEL
+            ctx->uarch->with_gui = true;
+            ctx->uarch->init(ctx.get());
+            ctx->late_init();
+#endif
             Q_EMIT contextChanged(ctx.get());
         }
         handler->load_json(ctx.get(), fileName.toStdString());

--- a/gui/basewindow.cc
+++ b/gui/basewindow.cc
@@ -369,13 +369,14 @@ void BaseMainWindow::open_json()
         disableActions();
         if (ctx->settings.find(ctx->id("synth")) == ctx->settings.end()) {
             ArchArgs chipArgs = ctx->args;
-            ctx = std::unique_ptr<Context>(new Context(chipArgs));
+            std::unique_ptr<Context> new_ctx = std::unique_ptr<Context>(new Context(chipArgs));
 #ifdef ARCH_HIMBAECHEL
-            ctx->uarch->with_gui = true;
-            ctx->uarch->init(ctx.get());
-            ctx->late_init();
+            new_ctx->uarch->with_gui = true;
+            new_ctx->uarch->init(new_ctx.get());
+            new_ctx->late_init();
 #endif
-            Q_EMIT contextChanged(ctx.get());
+            Q_EMIT contextChanged(new_ctx.get());
+            ctx = std::move(new_ctx);
         }
         handler->load_json(ctx.get(), fileName.toStdString());
         Q_EMIT updateTreeView();


### PR DESCRIPTION
This PR fixes a segfault occuring when using "Open json" in the gui.
The PR is split into three parts for easier review, but should probably be squashed before merging.

The three commits fix three separate (but related) issues:
c7990e8 fixes a null pointer deref in `isPipInverting()` due to `ctx->uarch` never being initialized when creating a new context during json load. This is also the issue in the stack trace posted issue #1625.

8b1976b fixes a double free error due to concurrent access to a hashmap by both the `FPGAViewWidget` and `import_module`.

6b583cb fixes another null pointer deref on `ctx->uarch`. Due to `FPGAViewWidget` holding a copy of the context, which is deleted by the `unique_ptr` assignment.

Please review carefully as I am not very familiar with the GUI code. I have also not tested this on any architecture except himbaechel + gatemate.

Fixes #1625

Implemented design I used to test:  [impl.json](https://github.com/user-attachments/files/30827244/impl.json)
