### PR TITLE
placer_heap: don't lose ripped-up clusters in try_place_cluster

### DIFF
--- a/common/place/placer_heap.cc
+++ b/common/place/placer_heap.cc
@@ -1429,7 +1429,15 @@ class HeAPPlacer
                         }
                     }
                     ctx->bindBel(target.second, target.first, STRENGTH_STRONG);
-                    moves_made[target.second] = bound;
+                    // Do not overwrite an existing ripup record: when a
+                    // cluster is ripped up, every member (including its
+                    // root) is recorded above; if a LATER target bel lands
+                    // on that cluster's root, `bound` was re-read after the
+                    // unbind and is nullptr - overwriting would erase the
+                    // root's record, so the ripped-up cluster is never
+                    // requeued and every one of its cells stays unbound.
+                    if (!moves_made.count(target.second))
+                        moves_made[target.second] = bound;
                 }
                 // Check that the move we have made is legal
                 for (auto &move : moves_made) {


### PR DESCRIPTION
## The bug

`placer_heap.cc`, `try_place_cluster()`: when placing cluster A over a bel occupied by a cell of cluster B, every cell of B (its root included) is unbound and recorded in `moves_made[cell->bel] = cell`. Each of A's target bels then also writes:

```cpp
ctx->bindBel(target.second, target.first, STRENGTH_STRONG);
moves_made[target.second] = bound;
```

where `bound` was re-read **after** B was unbound. If a later target bel lands on B's *root* cell's old bel, `bound` is `nullptr` and the root's ripup record is overwritten.

The requeue loop at the end of the function only requeues ripped-up cells that are cluster roots (members are expected to return when their root is re-placed):

```cpp
if (move.second != nullptr && (move.second->cluster == ClusterId() ||
                               ctx->getClusterRootCell(move.second->cluster) == move.second))
    remaining.emplace(...);
```

With the root's record now `nullptr`, cluster B is never requeued and every one of its cells stays unbound. The run then fails after placement with a wall of `Found unbound cell '...'` from the solution check.

## How it shows up

Observed on the himbaechel **gatemate** uarch, where `CC_MULT` multiplier arrays are large rectangular clusters: legalizing one array on top of another overlaps many bels, so the overwrite is near-certain once two arrays contend for the same region. A design with 33 multipliers (~58% CPE utilization on CCGM1A1) deterministically lost 3–4 whole arrays — ~1,300 unbound cells — and which arrays were lost moved with any change to the netlist, which made it look nondeterministic until the mechanism was found. Any arch that places multi-cell clusters through the heap placer can hit this.

Worth knowing when reproducing: the failing check runs **after** placement — `--pack-only` never reaches it, and `--no-route` still places first, so a run killed early by a timeout is indistinguishable from a pass.

## The fix

Keep the first `moves_made` record for a bel — it is the true previous occupant:

```cpp
if (!moves_made.count(target.second))
    moves_made[target.second] = bound;
```

This also repairs the `fail:` revert path, which restores `move.second` per bel: with the record overwritten to `nullptr`, a failed attempt left B's root unbound (and B partially rebound) as well.

Verified on the design above with a patched build: same JSON goes from 1,354 unbound cells (deterministic) to a clean place → route → bitstream. I can share the failing JSON (CCGM1A1, ~39k cells) if a regression case is wanted, though it is on the large side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
