### PR TITLE
timing: honor clock waveform for opposite-edge paths

### DIFF
--- a/common/kernel/timing.cc
+++ b/common/kernel/timing.cc
@@ -29,6 +29,27 @@
 
 NEXTPNR_NAMESPACE_BEGIN
 
+// Opposite edges are separated by the selected high/low phase, not always
+// half a period. Use the same interval for placement slack and reporting.
+static delay_t clock_period(const Context *ctx, IdString clock)
+{
+    auto net = ctx->nets.find(clock);
+    if (net != ctx->nets.end() && net->second->clkconstr)
+        return net->second->clkconstr->period.minDelay();
+    return ctx->getDelayFromNS(1.0e9 / ctx->setting<float>("target_freq"));
+}
+
+static delay_t clock_interval(const Context *ctx, IdString clock, ClockEdge launch, ClockEdge capture)
+{
+    if (launch == capture)
+        return clock_period(ctx, clock);
+    auto net = ctx->nets.find(clock);
+    if (net != ctx->nets.end() && net->second->clkconstr)
+        return launch == RISING_EDGE ? net->second->clkconstr->high.minDelay()
+                                     : net->second->clkconstr->low.minDelay();
+    return clock_period(ctx, clock) / 2;
+}
+
 TimingAnalyser::TimingAnalyser(Context *ctx) : ctx(ctx)
 {
     ClockDomainKey key{IdString(), ClockEdge::RISING_EDGE};
@@ -320,17 +341,7 @@ void TimingAnalyser::setup_port_domains()
         auto &capture_data = domains.at(dp.key.capture);
         if (launch_data.key.clock != capture_data.key.clock)
             continue;
-        IdString clk = launch_data.key.clock;
-        delay_t period = ctx->getDelayFromNS(1.0e9 / ctx->setting<float>("target_freq"));
-        if (ctx->nets.count(clk)) {
-            NetInfo *clk_net = ctx->nets.at(clk).get();
-            if (clk_net->clkconstr) {
-                period = clk_net->clkconstr->period.minDelay();
-            }
-        }
-        if (launch_data.key.edge != capture_data.key.edge)
-            period /= 2;
-        dp.period = DelayPair(period);
+        dp.period = DelayPair(clock_interval(ctx, launch_data.key.clock, launch_data.key.edge, capture_data.key.edge));
     }
 }
 
