### PR TITLE
gowin: fix DP port-B address timing being attached to the SP cell

### DIFF
--- a/himbaechel/uarch/gowin/gowin_arch_gen.py
+++ b/himbaechel/uarch/gowin/gowin_arch_gen.py
@@ -1925,6 +1925,17 @@ def create_timing_info(chip: Chip, db: chipdb.Device):
         for i in range(width):
             cell.add_clock_out(clock, f"{bus}{i}", ClockEdge.RISING, group_to_timingvalue(arc[group]))
 
+    def check_bram_timing(cell, variant, required):
+        # Every listed pin must have ended up with a timing model. The buses
+        # are added in a loop over a cell handle, so passing the wrong handle
+        # silently attaches a whole bus to another variant: the arcs are
+        # created, no error is raised, and the port is simply absent from the
+        # timing graph. A path ending there then has no setup check and the
+        # clock reports a false pass.
+        missing = [pin for pin in required if pin not in cell.pin_data]
+        assert not missing, \
+            f"{variant}: no timing model for {', '.join(missing)}"
+
 
     speed_grades = []
     for speed in db.timing.keys():
@@ -2017,6 +2028,7 @@ def create_timing_info(chip: Chip, db: chipdb.Device):
 
                     for sig in ["CE", "WRE", "OCE", "RESET"]:
                         sp.add_setup_hold("CLK", sig, ClockEdge.RISING, group_to_timingvalue(arc[f"clk_{sig.lower()}_set"]), group_to_timingvalue(arc[f"clk_{sig.lower()}_hold"]))
+                    check_bram_timing(sp, sp_type, ("CLK", "AD0", "DI0", "DO0", "BLKSEL0"))
                 for sdp_type in ("SDP", "SDPX9", "SDPB", "SDPX9B"):
                     sdp = tmg.add_cell_variant(speed, sdp_type)
                     add_bram_bus_output(sdp, "CLKB", "DO", 36 if sdp_type.startswith("SDPX9") else 32, "clkb_do_bypass")
@@ -2032,6 +2044,8 @@ def create_timing_info(chip: Chip, db: chipdb.Device):
 
                     for sig in ["CEB", "OCEB", "RESETB"]:
                         sdp.add_setup_hold("CLKB", sig, ClockEdge.RISING, group_to_timingvalue(arc[f"clkb_{sig.lower()}_set"]), group_to_timingvalue(arc[f"clkb_{sig.lower()}_hold"]))
+                    check_bram_timing(sdp, sdp_type,
+                                      ("CLKA", "CLKB", "ADA0", "ADB0", "DI0", "DO0"))
 
                 for dp_type in ("DP", "DPX9", "DPB", "DPX9B"):
                     dp = tmg.add_cell_variant(speed, dp_type)
@@ -2040,7 +2054,7 @@ def create_timing_info(chip: Chip, db: chipdb.Device):
                     add_bram_bus_input(dp, "CLKA", "DIA", 36 if dp_type.startswith("DPX9") else 32, "clka_dia")
                     add_bram_bus_input(dp, "CLKB", "DIB", 36 if dp_type.startswith("DPX9") else 32, "clkb_dib")
                     add_bram_bus_input(dp, "CLKA", "ADA", 14, "clka_ada")
-                    add_bram_bus_input(sp, "CLKB", "ADB", 14, "clkb_adb")
+                    add_bram_bus_input(dp, "CLKB", "ADB", 14, "clkb_adb")
 
                     add_bram_bus_input(dp, "CLKA", "BLKSELA", 3, "clka_blksel")
                     add_bram_bus_input(dp, "CLKB", "BLKSELB", 3, "clkb_blksel")
@@ -2050,6 +2064,8 @@ def create_timing_info(chip: Chip, db: chipdb.Device):
 
                     for sig in ["CEB", "OCEB", "WREB", "RESETB"]:
                         dp.add_setup_hold("CLKB", sig, ClockEdge.RISING, group_to_timingvalue(arc[f"clkb_{sig.lower()}_set"]), group_to_timingvalue(arc[f"clkb_{sig.lower()}_hold"]))
+                    check_bram_timing(dp, dp_type,
+                                      ("CLKA", "CLKB", "ADA0", "ADB0", "DIA0", "DIB0"))
 
 
             elif group == "fanout":

--- a/himbaechel/uarch/gowin/gowin_arch_gen.py
+++ b/himbaechel/uarch/gowin/gowin_arch_gen.py
@@ -1926,12 +1926,6 @@ def create_timing_info(chip: Chip, db: chipdb.Device):
             cell.add_clock_out(clock, f"{bus}{i}", ClockEdge.RISING, group_to_timingvalue(arc[group]))
 
     def check_bram_timing(cell, variant, required):
-        # Every listed pin must have ended up with a timing model. The buses
-        # are added in a loop over a cell handle, so passing the wrong handle
-        # silently attaches a whole bus to another variant: the arcs are
-        # created, no error is raised, and the port is simply absent from the
-        # timing graph. A path ending there then has no setup check and the
-        # clock reports a false pass.
         missing = [pin for pin in required if pin not in cell.pin_data]
         assert not missing, \
             f"{variant}: no timing model for {', '.join(missing)}"


### PR DESCRIPTION
In the BRAM timing model, the port-B address setup/hold for the DP/DPX9/DPB/DPX9B variants is added to `sp` rather than `dp`:

    add_bram_bus_input(dp, "CLKA", "ADA", 14, "clka_ada")
    add_bram_bus_input(sp, "CLKB", "ADB", 14, "clkb_adb")

`sp` is left over from the preceding `for sp_type in ("SP", "SPX9")` loop, so it still refers to the SPX9 variant, which has no ADB port. The arcs are created without error, four times over, on a cell that cannot use them, and the DP variants never receive ADB timing at all. The SDP block immediately above does the same thing correctly with `sdp`, which makes the two directly comparable in a design that uses both.

The consequence is that a path ending at DP-class ADB[*] has no setup endpoint, so it is not analysed and does not constrain the clock. This is a false pass rather than a pessimistic result: nextpnr reports the domain as meeting timing when the address path may be far too slow.

Reproduced on GW1N-9C with a 2048x8 true dual-port memory, written on one clock and read on another, with the read address driven through a long combinational chain. Constrained to 50 MHz:

    before:  clk_r 264.41 MHz (PASS)   exit 0
    after:   clk_r  15.50 MHz (FAIL)   exit 1

The write-side clock is unaffected either way, as expected.

Also adds a check that each BRAM variant ends up with timing for the ports it has. Passing the wrong cell handle to one of these bus helpers is silent by construction, and the failure mode it produces is a clock that reports a false pass, which is the hardest kind to notice. The check runs during chipdb generation, which CI already performs for GW1N-9C, so it needs no new infrastructure. Reverting only the one-line fix and keeping the check gives:

    AssertionError: DP: no timing model for ADB0