### PR TITLE
himbaechel/xilinx: fix lutperm attr separator

### DIFF
--- a/himbaechel/uarch/xilinx/fasm.cc
+++ b/himbaechel/uarch/xilinx/fasm.cc
@@ -426,8 +426,12 @@ struct FasmBackend
                 for (int k = 0; k < 6; k++) {
                     if ((j & (1 << k)) == 0)
                         continue;
-                    for (auto &p2l : phys_to_log[k])
-                        log_index |= (1 << log_to_bit[p2l]);
+                    for (auto &p2l : phys_to_log[k]) {
+                        if (!log_to_bit.count(p2l))
+                            log_error("cell '%s': X_ORIG_PORT_%s token '%s' does not name a logical input\n",
+                                      ctx->nameOf(lut), phys_inputs[k].c_str(ctx), p2l.c_str());
+                        log_index |= (1 << log_to_bit.at(p2l));
+                    }
                 }
                 bits[j] = (init.str.at(log_index) == Property::S1);
             }

--- a/himbaechel/uarch/xilinx/xilinx_place.cc
+++ b/himbaechel/uarch/xilinx/xilinx_place.cc
@@ -599,7 +599,7 @@ void XilinxImpl::fixup_routing()
                     auto &orig_attr = lut6->attrs[ctx->idf("X_ORIG_PORT_%s", p.c_str(ctx))].str;
                     bool first = true;
                     for (auto &nc : new_connections.at(p)) {
-                        orig_attr += orig_ports_l6[nc] + (first ? "" : " ");
+                        orig_attr += (first ? "" : " ") + orig_ports_l6[nc];
                         first = false;
                     }
                     if (orig_attr.empty())
@@ -614,7 +614,7 @@ void XilinxImpl::fixup_routing()
                     auto &orig_attr = lut5->attrs[ctx->idf("X_ORIG_PORT_%s", p.c_str(ctx))].str;
                     bool first = true;
                     for (auto &nc : new_connections.at(p)) {
-                        orig_attr += orig_ports_l5[nc] + (first ? "" : " ");
+                        orig_attr += (first ? "" : " ") + orig_ports_l5[nc];
                         first = false;
                     }
                     if (orig_attr.empty())


### PR DESCRIPTION
*Authorship notice: investigation and patch developed with substantial AI assistance (Claude), reviewed and hardware-verified by me.*

**Symptom.** Designs built via himbaechel-xilinx can end up with individual LUTs computing the wrong function, deterministically per build but varying with placement/routing. We hit it as a stable color tint in a DVI test-card design on Artix-7 (xc7a100t): three PnR runs of the same synthesized netlist gave white, green-tinted, and yellow-tinted output respectively, because different corrupted LUTs landed in different TMDS channel encoders.

**Root cause.** `fixup_routing()` eliminates LUT-permutation pips by rewriting the physical-to-logical pin mapping stored in the `X_ORIG_PORT_*` attributes. When one physical pin carries more than one logical port, the merge loop appends the separator after each entry instead of before each entry but the first:

```cpp
orig_attr += orig_ports_l6[nc] + (first ? "" : " ");
```

This produces `"I4I3 "` instead of `"I4 I3"`. The fasm exporter's `get_lut_init()` then splits the attribute on spaces and looks each token up in its logical-port map — a `dict` accessed with `operator[]`, which silently default-inserts 0 for the unmatched tokens (`"I4I3"` and `""`). Both bogus tokens therefore alias logical input 0, and the exported INIT is wrong for exactly the minterms involving that physical pin.

**Fix.** Commit 1 swaps the concatenation order so the separator lands between entries. Commit 2 makes `get_lut_init()` `log_error` on a token that does not name a logical input instead of silently corrupting the INIT — with the separator bug present, this turns a wrong bitstream into a hard error at export time, which is how it should have failed in the first place.

**Evidence.** With the bug: a routed netlist of our test-card design contains 28 mangled attributes, all on 6LUTs whose inputs the router permuted; decoding one specimen (logical `LUT5`, `INIT=0x555555C3`, attrs `A5=I1 A4=I2 A3=I0 A1="I4I3 "`) under the buggy interpretation predicts fasm `INIT[63:0] = 64'hFF0000FFFF0000FF`, which is byte-for-byte what the fasm contains; the correct interpretation (`A1=I4 I3`) appears nowhere. With the fix: the only fasm changes versus the buggy build are the INIT values of the affected LUTs (placement and routing identical), all attributes are space-separated, and the design shows the correct test card on hardware (QMTech Wukong, xc7a100tfgg676-2) — where the same netlist built without the fix showed a color-tinted card, differently tinted per PnR run.

The bug dates from the original himbaechel-xilinx import (5bfe0dd1) and affects any design where routing permutes a LUT pin carrying multiple logical inputs — the incidence is placement/routing-dependent, which makes it look like flaky hardware rather than a toolchain bug.
