### PR TITLE
himbaechel/xilinx: require a shared WE net per SLICEM in logic tile validity

### DIFF
--- a/himbaechel/uarch/xilinx/xilinx.cc
+++ b/himbaechel/uarch/xilinx/xilinx.cc
@@ -574,6 +574,7 @@ void XilinxImpl::assign_cell_tags()
             ct.lut.di1_net = ci->getPort(id_DI1);
             ct.lut.di2_net = ci->getPort(id_DI2);
             ct.lut.wclk = ci->getPort(id_CLK);
+            ct.lut.we = ci->getPort(id_WE);
             ct.lut.memory_group = 0; // fixme
             ct.lut.is_srl = ci->attrs.count(id_X_LUT_AS_SRL);
             ct.lut.is_memory = ci->attrs.count(id_X_LUT_AS_DRAM);

--- a/himbaechel/uarch/xilinx/xilinx.h
+++ b/himbaechel/uarch/xilinx/xilinx.h
@@ -42,7 +42,7 @@ struct XilinxCellTags
             bool only_drives_carry;
             NetInfo *input_sigs[6], *output_sigs[2];
             NetInfo *address_msb[3];
-            NetInfo *di1_net, *di2_net, *wclk;
+            NetInfo *di1_net, *di2_net, *wclk, *we;
         } lut;
         struct
         {

--- a/himbaechel/uarch/xilinx/xilinx_place.cc
+++ b/himbaechel/uarch/xilinx/xilinx_place.cc
@@ -50,6 +50,10 @@ bool XilinxImpl::xc7_logic_tile_valid(IdString tile_type, const LogicTileStatus 
     if (lts.cells[(3 << 4) | BEL_5LUT] != nullptr && get_tags(lts.cells[(3 << 4) | BEL_5LUT])->lut.is_memory)
         small_memory = true;
     NetInfo *wclk = nullptr;
+    // The SLICEM write enable (WEMUX_OUT) is a single per-slice signal shared
+    // by all LUTRAM WE and SRL CE pins, exactly like the shared write clock.
+    NetInfo *we = nullptr;
+    bool we_seen = false;
     // Check eight-tiles (mostly LUT-related validity)
     for (int i = 0; i < 8; i++) {
         if (lts.eights[i].dirty) {
@@ -73,6 +77,13 @@ bool XilinxImpl::xc7_logic_tile_valid(IdString tile_type, const LogicTileStatus 
                     if (wclk == nullptr)
                         wclk = lut6->lut.wclk;
                     else if (lut6->lut.wclk != wclk) {
+                        DBG();
+                        return false;
+                    }
+                    if (!we_seen) {
+                        we_seen = true;
+                        we = lut6->lut.we;
+                    } else if (lut6->lut.we != we) {
                         DBG();
                         return false;
                     }
@@ -111,10 +122,17 @@ bool XilinxImpl::xc7_logic_tile_valid(IdString tile_type, const LogicTileStatus 
                     DBG();
                     return false; // Memory and SRLs only valid in SLICEMs
                 }
-                if (lut5->lut.is_srl) {
+                if (lut5->lut.is_memory || lut5->lut.is_srl) {
                     if (wclk == nullptr)
                         wclk = lut5->lut.wclk;
                     else if (lut5->lut.wclk != wclk) {
+                        DBG();
+                        return false;
+                    }
+                    if (!we_seen) {
+                        we_seen = true;
+                        we = lut5->lut.we;
+                    } else if (lut5->lut.we != we) {
                         DBG();
                         return false;
                     }


### PR DESCRIPTION
*Authorship notice: investigation and patch developed with substantial AI assistance (Claude), reviewed and hardware-verified by me.*

**Symptom.** router2 dies during setup with `ERROR: attempting to reserve sink input path wire 'X..Y../SLICE_X..Y...WEMUX_OUT' for nets '<A>' and '<B>'` on designs that use distributed RAM or SRL shift registers. Whether it triggers depends on placement (netlist shuffle or seed), so the same design can build on one seed and crash on another. We hit two flavors on a MEGA65 core port (xc7a100t): a `$PACKER_VCC_NET`-tied-WE RAM next to a real-WE RAM, and two SRL16E delay lines (left/right audio channels) clocked identically but with per-channel clock enables.

**Root cause.** The SLICEM write enable (the WEMUX_OUT routing node) is a single per-slice signal shared by every LUTRAM WE pin and SRL CE pin in the slice, exactly like the shared write clock. `xc7_logic_tile_valid` enforced the shared WCLK but had no check for WE, so the placer freely co-located memory/SRL LUTs with the same write clock and different write enables; the impossible slice only surfaced later as the router2 reservation conflict.

**Fix.** Track the WE net in the LUT cell tags (`id_WE` port, populated in `assign_cell_tags`) and mirror the existing wclk check in `xc7_logic_tile_valid`: the first memory/SRL LUT in the tile fixes the WE net, any later one with a different WE net makes the tile invalid. A `we_seen` flag distinguishes "no WE seen yet" from a legitimately unconnected WE.

**Evidence.** MEGA65 core netlist (34k LC, xc7a100t, 200+ SRL16E, 300+ LUTRAM): before the fix router2 setup crashed 100% reproducibly on the mic-channel SRL pair (and previously on the VCC/real-WE DRAM pair, on two different seeds); with the fix the same JSON places, routes to 0 overused, and produces a working bitstream.