### PR TITLE
himbaechel/xilinx: drop the unused nextpnr-xilinx-meta submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "tests"]
 	path = tests
 	url = https://github.com/YosysHQ/nextpnr-tests
-[submodule "himbaechel/uarch/xilinx/meta"]
-	path = himbaechel/uarch/xilinx/meta
-	url = https://github.com/gatecat/nextpnr-xilinx-meta
 [submodule "3rdparty/corrosion"]
 	path = 3rdparty/corrosion
 	url = https://github.com/corrosion-rs/corrosion


### PR DESCRIPTION
Nothing reads it.  The only reference to himbaechel/uarch/xilinx/meta anywhere in the tree is the .gitmodules entry declaring it: no CMake, no generator, no script, no workflow, no documentation.  The chipdb generator takes all of its input from HIMBAECHEL_PRJXRAY_DB -- tilegrid.json, tile_type_*.json, package_pins.csv, the SDF timings -- and CMake refuses to configure without that, so there is no path by which meta could be consulted even accidentally.

It is a leftover of the legacy nextpnr-xilinx flow, which this tree no longer carries: there is no xilinx/ arch directory for it to serve.

Removing it is not free of consequence in the right direction: it is 19 MB, and every job in demos.yml checks out with submodules: recursive, so each of the fifteen matrix entries clones it once per run and opens none of it.

Verified by configuring the himbaechel/xilinx build with the submodule deinitialised and removed: cmake completes and writes build files as before.

The three remaining submodules -- tests, 3rdparty/corrosion, 3rdparty/googletest -- are untouched.