@@ -680,12 +691,12 @@ dict<domain_id_t, delay_t> TimingAnalyser::max_delay_by_domain_pairs()
             auto &req = ep_port.required.at(capture_id);
 
             for (auto &[launch_id, arr] : ep_port.arrival) {
-                const auto &launch = domains.at(capture_id);
+                const auto &launch = domains.at(launch_id);
 
                 auto dp = domain_pair_id(launch_id, capture_id);
 
                 auto clocks = std::make_pair(launch.key.clock, capture.key.clock);
-                auto same_clock = capture_id == launch_id;
+                auto same_clock = launch.key.clock == capture.key.clock;
                 auto related_clocks = clock_delays.count(clocks) > 0;
                 delay_t clock_to_clock = 0;
                 if (related_clocks) {
@@ -757,7 +768,7 @@ void TimingAnalyser::compute_slack()
             if (!setup_only)
                 pdp.second.hold_slack = arr.value.minDelay() - req.value.maxDelay() + clock_to_clock;
             pdp.second.max_path_length = arr.path_length + req.path_length;
-            if (dp.key.launch == dp.key.capture)
+            if (launch_clock == capture_clock)
                 pd.worst_setup_slack = std::min(pd.worst_setup_slack, dp.period.minDelay() + pdp.second.setup_slack);
             dp.worst_setup_slack = std::min(dp.worst_setup_slack, pdp.second.setup_slack);
             if (!setup_only) {
@@ -1105,7 +1116,8 @@ void TimingAnalyser::build_crit_path_reports()
         if (launch.edge == capture.edge)
             Fmax = 1000 / ctx->getDelayNS(path_delay);
         else
-            Fmax = 500 / ctx->getDelayNS(path_delay);
+            Fmax = 1000.0 * double(clock_interval(ctx, launch.clock, launch.edge, capture.edge)) /
+                   double(clock_period(ctx, launch.clock)) / ctx->getDelayNS(path_delay);
 
         if (!clock_fmax.count(launch.clock) || Fmax < clock_fmax.at(launch.clock).achieved) {
             float target = ctx->setting<float>("target_freq") / 1e6;
@@ -1180,12 +1192,7 @@ void TimingAnalyser::build_slack_histogram_report()
                     if (launch.clock != capture.clock || launch.is_async())
                         continue;
 
-                    float clk_period = ctx->getDelayFromNS(1.0e9 / ctx->setting<float>("target_freq"));
-                    if (ctx->nets.at(launch.clock)->clkconstr)
-                        clk_period = ctx->nets.at(launch.clock)->clkconstr->period.minDelay();
-
-                    if (launch.edge != capture.edge)
-                        clk_period = clk_period / 2;
+                    delay_t clk_period = clock_interval(ctx, launch.clock, launch.edge, capture.edge);
 
                     delay_t delay = arr.second.value.maxDelay() - req.second.value.minDelay();
                     delay_t slack = clk_period - delay;

--- a/generic/CMakeLists.txt
+++ b/generic/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SOURCES
 add_nextpnr_architecture(${family}
     CORE_SOURCES ${SOURCES}
     MAIN_SOURCE  main.cc
+    TEST_SOURCES tests/timing.cc
 )
 
 target_sources(nextpnr-${family}-chipdb PUBLIC chipdb.cc)

--- a/generic/tests/timing.cc
+++ b/generic/tests/timing.cc
@@ -1,0 +1,81 @@
+/*
+ *  nextpnr -- Next Generation Place and Route
+ *
+ *  Copyright (C) 2026  Deano Calver <deano@geometric.so>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "gtest/gtest.h"
+#include "nextpnr.h"
+#include "timing.h"
+
+USING_NEXTPNR_NAMESPACE
+
+// Exercise the common analyser without a device database or routing randomness.
+TEST(Timing, ClockWaveform)
+{
+    for (int duty : {25, 50, 75}) {
+        for (ClockEdge launch : {RISING_EDGE, FALLING_EDGE}) {
+            for (ClockEdge capture : {RISING_EDGE, FALLING_EDGE}) {
+                for (bool skew : {false, true}) {
+                    SCOPED_TRACE(::testing::Message() << "duty=" << duty << " launch=" << launch
+                                                    << " capture=" << capture << " skew=" << skew);
+                    Context ctx(ArchArgs{});
+                    ctx.settings[ctx.id("target_freq")] = 25e6;
+                    auto clk = ctx.createNet(ctx.id("clk"));
+                    clk->clkconstr = std::make_unique<ClockConstraint>();
+                    clk->clkconstr->period = DelayPair(40);
+                    clk->clkconstr->high = DelayPair(40 * duty / 100);
+                    clk->clkconstr->low = DelayPair(40 * (100 - duty) / 100);
+                    auto data = ctx.createNet(ctx.id("data"));
+                    auto source = ctx.createCell(ctx.id("source"), ctx.id("FF"));
+                    auto sink = ctx.createCell(ctx.id("sink"), ctx.id("FF"));
+                    auto c = ctx.id("CLK"), q = ctx.id("Q"), d = ctx.id("D");
+                    source->addInput(c);
+                    source->addOutput(q);
+                    sink->addInput(c);
+                    sink->addInput(d);
+                    source->connectPort(c, clk);
+                    sink->connectPort(c, clk);
+                    source->connectPort(q, data);
+                    sink->connectPort(d, data);
+                    ctx.addCellTimingClock(source->name, c);
+                    ctx.addCellTimingClock(sink->name, c);
+                    ctx.addCellTimingClockToOut(source->name, q, c, 2);
+                    ctx.addCellTimingSetupHold(sink->name, d, c, 1, 0);
+                    ctx.cellTiming[source->name].clockingInfo[q][0].edge = launch;
+                    ctx.cellTiming[sink->name].clockingInfo[d][0].edge = capture;
+                    TimingAnalyser timing(&ctx);
+                    timing.with_clock_skew = skew;
+                    timing.setup();
+                    timing.set_route_delay(CellPortKey(sink->name, d), DelayPair(5));
+                    timing.set_route_delay(CellPortKey(source->name, c), DelayPair(3));
+                    timing.set_route_delay(CellPortKey(sink->name, c), DelayPair(4));
+                    timing.run(false, false, true, true);
+                    float interval = launch == capture ? 40
+                            : launch == RISING_EDGE ? 40 * duty / 100 : 40 * (100 - duty) / 100;
+                    // 2 ns clock-to-Q + 5 ns data route + 1 ns setup,
+                    // reduced by the optional 1 ns positive capture-clock skew.
+                    float delay = skew ? 7 : 8;
+                    EXPECT_FLOAT_EQ(timing.get_setup_slack(CellPortKey(sink->name, d)), interval - delay);
+                    auto &result = timing.get_timing_result();
+                    EXPECT_NEAR(result.clock_fmax.at(clk->name).achieved, 1000 * interval / 40 / delay, 1e-4);
+                    EXPECT_FLOAT_EQ(result.clock_paths.at(clk->name).max_delay, interval);
+                    EXPECT_EQ(result.slack_histogram.count(int((interval - delay) * 1000)), 1u);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Paths between opposite edges of a clock currently use half the period for slack and Fmax, even when the clock constraint specifies a different high/low waveform. For a 40 ns clock with a 10 ns high phase and an 8 ns rising-to-falling path, the reported Fmax is 62.5 MHz instead of 31.25 MHz.

Use the constrained high/low interval consistently for domain budgets, slack histograms and Fmax. Treat opposite edges of the same clock as sharing a clock reference when accounting for skew, and include these paths in per-port setup slack. Correct the adjacent launch-domain lookup in the delay calculation.

Adds a device-independent generic-backend regression covering 25%, 50% and 75% duty cycles, all four launch/capture edge combinations, and clock-skew analysis enabled/disabled. Checks setup slack, Fmax, critical-path budget and histogram entry. The regression fails against the unmodified base and passes with this change.

Validation:

```sh
cmake -S . -B build -DARCH=generic -DBUILD_TESTS=ON -DBUILD_PYTHON=OFF -DBUILD_GUI=OFF
cmake --build build -j4 --target nextpnr-generic-test
ctest --test-dir build --output-on-failure
```

Host-only validation, based on upstream `3cfc28d02e05bef56a30517745d57d8d1118c97e`. Extracted from Cyclone V PLL duty-cycle work; no architecture-specific PLL or bitstream changes are included.
