### PR TITLE
Fix compilation with `NPNR_DISABLE_THREADS`.

### DIFF
--- a/frontend/frontend_base.h
+++ b/frontend/frontend_base.h
@@ -133,7 +133,9 @@ template <typename FrontendType> struct GenericFrontend
         m.prefix = "";
         m.path = top;
 
+#ifndef NPNR_DISABLE_THREADS
         std::lock_guard<std::mutex> lock(ctx->mutex);
+#endif
 
         ctx->top_module = top;
         // Do the actual import, starting from the top level module


### PR DESCRIPTION
Caught while building 0.11 for YoWASP.